### PR TITLE
feat(docs): add Obsidian graph docs and site navigation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,7 @@ source "https://rubygems.org"
 # Github Pages Gems - Use latest compatible version:
 gem 'github-pages'
 
-# Jekyll Theme - Using remote theme for production, gem for local dev
-gem 'jekyll-theme-zer0'
+# Jekyll Theme is loaded via `remote_theme` in `_config.yml` and `_config_dev.yml`.
 
 # If you have plugins enabled in the _config.yml, add them here too:
 group :jekyll_plugins do

--- a/_config.yml
+++ b/_config.yml
@@ -196,6 +196,7 @@ plugins:
   - jekyll-seo-tag
   - jekyll-paginate
   - jekyll-relative-links
+  - jekyll-redirect-from
 
 ## Gisgus Plugin #################################################################
 
@@ -214,6 +215,12 @@ gisgus:
 
 mermaid:
   src: '/assets/vendor/mermaid/mermaid.min.js'
+
+## Obsidian Knowledge Graph #######################################################
+# Keep implementation in the zer0-mistakes theme; configure only site paths here.
+
+obsidian:
+  attachments_path: '/assets/images/notes'
 
 ## Conversion
 # Markdown Options https://jekyllrb.com/docs/configuration/markdown/

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,7 +1,7 @@
 # Dev config override
 
-remote_theme             : false
-theme                    : "jekyll-theme-zer0"
+remote_theme             : "bamr87/zer0-mistakes"
+# theme                  : "jekyll-theme-zer0"
 
 # Performance: enable incremental builds for development
 incremental: true
@@ -9,8 +9,10 @@ incremental: true
 # Performance: disable feed/sitemap regeneration during dev
 # These plugins regenerate fully on every change, adding ~10-20s
 plugins:
+  - jekyll-remote-theme
   - jekyll-include-cache
   - jekyll-relative-links
+  - jekyll-redirect-from
   - jekyll-seo-tag
   - jekyll-paginate
 

--- a/_data/navigation/docs.yml
+++ b/_data/navigation/docs.yml
@@ -9,6 +9,14 @@
       url: /docs/
     - title: Frontmatter Preview
       url: /docs/frontmatter-preview-solution/
+- title: Obsidian
+  url: /docs/obsidian/
+  icon: bi-diagram-3
+  children:
+    - title: Knowledge Graph
+      url: /docs/obsidian/
+    - title: Graph View
+      url: /docs/obsidian/graph/
 - title: Jekyll
   url: /docs/jekyll/
   icon: bi-gem

--- a/_data/navigation/main.yml
+++ b/_data/navigation/main.yml
@@ -36,6 +36,8 @@
       url: /docs/jekyll/
     - title: Terminal
       url: /docs/terminal/
+    - title: Obsidian Graph
+      url: /docs/obsidian/graph/
 - title: Notebook
   url: /notes/
   icon: bi-journal-code

--- a/pages/_docs/index.md
+++ b/pages/_docs/index.md
@@ -75,6 +75,14 @@ The IT-Journey platform is built with Jekyll, a static site generator. The Jekyl
 - [Mermaid Diagrams](jekyll/jekyll-diagram-with-mermaid.md) - Creating diagrams
 - [Math Symbols](jekyll/jekyll-math-symbols-with-mathjax.md) - Mathematical notation
 
+### Obsidian
+
+Obsidian-style links help connect notes, docs, quests, and posts into a lightweight learning graph powered by the `zer0-mistakes` theme.
+
+**Topics:**
+- [Obsidian Knowledge Graph](/docs/obsidian/) - How IT-Journey uses theme-owned wiki links and graph views
+- [Obsidian Graph View](/docs/obsidian/graph/) - Interactive map of linked content across the site
+
 ### Future Documentation Areas
 
 This library will expand to include reference documentation for:

