### PR TITLE
docs: add Bashcrawl terminal learning path

### DIFF
--- a/_data/README.md
+++ b/_data/README.md
@@ -233,7 +233,7 @@ When adding new pages or collections:
 3. If needed, update sidebar configuration in `_config.yml` defaults
 4. Test navigation rendering locally with `bundle exec jekyll serve`
 
-**Last Updated:** 2025-12-20
+**Last Updated:** 2026-04-25
 
 ## Schema Data
 

--- a/_data/navigation/README.md
+++ b/_data/navigation/README.md
@@ -122,5 +122,5 @@ Navigation YAML files are validated at build time. Invalid schemas will produce 
 
 ---
 
-**Last Updated**: 2026-01-24  
+**Last Updated**: 2026-04-25
 **Theme Compatibility**: zer0-mistakes v0.17+

--- a/_data/navigation/docs.yml
+++ b/_data/navigation/docs.yml
@@ -29,7 +29,10 @@
       url: /docs/jekyll/mermaid-migration
 - title: Terminal
   icon: bi-terminal
+  url: /docs/terminal/
   children:
+    - title: Terminal Learning Path
+      url: /docs/terminal/
     - title: Terminal Shortcuts
       url: /docs/terminal-shortcuts-cheat-sheet/
     - title: Complete BASH Reference

--- a/_data/navigation/main.yml
+++ b/_data/navigation/main.yml
@@ -35,7 +35,7 @@
     - title: Jekyll
       url: /docs/jekyll/
     - title: Terminal
-      url: /docs/terminal-shortcuts-cheat-sheet/
+      url: /docs/terminal/
 - title: Notebook
   url: /notes/
   icon: bi-journal-code

--- a/_data/navigation/quests.yml
+++ b/_data/navigation/quests.yml
@@ -13,7 +13,11 @@
     - title: Begin Your Journey
       url: /quests/0000/begin-your-it-journey
     - title: Terminal Fundamentals
-      url: /quests/0000/terminal-fundamentals
+      url: /quests/level-0000-terminal-fundamentals/
+    - title: Bashcrawl Adventure
+      url: /quests/bashcrawl-terminal-adventure/
+    - title: Bash-run Extension
+      url: /quests/lvl_000/bash-run/
     - title: Git Basics
       url: /quests/0000/git-basics
     - title: Markdown Mastery
@@ -45,7 +49,7 @@
   url: /quests/0010/
   children:
     - title: Bash Scripting
-      url: /quests/0010/bash-scripting
+      url: /quests/0010/bash-scripting/
     - title: JavaScript Fundamentals
       url: /quests/0010/javascript-fundamentals
     - title: CSS Styling Basics

--- a/pages/_docs/index.md
+++ b/pages/_docs/index.md
@@ -17,7 +17,7 @@ sidebar:
   nav: docs
 toc_sticky: true
 date: 2021-12-03T09:05:06.000Z
-lastmod: 2026-04-02T03:24:28.792Z
+lastmod: 2026-04-25T00:00:00.000Z
 draft: false
 keywords:
   primary:
@@ -57,8 +57,10 @@ Reference documentation and educational resources for the tools and technologies
 Command-line reference and productivity guides for working effectively in the terminal.
 
 **Topics:**
+- [Terminal and Bash Learning Path](/docs/terminal/) - Complete path connecting Bashcrawl, terminal basics, cheatsheets, references, and scripting quests
 - [Terminal Shortcuts Cheat Sheet](/docs/terminal-shortcuts-cheat-sheet/) - Keyboard shortcuts for macOS, Linux, and Windows
 - [Complete BASH Reference](/docs/bash-complete-reference/) - Exhaustive GNU Bash reference: built-ins, scripting, text processing, and advanced techniques
