### PR TITLE
feat(news): add section index pages and improve navigation metadata

### DIFF
--- a/_data/navigation/main.yml
+++ b/_data/navigation/main.yml
@@ -10,12 +10,20 @@
       url: /quickstart/jekyll
     - title: Charm Tools
       url: /quickstart/charm-setup/
-- title: Journey
-  url: /posts/
-  icon: bi-journal-text
+- title: News
+  url: /news/
+  icon: bi-newspaper
   children:
-    - title: Posts Index
-      url: /posts/
+    - title: All News
+      url: /news/
+    - title: AI & ML
+      url: /news/ai-machine-learning/
+    - title: DevOps
+      url: /news/devops/
+    - title: Web Development
+      url: /news/web-development/
+    - title: Technology
+      url: /news/technology/
     - title: Quests
       url: /quests/home/
     - title: Stats

--- a/_data/navigation/posts.yml
+++ b/_data/navigation/posts.yml
@@ -1,39 +1,69 @@
-- title: Home
-  icon: bi-house
-  url: /posts/
+# News Section Navigation Configuration
+# Used by: News layout, section pages, and article navigation
+# Purpose: Section-based navigation for news content
+# Note: Sections match folders in pages/_posts/
+
 - title: AI & Machine Learning
   icon: bi-robot
-  url: /posts/ai/
+  url: /news/ai-machine-learning/
+  description: "AI-assisted development, ML applications, and intelligent automation"
+
 - title: Web Development
   icon: bi-browser-chrome
-  url: /posts/web/
+  url: /news/web-development/
+  description: "Jekyll, frameworks, static sites, and full-stack web development"
+
 - title: DevOps
   icon: bi-gear-wide-connected
-  url: /posts/devops/
+  url: /news/devops/
+  description: "CI/CD, containers, infrastructure as code, and automation"
+
 - title: Programming
   icon: bi-code-slash
-  url: /posts/programming/
+  url: /news/programming/
+  description: "Bash, Python, JavaScript, and scripting tutorials"
+
 - title: System Administration
   icon: bi-server
-  url: /posts/sysadmin/
+  url: /news/system-administration/
+  description: "Linux, macOS, Windows, and server management"
+
 - title: Data & Analytics
   icon: bi-bar-chart-line
-  url: /posts/data/
+  url: /news/data-analytics/
+  description: "Databases, APIs, data processing, and analytics tools"
+
+- title: Technology
+  icon: bi-cpu
+  url: /news/technology/
+  description: "Tech news, tools, hardware, and software reviews"
+
 - title: Tools & Environment
   icon: bi-tools
-  url: /posts/tools/
+  url: /news/tools-environment/
+  description: "VS Code, terminal setup, productivity, and dotfiles"
+
 - title: Creative & Experimental
   icon: bi-palette
-  url: /posts/creative/
+  url: /news/creative-experimental/
+  description: "AI-generated content, experiments, and exploratory projects"
+
 - title: Culture & Society
   icon: bi-globe
-  url: /posts/culture/
+  url: /news/culture-society/
+  description: "Identity, social analysis, and cultural commentary"
+
 - title: Trends & Ideas
   icon: bi-graph-up-arrow
-  url: /posts/trends/
+  url: /news/trends-ideas/
+  description: "Emerging technologies, innovation, and forward-looking IT perspectives"
+
 - title: Learning
   icon: bi-mortarboard
-  url: /posts/learning/
+  url: /news/learning/
+  description: "Learning paths, educational resources, and skill-building"
+
 - title: Business
   icon: bi-briefcase
-  url: /posts/business/
+  url: /news/business/
+  description: "Business strategies, startups, and professional development"