--- a/pages/_docs/obsidian/graph.md
+++ b/pages/_docs/obsidian/graph.md
@@ -1,0 +1,97 @@
+---
+title: Obsidian Graph View
+permalink: /docs/obsidian/graph/
+description: Interactive graph of IT-Journey pages connected by Obsidian-style wiki links.
+excerpt: Explore the IT-Journey knowledge graph generated from wiki links across docs, notes, quests, and posts.
+categories:
+  - docs
+  - obsidian
+tags:
+  - obsidian
+  - graph
+  - navigation
+sidebar:
+  nav: docs
+toc_sticky: true
+backlinks: false
+local_graph: false
+sitemap: false
+lastmod: 2026-04-25T00:00:00.000Z
+---
+
+<style>
+  #obsidian-graph {
+    width: 100%;
+    height: 82vh;
+    min-height: 620px;
+    border: 1px solid var(--bs-border-color, #dee2e6);
+    border-radius: var(--bs-border-radius-lg, .5rem);
+    background: var(--bs-tertiary-bg, #f8f9fa);
+    position: relative;
+    overflow: hidden;
+  }
+  .obsidian-graph-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .5rem .75rem;
+    align-items: center;
+    margin: .75rem 0;
+    padding: .625rem .75rem;
+    background: var(--bs-tertiary-bg, #f8f9fa);
+    border: 1px solid var(--bs-border-color, #dee2e6);
+    border-radius: var(--bs-border-radius, .375rem);
+  }
+  .obsidian-graph-toolbar .form-control {
+    max-width: 280px;
+    flex: 1 1 200px;
+  }
+  #obsidian-graph-status {
+    flex-basis: 100%;
+    font-size: .8125rem;
+    color: var(--bs-secondary-color, #6c757d);
+    min-height: 1.25rem;
+  }
+</style>
+
+# Obsidian Graph View
+
+A live, force-directed map of IT-Journey pages connected by `[[wiki links]]`.
+The graph is generated from [`assets/data/wiki-index.json`]({{ "/assets/data/wiki-index.json" | relative_url }})
+and rendered by the `zer0-mistakes` theme's graph script.
+
+<div id="obsidian-graph-stats" class="mb-2" aria-live="polite"></div>
+
+<div class="obsidian-graph-toolbar">
+  <input type="search"
+         class="form-control form-control-sm"
+         id="obsidian-graph-search"
+         placeholder="Filter nodes by title..."
+         aria-label="Filter graph nodes by title" />
+  <button type="button"
+          class="btn btn-outline-secondary btn-sm"
+          id="obsidian-graph-fit">
+    <i class="bi bi-arrows-fullscreen" aria-hidden="true"></i>
+    Reset view
+  </button>
+  <div class="form-check form-switch">
+    <input class="form-check-input"
+           type="checkbox"
+           role="switch"
+           id="obsidian-graph-orphans" />
+    <label class="form-check-label" for="obsidian-graph-orphans">
+      Show orphans
+    </label>
+  </div>
+  <span id="obsidian-graph-status" role="status"></span>
+</div>
+
+<div id="obsidian-graph" role="img" aria-label="IT-Journey knowledge graph"></div>
+
+Use the search box to focus a topic, click a node to open its page, and use
+Ctrl/Cmd-click to open a node in a new tab.
+
+<script src="https://cdn.jsdelivr.net/npm/cytoscape@3.30.0/dist/cytoscape.min.js"
+        integrity="sha384-kpMsYllYzyaWU69Piok08rPNktpnjqAoDMdB00fjqUkEk3lkuUbSuwJ+oXrjvN6B"
+        crossorigin="anonymous"
+        defer></script>
+<script src="{{ '/assets/js/obsidian-graph.js' | relative_url }}" defer></script>

--- a/pages/_docs/obsidian/index.md
+++ b/pages/_docs/obsidian/index.md
@@ -1,0 +1,48 @@
+---
+title: Obsidian Knowledge Graph
+permalink: /docs/obsidian/
+description: Use Obsidian-style wiki links, backlinks, embeds, and graph views across IT-Journey content.
+excerpt: Lightweight guide to the Obsidian-style knowledge features provided by the zer0-mistakes theme.
+categories:
+  - docs
+  - obsidian
+tags:
+  - obsidian
+  - wiki-links
+  - knowledge-graph
+  - notes
+sidebar:
+  nav: docs
+toc_sticky: true
+lastmod: 2026-04-25T00:00:00.000Z
+---
+
+# Obsidian Knowledge Graph
+
+IT-Journey uses the `zer0-mistakes` theme for Obsidian-style knowledge features while keeping the implementation in the theme. This site only adds the pages, navigation, and content links needed to make those features discoverable.
+
+## What Is Enabled
+
+- `[[wiki links]]` resolve to matching pages, notes, docs, quests, and posts.
+- `![[embeds]]` can preview linked notes or note images.
+- `#tags` in content become tag links.
+- The site graph is generated from `assets/data/wiki-index.json`.
+
+## Start Here
+
+- [Open the Obsidian Graph View](/docs/obsidian/graph/)
+- [Browse all notes](/notes/)
+- [Browse documentation](/docs/)
+
+## Related Wiki Links
+
+- [[Learning Resources Library]]
+- [[Jekyll Documentation]]
+- [[Terminal and Bash Learning Path]]
+- [[Notes Index]]
+- [[Quick Start: Build a Jekyll Site from Scratch]]
+- [[Markdown Mastery: Content Formatting Fundamentals]]
+
+## Authoring Guidance
+
+Add wiki links where they help learners move between concepts naturally. Prefer stable page titles or `aliases:` in front matter for important concepts, and keep `.obsidian/` as editor metadata only.


### PR DESCRIPTION
## Summary
- Add a dedicated Obsidian docs section with a landing page and graph view page in `pages/_docs/obsidian/`
- Wire Obsidian entries into docs and main navigation so graph features are discoverable
- Update Jekyll config for Obsidian-related settings/plugins and remote-theme-first local development

## Test plan
- [ ] Run `bundle exec jekyll build`
- [ ] Verify `/docs/obsidian/` and `/docs/obsidian/graph/` load successfully
- [ ] Confirm docs and main navigation show new Obsidian links
- [ ] Confirm graph page loads Cytoscape and renders data from `assets/data/wiki-index.json`

Made with [Cursor](https://cursor.com)