+- [Play Bashcrawl Online](https://bamr87.github.io/bashcrawl/) - Browser-based terminal dungeon for no-install command practice
 
 ### Jekyll
 

--- a/pages/_docs/terminal/README.md
+++ b/pages/_docs/terminal/README.md
@@ -1,0 +1,104 @@
+---
+title: "Terminal and Bash Learning Path"
+description: "A complete guide to learning the terminal, Bash commands, Bash scripting, and Bashcrawl through IT-Journey quests, notes, and references."
+date: 2026-04-25T00:00:00.000Z
+lastmod: 2026-04-25T00:00:00.000Z
+author: "IT-Journey Team"
+permalink: /docs/terminal/
+tags:
+  - terminal
+  - bash
+  - bashcrawl
+  - command-line
+  - learning-path
+  - reference
+categories:
+  - Documentation
+  - Terminal
+  - Learning Path
+keywords:
+  primary:
+    - terminal learning path
+    - bash learning path
+    - bashcrawl guide
+  secondary:
+    - command line beginner guide
+    - bash scripting resources
+    - terminal quests
+excerpt: "Start with Bashcrawl online, build terminal fundamentals, use the Bash reference and cheatsheet, then write and extend real Bash scripts."
+draft: false
+sidebar:
+  nav: docs
+toc: true
+toc_sticky: true
+---
+
+# Terminal and Bash Learning Path
+
+This guide connects the terminal, Bash, command references, and Bashcrawl into one learner journey. Start in the browser, practice real commands, then move into local scripting when you are ready.
+
+## Recommended Route
+
+| Stage | Resource | Outcome |
+|-------|----------|---------|
+| 1 | [Play Bashcrawl Online](https://bamr87.github.io/bashcrawl/) | Try `pwd`, `ls`, `cd`, and `cat` without installing anything |
+| 2 | [Terminal Fundamentals](/quests/level-0000-terminal-fundamentals/) | Learn navigation, files, pipes, redirection, and search |
+| 3 | [Bashcrawl Terminal Adventure](/quests/bashcrawl-terminal-adventure/) | Turn command practice into a guided quest checklist |
+| 4 | [Terminal Shortcuts Cheat Sheet](/docs/terminal-shortcuts-cheat-sheet/) | Build speed with history, completion, clearing, and editing shortcuts |
+| 5 | [Bash Cheatsheet](/shell/) | Keep everyday commands and syntax close while practicing |
+| 6 | [Complete BASH Reference](/docs/bash-complete-reference/) | Deepen your understanding of Bash built-ins, expansions, scripts, and patterns |
+| 7 | [Bash Scripting Mastery](/quests/0010/bash-scripting/) | Write reusable scripts with functions, validation, error handling, and tests |
+| 8 | [Bash-run Extension Quest](/quests/lvl_000/bash-run/) | Clone Bashcrawl and extend a real terminal learning game |
+
+## Bashcrawl Paths
+
+| Path | Use When | Link or Command |
+|------|----------|-----------------|
+| Online Web TUI | You are new, in a classroom, or on a locked-down machine | [bamr87.github.io/bashcrawl](https://bamr87.github.io/bashcrawl/) |
+| Local interactive mode | You want the full local TUI | `./main.sh --interactive` |
+| Classic mode | You want a pure Bash fallback | `./main.sh --classic` |
+| Native terminal mode | You want the traditional filesystem adventure | `./main.sh --native` |
+| Tutorial mode | You want guided onboarding | `./main.sh --tutorial` |
+| Agent mode | You are testing, scripting, or capturing screenshots | `./main.sh --agent` |
+
+Local setup uses the current IT-Journey Bashcrawl repository:
+
+```bash
+git clone https://github.com/bamr87/bashcrawl.git
+cd bashcrawl
+./setup.sh
+./main.sh --interactive
+```
+
+## Command Practice Map
+
+| Command | Practice in Bashcrawl | Reference |
+|---------|-----------------------|-----------|
+| `pwd` | Confirm your current room | [Terminal Fundamentals](/quests/level-0000-terminal-fundamentals/) |
+| `ls -F` | Identify rooms, scrolls, and executable encounters | [Bashcrawl Quest](/quests/bashcrawl-terminal-adventure/) |
+| `cat scroll` | Read room instructions and lore | [Bash Cheatsheet](/shell/) |
+| `cd cellar` | Move through the dungeon | [Complete BASH Reference](/docs/bash-complete-reference/) |
+| `less`, `head`, `tail` | Inspect longer scrolls and logs | [Terminal Shortcuts](/docs/terminal-shortcuts-cheat-sheet/) |
+| `grep` | Search scrolls and code for clues | [Bash Scripting](/quests/0010/bash-scripting/) |
+
+## For Different Learners
+
+| Learner | Best First Step | Next Step |
+|---------|-----------------|-----------|
+| Absolute beginner | [Play online](https://bamr87.github.io/bashcrawl/) | [Terminal Fundamentals](/quests/level-0000-terminal-fundamentals/) |
+| Finance or operations learner | [Finance terminal guide](/posts/terminal-bash-finance-accounting/) | [Bash Scripting Mastery](/quests/0010/bash-scripting/) |
+| Developer or contributor | [Bashcrawl GitHub repo](https://github.com/bamr87/bashcrawl/) | [Bash-run Extension Quest](/quests/lvl_000/bash-run/) |
+| Teacher or mentor | [Bashcrawl Web](https://bamr87.github.io/bashcrawl/) | [Bashcrawl Terminal Adventure](/quests/bashcrawl-terminal-adventure/) |
+
+## Reference Shelf
+
+- [Play Bashcrawl Online](https://bamr87.github.io/bashcrawl/) - No-install browser game with local browser saves.
+- [Bashcrawl Repository](https://github.com/bamr87/bashcrawl/) - Current comprehensive repo with TUI, static web, agent, and tests.
+- [Original Bashcrawl Upstream](https://gitlab.com/slackermedia/bashcrawl) - Historical upstream project.
+- [Terminal Fundamentals](/quests/level-0000-terminal-fundamentals/) - Foundation command-line quest.
+- [Bashcrawl Terminal Adventure](/quests/bashcrawl-terminal-adventure/) - Gamified Bashcrawl quest.
+- [Bash-run Extension Quest](/quests/lvl_000/bash-run/) - Extend Bashcrawl locally.
+- [Bash Scripting Mastery](/quests/0010/bash-scripting/) - Script automation quest.
+- [Bash Cheatsheet](/shell/) - Quick command and syntax notes.
+- [Complete BASH Reference](/docs/bash-complete-reference/) - Deep reference guide.
+- [Terminal Shortcuts Cheat Sheet](/docs/terminal-shortcuts-cheat-sheet/) - Keyboard productivity guide.

--- a/pages/_docs/terminal/bash-complete-reference.md
+++ b/pages/_docs/terminal/bash-complete-reference.md
@@ -1,25 +1,25 @@
 ---
-title: "The Complete BASH Reference: Commands, Functions, Snippets & Techniques"
-description: "Exhaustive reference guide covering every aspect of GNU Bash — built-in commands, parameter expansion, process control, scripting patterns, text processing, networking, and advanced techniques."
+title: "Complete BASH Reference: Commands & Techniques"
+description: "Deep GNU Bash reference for built-ins, expansion, process control, scripting patterns, text processing, networking, and advanced techniques."
 date: 2026-02-21T14:34:24.000Z
-lastmod: 2026-02-20T00:00:00.000Z
+lastmod: 2026-04-25T00:00:00.000Z
 author: "IT-Journey Team"
 permalink: /docs/bash-complete-reference/
 tags:
     - bash
     - shell
-    - scripting
-    - command-line
+    - script
+    - shell
     - linux
     - macos
-    - reference
-    - sysadmin
+    - reference-materials
+    - system-admin
     - automation
     - devops
 categories:
     - Documentation
-    - Terminal
-    - Reference
+    - System Administration
+    - Guides
 keywords:
     primary:
         - bash commands
@@ -45,9 +45,20 @@ draft: false
 
 ## 🎮 Practical Application
 
-Want to put these commands into practice? Try these interactive quests:
-- **[Bashcrawl Quest: Terminal Adventure RPG](/quests/bashcrawl-terminal-adventure/)**: Learn basic navigation and file commands through a dungeon exploration game.
-- **[bashrun and Beyond](/quests/lvl_000/bash-run/)**: Build your own advanced terminal game using bash scripting.
+Want to put these commands into practice? Follow the [Terminal and Bash Learning Path](/docs/terminal/) and use Bashcrawl as your practice environment:
+
+- **[Play Bashcrawl Online](https://bamr87.github.io/bashcrawl/)**: Practice `pwd`, `ls -F`, `cat`, and `cd` immediately in the browser.
+- **[Bashcrawl Quest: Terminal Adventure RPG](/quests/bashcrawl-terminal-adventure/)**: Turn the online experience into a guided quest checklist.
+- **[Bashcrawl Repository](https://github.com/bamr87/bashcrawl/)**: Study the current full game with TUI, classic, native, tutorial, agent, and static web modes.
+- **[bashrun and Beyond](/quests/lvl_000/bash-run/)**: Extend the local Bashcrawl project with new rooms and scripts.
+
+| Bashcrawl Command | Reference Area to Review |
+|-------------------|--------------------------|
+| `pwd`, `cd` | Navigation and directory built-ins |
+| `ls -F` | Commands, options, aliases, and file type signals |
+| `cat`, `less`, `head`, `tail` | Text viewing and stream processing |
+| `grep` | Pattern matching and pipelines |
+| `./treasure`, `./main.sh` | Executable scripts, permissions, arguments, and exit codes |
 
 ---
 
@@ -4615,8 +4626,14 @@ atrm job_number                  # Remove job
 - [Google Shell Style Guide](https://google.github.io/styleguide/shellguide.html)
 
 ### Related IT-Journey Quests
+- [Terminal and Bash Learning Path](/docs/terminal/)
+- [Play Bashcrawl Online](https://bamr87.github.io/bashcrawl/)
+- [Bashcrawl Repository](https://github.com/bamr87/bashcrawl/)
 - [Terminal Shortcuts Cheat Sheet](/docs/terminal-shortcuts-cheat-sheet/)
 - [Terminal Fundamentals Quest](/quests/level-0000-terminal-fundamentals/)
+- [Bashcrawl Terminal Adventure](/quests/bashcrawl-terminal-adventure/)
+- [Bash-run Extension Quest](/quests/lvl_000/bash-run/)
+- [Bash Scripting Mastery](/quests/0010/bash-scripting/)
 - [Git Basics Quest](/quests/level-0000-git-basics/)
 
 ### `man` and `help`
@@ -4629,7 +4646,7 @@ info bash                    # GNU info pages
 
 ---
 
-*Pro tip: Bookmark this page and combine it with the [Terminal Shortcuts Cheat Sheet](/docs/terminal-shortcuts-cheat-sheet/) for maximum command line productivity!*
+*Pro tip: Bookmark this page and combine it with the [Terminal and Bash Learning Path](/docs/terminal/) plus the [Terminal Shortcuts Cheat Sheet](/docs/terminal-shortcuts-cheat-sheet/) for maximum command line productivity!*
 
 ---
 

--- a/pages/_docs/terminal/terminal-shortcuts-cheat-sheet.md
+++ b/pages/_docs/terminal/terminal-shortcuts-cheat-sheet.md
@@ -2,7 +2,7 @@
 title: "Essential Terminal Shortcuts: macOS, Linux & Windows Cheat Sheet"
 description: "Complete reference guide for terminal keyboard shortcuts across macOS, Linux, and Windows. Master command line navigation, editing, and productivity shortcuts for Bash, Zsh, and PowerShell."
 date: 2025-12-20T10:05:28.000Z
-lastmod: 2025-12-20T00:00:00.000Z
+lastmod: 2026-04-25T00:00:00.000Z
 author: "IT-Journey Team"
 permalink: /docs/terminal-shortcuts-cheat-sheet/
 tags:
@@ -51,6 +51,22 @@ draft: false
 | **Exit terminal** | `Ctrl + D` | `exit` |
 | **Previous command** | `↑` or `Ctrl + P` | `↑` |
 | **Search history** | `Ctrl + R` | `Ctrl + R` |
+
+---
+
+## 🎮 Practice These in Bashcrawl Web
+
+[Bashcrawl Web](https://bamr87.github.io/bashcrawl/) includes a browser terminal that reinforces the same muscle memory safely:
+
+| Browser Terminal Action | Shortcut |
+|-------------------------|----------|
+| Run command | `Enter` |
+| Previous/next command | `Up` / `Down` |
+| Complete command or path | `Tab` |
+| Open in-game docs | `F1` |
+| Clear terminal | `Ctrl + L` |
+
+Use the online game for first practice, then keep this sheet open when you move into your local macOS, Linux, WSL, or PowerShell terminal.
 
 ---
 

--- a/pages/_notes/cheetsheets/bash-cheatsheet.md
+++ b/pages/_notes/cheetsheets/bash-cheatsheet.md
@@ -23,7 +23,7 @@ keywords:
   - Conditional execution
   - Command substitution
 slug: /shell/
-lastmod: 2024-05-14T15:14:49.051Z
+lastmod: 2026-04-25T00:00:00.000Z
 draft: false
 related_quests:
   - /quests/bashcrawl-terminal-adventure/
@@ -34,8 +34,12 @@ date: 2021-12-28T13:35:40.000Z
 
 [![hackmd-github-sync-badge](https://hackmd.io/mCoifzaSQLOH_18DCH1IQg/badge)](https://hackmd.io/mCoifzaSQLOH_18DCH1IQg)
 
+## Practice Routes
 
-test
+- [Play Bashcrawl Online](https://bamr87.github.io/bashcrawl/) - Practice `pwd`, `ls`, `cd`, `cat`, history, and completion in a safe browser dungeon.
+- [Bashcrawl Repository](https://github.com/bamr87/bashcrawl/) - Study a real Bash-powered learning game and extend it locally.
+- [Terminal and Bash Learning Path](/docs/terminal/) - Follow the full path from command basics to Bash scripting.
+- [Complete BASH Reference](/docs/bash-complete-reference/) - Use when you need deeper detail than a cheatsheet can hold.
 
 Getting started
 {: .cols-3 }

--- a/pages/_posts/business/2026-02-23-terminal-bash-finance-accounting.md
+++ b/pages/_posts/business/2026-02-23-terminal-bash-finance-accounting.md
@@ -31,7 +31,7 @@ keywords:
         - csv-processing
         - data-analysis
         - month-end-close
-lastmod: 2026-02-23T00:00:00.000Z
+lastmod: 2026-04-25T00:00:00.000Z
 permalink: /posts/terminal-bash-finance-accounting/
 comments: true
 difficulty: "🟢 Beginner"
@@ -356,7 +356,7 @@ Start with the [Terminal Fundamentals: Command Line Navigation Quest](/quests/le
 
 ### 🎮 Quest 2: Learn by Playing
 
-Memorizing syntax can feel like studying for the CPA exam all over again. So instead, learn by playing a game. The [Bashcrawl Terminal Adventure](/quests/bashcrawl-terminal-adventure/) quest drops you into a text-based dungeon where you navigate rooms, read scrolls, and battle monsters — all using real Bash commands. You'll learn `cd`, `ls`, `cat`, and more without even realizing you're studying. It's like Zork, but educational and on your resume.
+Memorizing syntax can feel like studying for the CPA exam all over again. So instead, learn by playing a game. Start with [Bashcrawl Web](https://bamr87.github.io/bashcrawl/) for a no-install browser version, then use the [Bashcrawl Terminal Adventure](/quests/bashcrawl-terminal-adventure/) quest for the full checklist. You'll navigate rooms, read scrolls, and battle monsters using real Bash commands such as `cd`, `ls`, `cat`, and `grep`. It's like Zork, but educational and on your resume.
 
 ### ⚔️ Quest 3: Level Up Your Scripting
 

--- a/pages/_posts/learning/2025-08-01-enhancing-bashcrawl-cellar-scroll-educational-content.md
+++ b/pages/_posts/learning/2025-08-01-enhancing-bashcrawl-cellar-scroll-educational-content.md
@@ -27,7 +27,7 @@ keywords:
         - shell aliases
         - progressive learning
         - gamified education
-lastmod: 2025-08-02T04:47:31.045Z
+lastmod: 2026-04-25T00:00:00.000Z
 permalink: /enhancing-bashcrawl-cellar-scroll-educational-content/
 attachments: ""
 comments: true
@@ -35,6 +35,8 @@ section: Learning
 ---
 
 ## The Challenge: Transforming Basic Terminal Instructions into Comprehensive Learning
+
+> **2026 update:** Bashcrawl now has a no-install web version at [bamr87.github.io/bashcrawl](https://bamr87.github.io/bashcrawl/) and a comprehensive IT-Journey fork at [github.com/bamr87/bashcrawl](https://github.com/bamr87/bashcrawl/). This post remains the content-design story behind the cellar scroll, while the current learner path begins online and continues into the full local repository.
 
 When encountering the original Bashcrawl cellar scroll, I found a functional but minimal tutorial that introduced `ls -F` and shell aliases. While the content was accurate, it missed opportunities to create a truly engaging and comprehensive learning experience that could serve beginners while building toward advanced concepts.
 

--- a/pages/_quests/0000/README.md
+++ b/pages/_quests/0000/README.md
@@ -4,7 +4,7 @@ title: Level 0000 - Foundation & Init World
 description: Your starting point in the IT-Journey. Character creation, OS selection, terminal basics, and first steps into the digital realm
 preview: images/previews/level-0000-foundation-init-world.png
 permalink: /quests/level-0000/
-lastmod: 2025-12-20T00:00:00.000Z
+lastmod: 2026-04-25T00:00:00.000Z
 
 level: 0000
 categories: quests
@@ -22,6 +22,7 @@ Level 0000 quests focus on:
 - **Character Creation** - Establishing your digital identity and choosing your path
 - **OS Selection** - Picking your primary operating system realm (Windows, macOS, Linux, Cloud)
 - **Terminal Mastery** - Learning command-line fundamentals and navigation
+- **Bashcrawl Practice** - Reinforcing commands through the online terminal dungeon and local extension labs
 - **Development Environment** - Setting up your first tools and configurations
 - **Community Entry** - Creating accounts and joining the guild
 
@@ -38,6 +39,7 @@ Level 0000 quests focus on:
 | [Git Basics: Version Control Introduction](/quests/level-0000-git-basics/) | 🟢 Easy | 60-75 minutes | main_quest | ✅ Complete |
 | [Markdown Mastery: Content Formatting Fundamentals](/quests/level-0000-markdown-mastery/) | 🟢 Easy | 30-45 minutes | main_quest | ✅ Complete |
 | [Terminal Fundamentals: Command Line Navigation Quest](/quests/level-0000-terminal-fundamentals/) | 🟢 Easy | 45-60 minutes | main_quest | ✅ Complete |
+| [Bashcrawl Terminal Adventure](/quests/bashcrawl-terminal-adventure/) | 🟢 Easy | 60-90 minutes | main_quest | ✅ Complete |
 | [bashrun and Beyond: Building an Advanced Terminal Game](/quests/lvl_000/bash-run/) | 🟡 Medium | 90-120 minutes | side_quest | ✅ Complete |
 | [Begin your IT Journey](/quests/lvl_000/begin-your-it-journey/) | 🟢 Easy | 30-45 minutes | main_quest | ✅ Complete |
 | [Character Selection](/quests/lvl_000/character-selection/) | 🟢 Easy | 20-30 minutes | main_quest | ✅ Complete |
@@ -213,6 +215,21 @@ Master the command line — the most powerful interface in any IT hero's arsenal
 
 ---
 
+#### [Bashcrawl Terminal Adventure](bashcrawl/)
+**Quest Type**: Main 🏰 | **Difficulty**: 🟢 Easy | **Estimated Time**: 60-90 minutes
+
+Practice terminal commands in the [online Bashcrawl dungeon](https://bamr87.github.io/bashcrawl/) before installing anything locally. This quest turns `pwd`, `ls -F`, `cat`, and `cd` into an adventure path.
+
+**Skills You'll Master:**
+- Safe no-install terminal practice
+- Directory navigation in a game world
+- Reading scrolls and command output
+- Moving from browser practice to local Bash workflows
+
+**Prerequisites:** Basic terminal curiosity; [Terminal Fundamentals](terminal-fundamentals.md) recommended
+
+---
+
 #### [Git Basics](git-basics.md)
 **Quest Type**: Main 🏰 | **Difficulty**: 🟢 Easy | **Estimated Time**: 60-75 minutes
 
@@ -258,18 +275,18 @@ Forge your ultimate development weapon. Master VS Code setup, extensions, and pr
 
 ---
 
-#### [Bash Fundamentals](bash-run.md)
-**Quest Type**: Main 🏰 | **Difficulty**: 🟡 Medium | **Estimated Time**: 90-120 minutes
+#### [Bash-run Extension Lab](bash-run.md)
+**Quest Type**: Side ⚔️ | **Difficulty**: 🟡 Medium | **Estimated Time**: 90-120 minutes
 
-Learn the terminal incantations that power Unix-like systems. Master Bash scripting basics.
+Clone the current [Bashcrawl repository](https://github.com/bamr87/bashcrawl/) and extend a real terminal learning game with new rooms, scrolls, and helper scripts.
 
 **Skills You'll Master:**
-- Bash command syntax
+- Bash project structure
 - Script creation and execution
-- Variables and control flow
-- File manipulation
+- Variables, functions, and control flow
+- Game-state and room-extension patterns
 
-**Prerequisites:** Terminal access, [Hello Linux](hello-linux/linux-fundamentals.md) or [Hello macOS](hello-mac/hello-mac.md)
+**Prerequisites:** [Bashcrawl Terminal Adventure](bashcrawl/) and [Terminal Fundamentals](terminal-fundamentals.md)
 
 ---
 
@@ -284,7 +301,7 @@ Learn terminal commands through an interactive text adventure game. Navigate dun
 - File management (cp, mv, rm)
 - Command-line gaming fun!
 
-**Prerequisites:** Basic terminal access
+**Prerequisites:** Basic terminal access or a browser for [Bashcrawl Web](https://bamr87.github.io/bashcrawl/)
 
 ### 📜 Script Examples
 
@@ -315,19 +332,21 @@ See the [tools collection](../tools/README.md) for beginner tool guides and gett
 4. [OS Selection](os-selection.md) - Choose your platform
 5. Platform-specific Hello quest
 6. [Terminal Fundamentals](terminal-fundamentals.md) - Command line basics
-7. [Git Basics](git-basics.md) - Version control
-8. [Markdown Mastery](markdown-mastery.md) - Documentation formatting
+7. [Bashcrawl Adventure](bashcrawl/) - Practice commands in the browser dungeon
+8. [Git Basics](git-basics.md) - Version control
+9. [Markdown Mastery](markdown-mastery.md) - Documentation formatting
 
 ### For Those with Some Experience
 1. [Character Selection](character-selection.md) - Confirm your specialization
 2. Platform-specific Hello quest
 3. [VS Code Mastery Quest](vscode-mastery.md) - Set up your IDE
 4. [Terminal Fundamentals](terminal-fundamentals.md) - Solidify CLI skills
-5. [Git Basics](git-basics.md) - Version control workflow
-6. [Bash Fundamentals](bash-run.md) - Advanced terminal proficiency
+5. [Bashcrawl Adventure](bashcrawl/) - Reinforce commands through play
+6. [Git Basics](git-basics.md) - Version control workflow
+7. [Bash-run Extension Lab](bash-run.md) - Extend a real Bash learning game
 
 ### For Quick Setup
-1. [Hello n00b](hello-noob.md) → Platform Hello quest → [VS Code Mastery Quest](vscode-mastery.md) → [Terminal Fundamentals](terminal-fundamentals.md) → [Git Basics](git-basics.md)
+1. [Hello n00b](hello-noob.md) → Platform Hello quest → [VS Code Mastery Quest](vscode-mastery.md) → [Terminal Fundamentals](terminal-fundamentals.md) → [Bashcrawl Adventure](bashcrawl/) → [Git Basics](git-basics.md)
 
 ## Quest Dependencies & Progression
 
@@ -346,9 +365,10 @@ graph TD
     H --> K
     I --> K
     K --> N[🖥️ Terminal Fundamentals]
-    N --> O[📝 Git Basics]
+    N --> Q[🎮 Bashcrawl Adventure]
+    Q --> O[📝 Git Basics]
     N --> P[📄 Markdown Mastery]
-    N --> L[📝 Bash Fundamentals]
+    Q --> L[📝 Bash-run Extension Lab]
     O --> M[Level 0001 Quests]
     P --> M
     L --> M

--- a/pages/_quests/0000/bash-run.md
+++ b/pages/_quests/0000/bash-run.md
@@ -6,7 +6,7 @@ excerpt: Starting with bashcrawl as a base and building upon it is a great way t
 snippet: Transform basic shell commands into an interactive gaming experience
 preview: images/previews/bashrun-and-beyond-building-an-advanced-terminal-g.png
 date: 2024-05-29T10:39:06.000Z
-lastmod: 2026-03-21T20:13:00.576Z
+lastmod: 2026-04-25T00:00:00.000Z
 level: "0000"
 difficulty: 🟡 Medium
 estimated_time: 90-120 minutes
@@ -93,10 +93,12 @@ related_quests:
 ---
 *Greetings, aspiring script mage! In this side quest, you will study how [bashcrawl](https://github.com/bamr87/bashcrawl) is built and then extend it with new rooms, encounters, and game mechanics. bashcrawl is an elegant dungeon crawler that uses the file system itself as the game world — directories are rooms, text files are scrolls, and executable scripts are interactive items. By the end, you will have forged your own additions to this adventure.*
 
+*If you have not played yet, begin with the no-install web version at [Bashcrawl Web](https://bamr87.github.io/bashcrawl/). Treat the browser game as your first scouting run, then clone the repository when you are ready to read and modify the actual Bash scripts.*
+
 ## 🎯 Quest Objectives
 
 ### Primary Objectives (Required for Quest Completion)
-- [ ] **Clone and explore the bashcrawl repository** — Understand how directories, scrolls, and executables form the game
+- [ ] **Play online, then clone and explore the bashcrawl repository** — Understand how directories, scrolls, and executables form the game
 - [ ] **Add a new room with a scroll and treasure** — Extend the dungeon with your own content
 - [ ] **Create an interactive encounter script** — Build an executable item using `read`, `case`, and environment variables
 - [ ] **Implement a hidden room mechanic** — Use dot-prefixed directories to create discoverable secrets
@@ -139,13 +141,19 @@ Here's a step-by-step guide to understanding bashcrawl's design and building upo
 
 ### Step 1: Setting Up bashcrawl
 
-1. **Clone the Repository:**
+1. **Scout the Dungeon Online:**
+
+    Open [Bashcrawl Web](https://bamr87.github.io/bashcrawl/) and complete the first objectives with `pwd`, `ls -F`, `cat scroll`, and `cd cellar`. This gives you the player experience before you inspect the code.
+
+2. **Clone the Repository:**
+
    ```bash
    git clone https://github.com/bamr87/bashcrawl.git
    cd bashcrawl
    ```
 
-2. **Run the Setup and Start Playing:**
+3. **Run the Setup and Start Playing Locally:**
+
    ```bash
    ./setup.sh       # One-time setup: sets permissions, creates game state
    ./main.sh        # Launch the game (multiple modes available)
@@ -153,7 +161,18 @@ Here's a step-by-step guide to understanding bashcrawl's design and building upo
 
    > **Tip**: Before modifying anything, play through the game first! Navigate with `cd`, read scrolls with `cat scroll`, and run items with `./treasure`. Understanding the player experience is essential before extending it.
 
-3. **Understand the Architecture:**
+4. **Choose the Right Mode for Your Work:**
+
+    | Goal | Command |
+    |------|---------|
+    | Beginner-safe local play | `./main.sh --interactive` |
+    | Pure Bash fallback | `./main.sh --classic` |
+    | Traditional filesystem adventure | `./main.sh --native` |
+    | Guided onboarding | `./main.sh --tutorial` |
+    | AI/headless playtesting | `./main.sh --agent` |
+    | Run one command for tests | `./main.sh --command "pwd"` |
+
+5. **Understand the Architecture:**
 
    The game world lives inside the `entrance/` directory. Each subdirectory is a room:
 
@@ -518,6 +537,16 @@ cat lib/state.sh
 cat .bashcrawl_save.json
 ```
 
+### Step 7: Extension Workflow Checklist
+
+Before opening a pull request or sharing your mod, verify your addition like a maintainer:
+
+- [ ] Play the room in [Bashcrawl Web](https://bamr87.github.io/bashcrawl/) or local TUI to compare the learner experience
+- [ ] Run `./setup.sh --verify` after changing executable files or permissions
+- [ ] Run `./main.sh --classic` and navigate to your new room without errors
+- [ ] Keep generated web data in sync with the Bashcrawl repo workflow (`make web-build`, then `make web-test`)
+- [ ] Document the command your room teaches and where it fits in the skill progression
+
 ## 🏆 Quest Completion Validation
 
 ### Portfolio Artifacts Created
@@ -536,6 +565,7 @@ cat .bashcrawl_save.json
 
 - [The Spellbook: Bash Cheatsheet](/shell/) - Quick reference for essential commands and scripting techniques.
 - [The Grand Grimoire: Complete BASH Reference](/docs/bash-complete-reference/) - Exhaustive guide covering every aspect of GNU Bash.
+- [Play Bashcrawl Online](https://bamr87.github.io/bashcrawl/) — No-install first playthrough with local browser saves
 - [bashcrawl on GitHub](https://github.com/bamr87/bashcrawl) — The game repository this quest is based on
 - [Bash Reference Manual (GNU)](https://www.gnu.org/software/bash/manual/bash.html)
 - [Advanced Bash-Scripting Guide (TLDP)](https://tldp.org/LDP/abs/html/)

--- a/pages/_quests/0000/bashcrawl/README.md
+++ b/pages/_quests/0000/bashcrawl/README.md
@@ -75,7 +75,7 @@ sub-title: "Level 000 Quest: Terminal Dungeon Adventure"
 excerpt: "Embark on an epic terminal adventure that teaches command line skills through interactive dungeon exploration and puzzle-solving"
 snippet: "Learn bash through adventure - where every command is a spell and every directory is a new realm to explore"
 permalink: /quests/bashcrawl-terminal-adventure/
-lastmod: 2024-05-28T00:00:00.000Z
+lastmod: 2026-04-25T00:00:00.000Z
 ---
 
 *Welcome, brave adventurer, to the mystical realm of Bashcrawl! This is no ordinary quest - it's an interactive terminal-based adventure that will transform you from a command line novice into a seasoned digital explorer.*
@@ -124,33 +124,49 @@ You'll know you've truly conquered this quest when you can:
 ## 📚 Resource Codex
 
 To aid you in your quest, consult these ancient tomes of knowledge:
+
+- [Play Bashcrawl Online](https://bamr87.github.io/bashcrawl/) - Start instantly in your browser with no local setup.
+- [Bashcrawl GitHub Repository](https://github.com/bamr87/bashcrawl/) - Clone the full game for local play, scripting practice, and contributions.
 - [The Spellbook: Bash Cheatsheet](/shell/) - Quick reference for essential commands and scripting techniques.
 - [The Grand Grimoire: Complete BASH Reference](/docs/bash-complete-reference/) - Exhaustive guide covering every aspect of GNU Bash.
 
+## ☁️ Instant Play Online
+
+The fastest way to begin is the web version:
+
+1. Open [Bashcrawl Web](https://bamr87.github.io/bashcrawl/).
+2. Start with `pwd`, `ls -F`, `cat scroll`, and `cd cellar`.
+3. Use the **Docs** panel or press `F1` when you need help.
+4. Let the quest tracker guide you through the first objectives.
+
+The web game runs fully in your browser, stores progress locally, and keeps you inside a safe simulated terminal. Use it as your first playthrough before installing the full repository.
+
 ## 🌍 Adventure Setup Guide
 
+Use the local repository when you want the complete Bashcrawl experience, including the Textual TUI, classic Bash emulator, native terminal mode, tutorial mode, agent mode, screenshots, tests, and contribution workflow.
+
 ### 🐧 Linux Territory Setup
+
 ```bash
-# Clone or download the bashcrawl adventure
 git clone https://github.com/bamr87/bashcrawl.git
 cd bashcrawl
-chmod +x entrance.sh
-./entrance.sh
+./setup.sh
+./main.sh --interactive
 ```
 
 ### 🍎 macOS Kingdom Setup
-```bash
-# Install via Homebrew (recommended)
-brew install bashcrawl
 
-# Or clone directly
+```bash
 git clone https://github.com/bamr87/bashcrawl.git
 cd bashcrawl
-chmod +x entrance.sh
-./entrance.sh
+./setup.sh
+./main.sh --interactive
 ```
 
+> **macOS note:** If you download a ZIP, Archive Utility can strip executable permissions. `git clone` is the recommended path.
+
 ### 🪟 Windows Empire Setup (WSL)
+
 ```powershell
 # First ensure WSL is installed
 wsl --install
@@ -158,8 +174,29 @@ wsl --install
 # Then in WSL terminal:
 git clone https://github.com/bamr87/bashcrawl.git
 cd bashcrawl
-chmod +x entrance.sh
-./entrance.sh
+./setup.sh
+./main.sh --interactive
+```
+
+### 🎮 Choose Your Play Mode
+
+| Mode | Command or Link | Best For |
+|------|-----------------|----------|
+| Web TUI | [bamr87.github.io/bashcrawl](https://bamr87.github.io/bashcrawl/) | First playthrough, classrooms, no-install practice |
+| Textual TUI | `./main.sh --interactive` | Beginners who want a rich local interface |
+| Classic Bash Emulator | `./main.sh --classic` | Systems without Python/Textual dependencies |
+| Native Terminal | `./main.sh --native` | Experienced users who want the traditional filesystem adventure |
+| Tutorial Mode | `./main.sh --tutorial` | Step-by-step guided learning |
+| Agent Mode | `./main.sh --agent` | AI playtesting, screenshots, and automation workflows |
+
+### 🛠️ Local Maintenance Commands
+
+```bash
+./setup.sh --verify        # Check installation health
+./setup.sh --repair        # Fix common permission/setup issues
+./setup.sh --health-check  # Run diagnostics
+./main.sh --status         # Show current game progress
+./main.sh --reset          # Reset progress for a fresh run
 ```
 
 ## 🧙‍♂️ Chapter 1: Entering the Digital Dungeon
@@ -195,10 +232,10 @@ When you cast `ls -F`, you'll see these magical markers:
 Start your journey by running the entrance script:
 
 ```bash
-./entrance.sh
+./main.sh --interactive
 ```
 
-This will transport you to the beginning of your adventure!
+This will launch the safe local TUI and transport you to the beginning of your adventure. If you are playing online, use the browser prompt instead and begin with `pwd`.
 
 ### 🗝️ Step 2: Read Everything Carefully
 
@@ -292,6 +329,7 @@ When you encounter challenges:
 
 **Follow-Up Quests**:
 - [Bash Run Quest](../bash-run.md) - Shell Scripting Fundamentals
+- [Bash Scripting Mastery](/quests/0010/bash-scripting/) - Automation and reusable scripts
 - [Hello n00b Quest](../hello-noob.md) - Continuing Your IT Journey
 - [VS Code Mastery](../vscode-mastery.md) - Development Environment Setup
 
@@ -314,7 +352,9 @@ Your newfound terminal mastery opens several exciting paths:
 
 ### 📚 Additional Resources
 
-- **Official Bashcrawl Repository**: [GitLab](https://gitlab.com/slackermedia/bashcrawl)
+- **Play Online**: [Bashcrawl Web](https://bamr87.github.io/bashcrawl/)
+- **Current IT-Journey Fork**: [GitHub — bamr87/bashcrawl](https://github.com/bamr87/bashcrawl/)
+- **Original Upstream Repository**: [GitLab — slackermedia/bashcrawl](https://gitlab.com/slackermedia/bashcrawl)
 - **Command Line Learning**: [The Linux Command Line](http://linuxcommand.org/)
 - **Terminal Games**: [Other CLI adventure games](https://github.com/topics/terminal-game)
 - **Advanced Bash**: [Advanced Bash Scripting Guide](https://tldp.org/LDP/abs/html/)

--- a/pages/_quests/0000/bashcrawl/bash_crawl.sh
+++ b/pages/_quests/0000/bashcrawl/bash_crawl.sh
@@ -1,26 +1,152 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
+# Script: bash_crawl.sh
+# Description: Guided Bashcrawl launcher for online play or local setup.
+# Author: IT-Journey Team
+# Version: 2.0.0
+# Last Modified: 2026-04-25
+# Dependencies: bash, git, optional browser opener (open/xdg-open)
+# Tested On: macOS, Linux, WSL
+#
+# Usage: bash_crawl.sh [online|local|classic|native|help]
 
-echo "Let's bash crawl"
-read -p "Do you want to play Bash Crawl? yes or no `echo $'\n>'`" parm1
-read -rep $'Do you know how to nano? yes or no  \n' parm2
+set -euo pipefail
 
-if [[ $parm1 == "no" ]]; then
-    echo "umm you said $parm1"
-    exit 0
-elif [[ $parm1 == "yes" && $parm2 == "yes" ]]; then
-    sleep 2
-    echo 'installing bash crawl now...'
-    
-    if [ ! -d "bashcrawl" ]; then
-        git clone https://github.com/bamr87/bashcrawl.git
+readonly SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+readonly BASHCRAWL_WEB_URL="https://bamr87.github.io/bashcrawl/"
+readonly BASHCRAWL_REPO_URL="https://github.com/bamr87/bashcrawl.git"
+readonly BASHCRAWL_DIR="${BASHCRAWL_DIR:-bashcrawl}"
+
+show_help() {
+    cat <<EOF
+Bashcrawl Quest Launcher
+
+Usage:
+  $SCRIPT_NAME [online|local|classic|native|help]
+
+Modes:
+  online   Open the no-install browser version
+  local    Clone/update the repo and launch Textual TUI mode
+  classic  Clone/update the repo and launch the pure Bash emulator
+  native   Clone/update the repo and show native terminal instructions
+  help     Show this help text
+
+Environment:
+  BASHCRAWL_DIR  Local clone directory (default: ./bashcrawl)
+EOF
+}
+
+open_online_game() {
+    echo "Opening Bashcrawl Web: $BASHCRAWL_WEB_URL"
+
+    if command -v open >/dev/null 2>&1; then
+        open "$BASHCRAWL_WEB_URL"
+    elif command -v xdg-open >/dev/null 2>&1; then
+        xdg-open "$BASHCRAWL_WEB_URL"
     else
-        echo "bashcrawl already installed."
+        echo "Open this URL in your browser: $BASHCRAWL_WEB_URL"
     fi
-    
-    cd bashcrawl || exit 1
-    chmod +x entrance.sh
-    ./entrance.sh
-else
-    echo "wrong answer"
-    exit 1
-fi
+}
+
+ensure_git() {
+    if ! command -v git >/dev/null 2>&1; then
+        echo "Error: git is required for local Bashcrawl setup." >&2
+        echo "Use online mode instead: $BASHCRAWL_WEB_URL" >&2
+        exit 3
+    fi
+}
+
+clone_or_update_repo() {
+    ensure_git
+
+    if [[ -d "$BASHCRAWL_DIR/.git" ]]; then
+        echo "Updating existing Bashcrawl clone in $BASHCRAWL_DIR..."
+        git -C "$BASHCRAWL_DIR" pull --ff-only
+    elif [[ -e "$BASHCRAWL_DIR" ]]; then
+        echo "Error: $BASHCRAWL_DIR exists but is not a Git repository." >&2
+        echo "Set BASHCRAWL_DIR to another path or move the existing directory." >&2
+        exit 5
+    else
+        echo "Cloning Bashcrawl into $BASHCRAWL_DIR..."
+        git clone "$BASHCRAWL_REPO_URL" "$BASHCRAWL_DIR"
+    fi
+}
+
+run_setup() {
+    if [[ ! -x "$BASHCRAWL_DIR/setup.sh" ]]; then
+        chmod +x "$BASHCRAWL_DIR/setup.sh"
+    fi
+
+    "$BASHCRAWL_DIR/setup.sh" --quick
+    "$BASHCRAWL_DIR/setup.sh" --verify
+}
+
+launch_local_mode() {
+    local mode="$1"
+
+    clone_or_update_repo
+    run_setup
+
+    case "$mode" in
+        local)
+            exec "$BASHCRAWL_DIR/main.sh" --interactive
+            ;;
+        classic)
+            exec "$BASHCRAWL_DIR/main.sh" --classic
+            ;;
+        native)
+            echo "Native mode uses your real terminal environment."
+            echo "Run this when you are ready:"
+            echo "  cd $BASHCRAWL_DIR"
+            echo "  ./main.sh --native"
+            ;;
+        *)
+            echo "Error: unknown local mode: $mode" >&2
+            exit 2
+            ;;
+    esac
+}
+
+prompt_for_mode() {
+    cat <<EOF
+Choose your Bashcrawl path:
+
+1) Play online now (recommended first run)
+2) Install/update locally and launch Textual TUI
+3) Install/update locally and launch classic Bash emulator
+4) Prepare native terminal mode
+5) Show help
+EOF
+    printf "\nSelection [1-5]: "
+    read -r selection
+
+    case "$selection" in
+        1) open_online_game ;;
+        2) launch_local_mode local ;;
+        3) launch_local_mode classic ;;
+        4) launch_local_mode native ;;
+        5) show_help ;;
+        *)
+            echo "Error: choose a number from 1 to 5." >&2
+            exit 2
+            ;;
+    esac
+}
+
+main() {
+    local mode="${1:-menu}"
+
+    case "$mode" in
+        online) open_online_game ;;
+        local|classic|native) launch_local_mode "$mode" ;;
+        help|--help|-h) show_help ;;
+        menu) prompt_for_mode ;;
+        *)
+            echo "Error: unknown mode: $mode" >&2
+            show_help
+            exit 2
+            ;;
+    esac
+}
+
+main "$@"

--- a/pages/_quests/0000/terminal-fundamentals.md
+++ b/pages/_quests/0000/terminal-fundamentals.md
@@ -7,7 +7,7 @@ excerpt: Learn essential command line skills for navigating and managing files i
   any operating system.
 preview: images/previews/terminal-fundamentals-command-line-navigation-ques.png
 date: 2025-11-29T22:51:57.000Z
-lastmod: 2025-12-20 00:00:00+00:00
+lastmod: 2026-04-25T00:00:00.000Z
 level: '0000'
 difficulty: 🟢 Easy
 estimated_time: 45-60 minutes
@@ -19,7 +19,9 @@ quest_arc: Terminal Mastery Arc
 quest_dependencies:
   required_quests: []
   recommended_quests: []
-  unlocks_quests: []
+  unlocks_quests:
+    - /quests/bashcrawl-terminal-adventure/
+    - /quests/0010/bash-scripting/
 quest_relationships:
   parent_quest: null
   child_quests: []
@@ -362,6 +364,20 @@ find . -mtime -1
 
 ---
 
+## 🎮 Practice Path: Enter Bashcrawl
+
+Once you can use `pwd`, `ls`, `cd`, and `cat`, reinforce those skills in [Bashcrawl Web](https://bamr87.github.io/bashcrawl/). The browser game gives you a safe terminal-inspired dungeon where:
+
+- `pwd` reveals your current room
+- `ls -F` shows directories, files, and executable encounters
+- `cat scroll` reads the lesson in each chamber
+- `cd cellar` moves you deeper into the adventure
+- `F1` opens in-game documentation when you need a hint
+
+After your first online run, continue with the [Bashcrawl Terminal Adventure Quest](/quests/bashcrawl-terminal-adventure/) for the full quest checklist and then [Bash Scripting Mastery](/quests/0010/bash-scripting/) when you are ready to automate.
+
+---
+
 ## 🎮 Mastery Challenges
 
 ### 🟢 Novice Challenge: Directory Explorer
@@ -402,3 +418,5 @@ find . -mtime -1
 - [ExplainShell — Visualize Shell Commands](https://explainshell.com/)
 - [The Art of Command Line (GitHub)](https://github.com/jlevy/the-art-of-command-line)
 - [tldr pages — Simplified Man Pages](https://tldr.sh/)
+- [Bashcrawl Web](https://bamr87.github.io/bashcrawl/) - Browser-based terminal dungeon for practicing the commands in this quest
+- [Bashcrawl Repository](https://github.com/bamr87/bashcrawl/) - Full local game, scripts, docs, and contribution path

--- a/pages/_quests/0010/README.md
+++ b/pages/_quests/0010/README.md
@@ -4,7 +4,7 @@ title: Level 0010 - Terminal Enhancement & Shell Mastery
 description: Enhance your terminal experience with Oh My Zsh, Nerd Fonts, and advanced shell customization
 preview: images/previews/level-0010-terminal-enhancement-shell-mastery.png
 permalink: /quests/level-0010/
-lastmod: 2026-02-14T00:00:00.000Z
+lastmod: 2026-04-25T00:00:00.000Z
 
 level: 0010
 categories: quests
@@ -22,13 +22,14 @@ Level 0010 quests focus on:
 - **Shell Framework Mastery** - Oh My Zsh and plugin ecosystems
 - **Visual Enhancements** - Nerd Fonts, themes, and prompt customization
 - **Terminal Configuration** - Advanced shell scripting and optimization
+- **Project-Based Bash Practice** - Study Bashcrawl locally and extend a working terminal learning game
 - **Developer Productivity** - Tools and workflows for efficient development
 
 ## Available Quests
 
 | Quest | Difficulty | Time | Type | Status |
 |-------|------------|------|------|--------|
-| [Mastering the Bash Incantations: Binary Level 0010 (2) Command Line Sorcery Quest](../README.mdlevel-0010-bash-scripting/) | 🟡 Medium | 90-120 minutes | main_quest | ✅ Complete |
+| [Mastering the Bash Incantations: Binary Level 0010 (2) Command Line Sorcery Quest](/quests/0010/bash-scripting/) | 🟡 Medium | 90-120 minutes | main_quest | ✅ Complete |
 | [Terminal Enchantment: Oh-My-Zsh Mastery related_quests:](../README.mdlevel-0010-oh-my-zsh-mastery/) | 🟡 Medium | 45-90 minutes | main_quest | 🔮 Placeholder |
 | [The Diagrammatic Enchantment: Jekyll-Mermaid Integration Quest](../README.mdlevel-0010/jekyll-mermaid-integration-quest/) | 🟡 Medium | 2-3 hours | main_quest | ✅ Complete |
 | [Understanding Action Triggers in Depth](/quests/level-0010-action-triggers/) | 🟢 Easy | 30-60 minutes | main_quest | 🔮 Placeholder |
@@ -99,15 +100,16 @@ Master the art of terminal-based frontend development workflows. Build, test, an
 #### [Bash Scripting Mastery](bash-scripting.md)
 **Quest Type**: Main 🏰 | **Difficulty**: 🟡 Medium | **Estimated Time**: 90-120 minutes
 
-Advance beyond basic commands to write powerful, reusable Bash scripts. Learn control flow, error handling, and best practices.
+Advance beyond basic commands to write powerful, reusable Bash scripts. Use Bashcrawl as a capstone project for studying launchers, setup checks, state, and testable command workflows.
 
 **Skills You'll Master:**
 - Advanced Bash scripting patterns
 - Error handling and exit codes
 - Script parameterization and validation
 - Cross-platform compatibility
+- Bashcrawl extension and local project analysis
 
-**Prerequisites:** [Bash Fundamentals](../0000/bash-run.md)
+**Prerequisites:** [Terminal Fundamentals](../0000/terminal-fundamentals.md), [Bashcrawl Adventure](../0000/bashcrawl/), and [Bash-run Extension Lab](../0000/bash-run.md)
 
 ---
 

--- a/pages/_quests/0010/bash-scripting.md
+++ b/pages/_quests/0010/bash-scripting.md
@@ -9,11 +9,11 @@ excerpt: Transform from a terminal novice into a bash scripting wizard through h
 snippet: When the shell speaks, the system listens - master the ancient bash incantations!
 preview: images/previews/mastering-the-bash-incantations-binary-level-0010-.png
 date: 2025-07-28T23:34:51.000Z
-lastmod: 2025-11-08 15:07:21.509000+00:00
+lastmod: 2026-04-25T00:00:00.000Z
 level: '0010'
 difficulty: 🟡 Medium
 estimated_time: 90-120 minutes
-primary_technology: lvl-0010
+primary_technology: bash
 quest_type: main_quest
 quest_series: Foundation Binary Mastery Path
 skill_focus:
@@ -26,6 +26,7 @@ prerequisites:
 - Familiarity with file system structure (directories, files, paths)
 - Text editor comfort (nano, vim, or VS Code)
 - Understanding of basic computing concepts
+- Recommended: play the no-install Bashcrawl web adventure before studying its scripts
 validation_criteria:
 - Create functional bash scripts with error handling
 - Demonstrate automation of repetitive tasks
@@ -232,6 +233,29 @@ cd /workspace/bash-quest
 ```
 
 *Web-specific notes: Great for quick experimentation and learning. Limited file persistence and system access.*
+
+## 🎮 Bashcrawl as Your Capstone Lab
+
+Before writing larger scripts from scratch, play [Bashcrawl Web](https://bamr87.github.io/bashcrawl/) and notice how a terminal lesson can become a guided system. Then clone the [Bashcrawl repository](https://github.com/bamr87/bashcrawl/) and study it as a real Bash project.
+
+```bash
+git clone https://github.com/bamr87/bashcrawl.git
+cd bashcrawl
+./setup.sh --verify
+./main.sh --interactive
+```
+
+Use Bashcrawl as a running example throughout this quest:
+
+| Bash Skill | Bashcrawl Example to Study |
+|------------|----------------------------|
+| Functions and reuse | `src/help/` and shared helper scripts |
+| State management | `.bashcrawl_save.json` and `lib/state.sh` |
+| Argument parsing | `main.sh` launcher flags such as `--classic`, `--native`, and `--agent` |
+| Error handling | `setup.sh --verify`, `--repair`, and `--health-check` |
+| Testing and parity | `make web-test` and command validation scripts |
+
+The goal is not to memorize every file. The goal is to learn how readable Bash scripts are structured, guarded, documented, and tested in a living project.
 
 ## 🧙‍♂️ Chapter 1: The Foundation Incantations
 
@@ -842,6 +866,28 @@ main "$@"
 
 ## 🎮 Quest Implementation Challenges
 
+### 🧩 Capstone Challenge: Bashcrawl Room Automation (🕐 Estimated Time: 45-75 minutes)
+
+*Use a real educational game as your scripting laboratory.*
+
+**Objective**: Add a small Bashcrawl helper or room extension that teaches one command clearly.
+
+**Requirements**:
+
+- [ ] Start with a complete playthrough of [Bashcrawl Web](https://bamr87.github.io/bashcrawl/)
+- [ ] Clone the [Bashcrawl repository](https://github.com/bamr87/bashcrawl/) locally
+- [ ] Add a room, scroll, or helper script that teaches one command or scripting concept
+- [ ] Include defensive checks and helpful error messages
+- [ ] Run `./setup.sh --verify` and launch the game with `./main.sh --classic`
+- [ ] Document where your addition fits in the command progression
+
+**Success Criteria**:
+
+- [ ] A learner can discover your addition by navigating normally
+- [ ] Your script exits cleanly and does not modify files outside the game tree
+- [ ] The room links the fantasy action to a real terminal skill
+- [ ] Your implementation can be explained using functions, variables, conditionals, and exit codes
+
 ### 🟢 Novice Challenge: Personal File Organizer (🕐 Estimated Time: 30-45 minutes)
 
 *Create a script that organizes files in a directory by type.*
@@ -994,6 +1040,9 @@ main "$@"
 
 ### 📖 Essential Documentation
 
+- [Bashcrawl Web](https://bamr87.github.io/bashcrawl/) - No-install terminal dungeon for practicing commands before scripting
+- [Bashcrawl Repository](https://github.com/bamr87/bashcrawl/) - Complete Bash, Python TUI, static web, and testing project to study and extend
+- [Complete BASH Reference](/docs/bash-complete-reference/) - IT-Journey's reference guide for command syntax and scripting patterns
 - [Bash Manual](https://www.gnu.org/software/bash/manual/) - Official GNU Bash reference
 - [Advanced Bash Scripting Guide](https://tldp.org/LDP/abs/html/) - Comprehensive tutorial resource
 - [ShellCheck Wiki](https://github.com/koalaman/shellcheck/wiki) - Best practices and common mistakes

--- a/pages/_quests/home.md
+++ b/pages/_quests/home.md
@@ -19,7 +19,7 @@ mermaid: true
 toc: true
 toc_sticky: true
 date: 2021-11-30T14:41:59.000Z
-lastmod: 2026-04-02T03:24:28.781Z
+lastmod: 2026-04-25T00:00:00.000Z
 draft: false
 excerpt: "Your central command hub for tracking progress through the IT mastery quest system — navigate learning paths, monitor achievements, and plan next adventures."
 keywords:
@@ -160,10 +160,11 @@ Terminal Mastery & Basic Setup
 **Available Quests:**
 
 - [ ] [VS Code Mastery Quest](0000/vscode-mastery.md) - *Forge Your Ultimate Development Weapon* (50 XP)
-- [ ] [Bash Fundamentals](0000/bash-run.md) - *Terminal Incantations* (40 XP)
+- [ ] [Terminal Fundamentals](0000/terminal-fundamentals.md) - *Command Line Mastery* (40 XP)
+- [ ] [Bashcrawl Adventure](0000/bashcrawl/) - *Browser Dungeon Practice* (40 XP)
+- [ ] [Bash-run Extension Lab](0000/bash-run.md) - *Terminal Game Scripting* (40 XP)
 - [ ] [Begin Your IT Journey](0000/begin-your-it-journey.md) - *The Hero's Call* (30 XP)
 - [ ] [Hello n00b](0000/hello-noob.md) - *First Steps* (20 XP)
-- [ ] [Terminal Fundamentals](0000/terminal-fundamentals.md) - *Command Line Mastery* (40 XP)
 - [ ] [Git Basics](0000/git-basics.md) - *Version Control Foundation* (40 XP)
 - [ ] [Markdown Mastery](0000/markdown-mastery.md) - *Documentation Magic* (30 XP)
 - [ ] [Character Building](0000/character-building.md) - *Forge Your Identity* (30 XP)
@@ -711,9 +712,10 @@ Fast Track Adventures
 3. [Personal Site](0001/personal-site.md) - First Project
 
 #### 🏗️ Engineer Quick Start
-1. [Bash Fundamentals](0000/bash-run.md) - Terminal Basics
-2. [Oh My Zsh](0010/oh-my-zsh-terminal-enchantment.md) - Terminal Enhancement
-3. [Bash Scripting](0010/bash-scripting.md) - Automation
+1. [Terminal Fundamentals](0000/terminal-fundamentals.md) - Terminal Basics
+2. [Bashcrawl Adventure](0000/bashcrawl/) - Browser command practice
+3. [Bash-run Extension Lab](0000/bash-run.md) - Local Bash project extension
+4. [Bash Scripting](0010/bash-scripting.md) - Automation
 
 #### 🛡️ Security Quick Start
 1. [Terminal Mastery](0000/) - Command Line Foundation
@@ -990,8 +992,9 @@ Based on your current progress:
 
 1. **Start Here:** [Hello n00b](0000/hello-noob.md) - Begin your journey
 2. **Then:** [VS Code Mastery](0000/vscode-mastery.md) - Set up your tools
-3. **Next:** [Bash Fundamentals](0000/bash-run.md) - Learn the terminal
-4. **Goal:** Complete Apprentice Tier (Levels 0000-0011)
+3. **Next:** [Terminal Fundamentals](0000/terminal-fundamentals.md) - Learn the terminal
+4. **Practice:** [Bashcrawl Adventure](0000/bashcrawl/) - Reinforce commands through play
+5. **Goal:** Complete Apprentice Tier (Levels 0000-0011)
 
 ## Community & Support
 
@@ -1099,7 +1102,7 @@ _Last generated: 2026-01-15T20:39:18Z_
 | [Forging the Prompt Crystal: Master AI Communication](/quests/level-0010-prompt-engineering-mastery/) | main_quest | 🟡 Medium | 90-120 minutes | AI Development Mastery | ✅ Complete |
 | [JavaScript Fundamentals: DOM Manipulation & Events](/quests/level-0010-javascript-fundamentals/) | main_quest | 🟡 Medium | 75-90 minutes | Web Development Fundamentals | 🔮 Draft |
 | [Mastering Branches and Pull Requests for Developers](/quests/level-0010-branches-and-pull-requests/) | main_quest | 🟢 Easy | 30-60 minutes | Tools Collection | ✅ Complete |
-| [Mastering the Bash Incantations: Binary Level 0010 (2) Command Line Sorcery Quest](../README.mdlevel-0010-bash-scripting/) | main_quest | 🟡 Medium | 90-120 minutes | Foundation Binary Mastery Path | ✅ Complete |
+| [Mastering the Bash Incantations: Binary Level 0010 (2) Command Line Sorcery Quest](/quests/0010/bash-scripting/) | main_quest | 🟡 Medium | 90-120 minutes | Foundation Binary Mastery Path | ✅ Complete |
 | [Nerd Font Enchantment: Terminal Icon Mastery](/quests/side-quest-nerd-font-enchantment/) | side_quest | 🟢 Easy | 20-30 minutes | Terminal Mastery Path | ✅ Complete |
 | [planting seeds](/quests/level-0010-planting-seeds/) | main_quest | 🟢 Easy | 30-60 minutes | Tools Collection | ✅ Complete |
 | [Recursive Realms: Testing Infinite Loops with AI](/quests/level-0010-recursive-realms-testing/) | main_quest | 🟡 Medium | 90-120 minutes | Python Mastery Path | ✅ Complete |

--- a/pages/_quickstart/cicd-automation.md
+++ b/pages/_quickstart/cicd-automation.md
@@ -7,7 +7,7 @@ permalink: /quickstart/cicd-automation/
 categories:
   - quickstart
 slug: cicd-automation
-lastmod: 2026-04-02T03:14:50.968Z
+lastmod: 2026-04-25T00:00:00.000Z
 draft: false
 date: 2026-04-01T00:00:00.000Z
 difficulty: 🟡 Medium
@@ -223,7 +223,7 @@ Access in workflows with `${{ secrets.SECRET_NAME }}`.
 |-----------|-------|
 | Optimize for SEO, performance, and accessibility | [Optimization & Maintenance](/quickstart/optimization-maintenance/) |
 
-> **IT-Journey Quests:** [CI/CD Fundamentals](/quests/cicd/cicd-fundamentals/) · [GitHub Actions Basics](/quests/cicd/github-actions-basics/) · [Bash Scripting](/quests/intermediate/bash-scripting/)
+> **IT-Journey Quests:** [CI/CD Fundamentals](/quests/cicd/cicd-fundamentals/) · [GitHub Actions Basics](/quests/cicd/github-actions-basics/) · [Bash Scripting](/quests/0010/bash-scripting/)
 >
 > **IT-Journey Docs:** [GitHub Actions Workflows](/docs/workflows/GITHUB_ACTIONS/) · [Testing Frameworks](/docs/testing/TESTING_FRAMEWORKS/) · [Scripts Guide](/docs/scripts/SCRIPTS_GUIDE/)
 >

--- a/pages/_quickstart/index.md
+++ b/pages/_quickstart/index.md
@@ -14,7 +14,7 @@ tags:
   - github-pages
 sidebar:
   nav: quickstart
-lastmod: 2026-04-02T03:24:28.768Z
+lastmod: 2026-04-25T00:00:00.000Z
 date: 2021-12-05T18:52:20.000Z
 draft: false
 keywords:
@@ -312,9 +312,9 @@ The IT-Journey quest system uses binary level codes. Here's the full progression
 
 | Level | Tier | Focus Area | Example Quests |
 |-------|------|-----------|----------------|
-| `0000` | Foundation | OS setup, terminal, Git, Markdown, VS Code | [Begin Your IT Journey](/quests/init_world/begin-your-it-journey/), [Terminal Fundamentals](/quests/init_world/terminal-fundamentals/) |
+| `0000` | Foundation | OS setup, terminal, Git, Markdown, VS Code | [Begin Your IT Journey](/quests/lvl_000/begin-your-it-journey/), [Terminal Fundamentals](/quests/level-0000-terminal-fundamentals/), [Bashcrawl Online](https://bamr87.github.io/bashcrawl/) |
 | `0001` | Beginner | GitHub Pages, Jekyll, YAML, Liquid | [Jekyll Fundamentals](/quests/frontend/jekyll-fundamentals/), [YAML Configuration](/quests/frontend/yaml-configuration/) |
-| `0010` | Intermediate | JavaScript, CSS, Bootstrap, Bash scripting | [JavaScript Fundamentals](/quests/intermediate/javascript-fundamentals/), [Bash Scripting](/quests/intermediate/bash-scripting/) |
+| `0010` | Intermediate | JavaScript, CSS, Bootstrap, Bash scripting | [JavaScript Fundamentals](/quests/level-0010-javascript-fundamentals/), [Bash Scripting](/quests/0010/bash-scripting/) |
 | `0011` | Advanced | Git workflows, Jekyll plugins, SEO, analytics | [Advanced Git Workflows](/quests/advanced/advanced-git-workflows/), [SEO Optimization](/quests/advanced/seo-optimization/) |
 | `0100` | Containers | Docker, Docker Compose, frontend containers | [Container Fundamentals](/quests/containers/container-fundamentals/), [Docker Compose](/quests/containers/docker-compose-orchestration/) |
 | `0101` | CI/CD | GitHub Actions, deployment pipelines, secrets | [CI/CD Fundamentals](/quests/cicd/cicd-fundamentals/), [GitHub Actions Basics](/quests/cicd/github-actions-basics/) |
@@ -340,7 +340,7 @@ Now that you can build and deploy a Jekyll site, explore the rest of IT-Journey:
 | Collection | What It Is | Start Here |
 |------------|-----------|------------|
 | [🏰 Quest Map](/quests/home/) | Gamified learning adventures across 16 binary levels (0000–1111) — from terminal basics to system architecture. Track XP, unlock tiers, and follow character-class paths. | [Hello n00b](/quests/init_world/hello-noob/) | 
-| [📚 Docs Library](/docs/) | Reference documentation for the tools powering IT-Journey — terminal shortcuts, Bash reference, Jekyll configuration, Liquid templating, Mermaid diagrams, and MathJax. | [Terminal Shortcuts](/docs/terminal-shortcuts-cheat-sheet/) |
+| [📚 Docs Library](/docs/) | Reference documentation for the tools powering IT-Journey — terminal learning path, shortcuts, Bash reference, Jekyll configuration, Liquid templating, Mermaid diagrams, and MathJax. | [Terminal and Bash Learning Path](/docs/terminal/) |
 | [📝 Notes](/notes/) | Working notes, code snippets, and quick references collected during development — PowerShell, Linux, macOS tips, and more. | [Notes Index](/notes/) |
 | [📰 Blog Posts](/posts/) | Tutorials, AI-assisted development chronicles, and technical write-ups organized across 10 categories — from web development to DevOps to data analytics. | [Posts Index](/posts/) |
 | [🏠 Site Home](/home/) | The main IT-Journey hub with links to every section of the platform. | [Home](/home/) |

--- a/pages/posts.md
+++ b/pages/posts.md
@@ -4,7 +4,7 @@ author: Amr
 description: Comprehensive collection of educational blog posts covering web development, DevOps, system administration, AI & machine learning, and emerging technologies — documenting the learning journey from zero to hero.
 excerpt: A complete index of posts documenting this journey, organized into categories, journal entries, and articles
 date: 2025-12-17T19:56:57.000Z
-lastmod: 2026-04-01T00:00:00.000Z
+lastmod: 2026-04-25T00:00:00.000Z
 version: 2.0.0
 draft: false
 sidebar:
@@ -117,6 +117,8 @@ Practical tutorials, deep-dive technical articles, AI-assisted development chron
 ### Shell Scripting & Bash
 
 - [**Bash Scripting**](programming/bash-scripting.md) - Comprehensive scripting guide
+- [**Enhancing Bashcrawl Cellar Scroll**](learning/2025-08-01-enhancing-bashcrawl-cellar-scroll-educational-content.md) - Turning Bashcrawl command practice into richer terminal education
+- [**Terminal Bash for Finance and Accounting**](business/2026-02-23-terminal-bash-finance-accounting.md) - Practical Bash automation for spreadsheet-heavy workflows
 - [**AI-Powered Modular Shell Script Refactoring**](programming/2025-07-05-ai-powered-modular-refactoring-shell-scripts.md) - Advanced architecture patterns
 
 ### Python Programming

--- a/roadmap.md
+++ b/roadmap.md
@@ -5,7 +5,7 @@ layout: default
 author: IT-Journey Team
 permalink: /roadmap/
 backlink: /
-lastmod: 2025-12-19T00:00:00.000Z
+lastmod: 2026-04-25T00:00:00.000Z
 draft: false
 toc: true
 toc_sticky: true
@@ -135,7 +135,10 @@ Where learning becomes an adventure through Posts and Quests - 46+ gamified lear
 | [IT Fundamentals](/quests/0000/it-fundamentals/) | Core Concepts | 🟢 Easy | All |
 | [OS Selection](/quests/0000/os-selection/) | Platform Choice | 🟢 Easy | All |
 | [VS Code Mastery](/quests/0000/vscode-mastery-quest/) | IDE Configuration | 🟡 Medium | All |
-| [Terminal Fundamentals](/quests/0000/terminal-fundamentals/) | Command Line Basics | 🟢 Easy | All |
+| [Terminal Fundamentals](/quests/level-0000-terminal-fundamentals/) | Command Line Basics | 🟢 Easy | All |
+| [Bashcrawl Online](https://bamr87.github.io/bashcrawl/) | Browser Terminal Practice | 🟢 Easy | All |
+| [Bashcrawl Adventure](/quests/bashcrawl-terminal-adventure/) | Terminal Game Quest | 🟢 Easy | All |
+| [Bash-run Extension Lab](/quests/lvl_000/bash-run/) | Local Bash Project Extension | 🟡 Medium | All |
 | [Markdown Mastery](/quests/0000/markdown-mastery/) | Documentation | 🟢 Easy | All |
 | [Git Basics](/quests/0000/git-basics/) | Version Control | 🟢 Easy | All |
 


### PR DESCRIPTION
## Summary
- Add a new Terminal and Bash Learning Path hub at `/docs/terminal/`
- Update Bashcrawl, terminal fundamentals, Bash-run, and Bash scripting quests to use the online Bashcrawl path and current `bamr87/bashcrawl` repo workflow
- Refresh docs, navigation, quickstart, roadmap, posts, and cheatsheet references around Bashcrawl and terminal learning
- Rewrite the Bashcrawl quest launcher with online/local/classic/native modes

## Verification
- `bash -n pages/_quests/0000/bashcrawl/bash_crawl.sh`
- Quest validator passed for Bashcrawl, Bash-run, Terminal Fundamentals, and Bash Scripting
- `docker-compose exec -T jekyll bundle exec jekyll build --trace`
- `git diff --check`
- VS Code diagnostics clean for touched files checked

## Notes
- Left pre-existing unrelated changes unstaged: `pages/_quests/0100/README.md`, `pages/_quests/0100/jekyll-component-refactoring.md`, and `scripts/prd-machine/prd-machine.py.bak`.