--- a/pages/_posts/2000-01-01-index.md
+++ b/pages/_posts/2000-01-01-index.md
@@ -1,0 +1,38 @@
+---
+title: "IT-Journey News"
+description: Practical tutorials, deep-dive technical articles, AI-assisted development chronicles, and professional insights for the IT learning journey
+date: 2000-01-01T00:00:00.000Z
+preview: /images/previews/it-journey-news.png
+tags:
+  - jekyll
+  - devops
+  - web-development
+  - ai
+  - tutorials
+categories:
+  - Technology
+  - Development
+sub-title: From zero to hero in information technology
+excerpt: A curated library of IT content organized by category — covering DevOps, web development, AI, programming, system administration, and more
+snippet: Your hub for IT knowledge and learning resources
+author: IT-Journey Team
+layout: news
+index: true
+section_style: magazine
+keywords:
+  primary:
+    - IT tutorials
+    - devops guides
+    - web development
+  secondary:
+    - system administration
+    - programming
+    - ai machine learning
+    - technology news
+lastmod: 2026-04-01T00:00:00.000Z
+permalink: /news/
+attachments: ""
+comments: true
+featured: true
+draft: false
+---

--- a/pages/_posts/ai & machine learning/2000-01-01-index.md
+++ b/pages/_posts/ai & machine learning/2000-01-01-index.md
@@ -1,0 +1,12 @@
+---
+title: AI & Machine Learning
+description: AI-assisted development, machine learning applications, GPT tools, and intelligent automation
+preview: /images/previews/ai-machine-learning.png
+layout: section
+category: ai & machine learning
+icon: robot
+index: true
+section_style: grid
+permalink: /news/ai-machine-learning/
+lastmod: 2026-04-01T00:00:00.000Z
+---

--- a/pages/_posts/business/2000-01-01-index.md
+++ b/pages/_posts/business/2000-01-01-index.md
@@ -1,0 +1,12 @@
+---
+title: Business
+description: Business strategies, startup journeys, entrepreneurship, and professional development in tech
+preview: /images/previews/business.png
+layout: section
+category: business
+icon: briefcase
+index: true
+section_style: list
+permalink: /news/business/
+lastmod: 2026-04-01T00:00:00.000Z
+---

--- a/pages/_posts/creative & experimental/2000-01-01-index.md
+++ b/pages/_posts/creative & experimental/2000-01-01-index.md
@@ -1,0 +1,12 @@
+---
+title: Creative & Experimental
+description: AI-generated content, creative experiments, generative art, and exploratory technology projects
+preview: /images/previews/creative-experimental.png
+layout: section
+category: creative & experimental
+icon: palette
+index: true
+section_style: grid
+permalink: /news/creative-experimental/
+lastmod: 2026-04-01T00:00:00.000Z
+---

--- a/pages/_posts/culture & society/2000-01-01-index.md
+++ b/pages/_posts/culture & society/2000-01-01-index.md
@@ -1,0 +1,12 @@
+---
+title: Culture & Society
+description: Identity, social analysis, cultural commentary, and the human side of information technology
+preview: /images/previews/culture-society.png
+layout: section
+category: culture & society
+icon: globe
+index: true
+section_style: magazine
+permalink: /news/culture-society/
+lastmod: 2026-04-01T00:00:00.000Z
+---

--- a/pages/_posts/data & analytics/2000-01-01-index.md
+++ b/pages/_posts/data & analytics/2000-01-01-index.md
@@ -1,0 +1,12 @@
+---
+title: Data & Analytics
+description: Databases, APIs, data processing, analytics tools, and working with structured data
+preview: /images/previews/data-analytics.png
+layout: section
+category: data & analytics
+icon: bar-chart-line
+index: true
+section_style: grid
+permalink: /news/data-analytics/
+lastmod: 2026-04-01T00:00:00.000Z
+---

--- a/pages/_posts/devops/2000-01-01-index.md
+++ b/pages/_posts/devops/2000-01-01-index.md
@@ -1,0 +1,12 @@
+---
+title: DevOps
+description: CI/CD pipelines, containerization, automation, infrastructure as code, and deployment practices
+preview: /images/previews/devops.png
+layout: section
+category: devops
+icon: gear-wide-connected
+index: true
+section_style: grid
+permalink: /news/devops/
+lastmod: 2026-04-01T00:00:00.000Z
+---

--- a/pages/_posts/learning/2000-01-01-index.md
+++ b/pages/_posts/learning/2000-01-01-index.md
@@ -1,0 +1,12 @@
+---
+title: Learning
+description: Learning paths, educational resources, study strategies, and skill-building for IT professionals
+preview: /images/previews/learning.png
+layout: section
+category: learning
+icon: mortarboard
+index: true
+section_style: list
+permalink: /news/learning/
+lastmod: 2026-04-01T00:00:00.000Z
+---

--- a/pages/_posts/programming/2000-01-01-index.md
+++ b/pages/_posts/programming/2000-01-01-index.md
@@ -1,0 +1,12 @@
+---
+title: Programming
+description: Bash, Python, JavaScript, and scripting — practical coding techniques and language-focused tutorials
+preview: /images/previews/programming.png
+layout: section
+category: programming
+icon: code-slash
+index: true
+section_style: grid
+permalink: /news/programming/
+lastmod: 2026-04-01T00:00:00.000Z
+---

--- a/pages/_posts/system administration/2000-01-01-index.md
+++ b/pages/_posts/system administration/2000-01-01-index.md
@@ -1,0 +1,12 @@
+---
+title: System Administration
+description: Linux, macOS, Windows, server setup, shell configuration, and operating system management
+preview: /images/previews/system-administration.png
+layout: section
+category: system administration
+icon: server
+index: true
+section_style: grid
+permalink: /news/system-administration/
+lastmod: 2026-04-01T00:00:00.000Z
+---

--- a/pages/_posts/technology/2000-01-01-index.md
+++ b/pages/_posts/technology/2000-01-01-index.md
@@ -1,0 +1,12 @@
+---
+title: Technology
+description: Tech news, emerging tools, hardware, software reviews, and the latest in the tech industry
+preview: /images/previews/technology.png
+layout: section
+category: technology
+icon: cpu
+index: true
+section_style: grid
+permalink: /news/technology/
+lastmod: 2026-04-01T00:00:00.000Z
+---

--- a/pages/_posts/tools & environment/2000-01-01-index.md
+++ b/pages/_posts/tools & environment/2000-01-01-index.md
@@ -1,0 +1,12 @@
+---
+title: Tools & Environment
+description: VS Code, terminal setup, productivity tools, dotfiles, and development environment configuration
+preview: /images/previews/tools-environment.png
+layout: section
+category: tools & environment
+icon: tools
+index: true
+section_style: grid
+permalink: /news/tools-environment/
+lastmod: 2026-04-01T00:00:00.000Z
+---

--- a/pages/_posts/trends & ideas/2000-01-01-index.md
+++ b/pages/_posts/trends & ideas/2000-01-01-index.md
@@ -1,0 +1,12 @@
+---
+title: Trends & Ideas
+description: Emerging technologies, innovation, philosophy of technology, and forward-looking IT perspectives
+preview: /images/previews/trends-ideas.png
+layout: section
+category: trends & ideas
+icon: graph-up-arrow
+index: true
+section_style: magazine
+permalink: /news/trends-ideas/
+lastmod: 2026-04-01T00:00:00.000Z
+---

--- a/pages/_posts/web development/2000-01-01-index.md
+++ b/pages/_posts/web development/2000-01-01-index.md
@@ -1,0 +1,12 @@
+---
+title: Web Development
+description: Jekyll, static sites, HTML/CSS, JavaScript frameworks, and full-stack web development tutorials
+preview: /images/previews/web-development.png
+layout: section
+category: web development
+icon: browser-chrome
+index: true
+section_style: grid
+permalink: /news/web-development/
+lastmod: 2026-04-01T00:00:00.000Z
+---


### PR DESCRIPTION
## Summary\n- add main news index plus per-category section index pages\n- enrich posts navigation with descriptions and section metadata\n- update top-level navigation references for improved news browsing\n\n## Validation\n- changes reviewed against existing navigation and category structure