### PR TITLE
Embed Bashcrawl web terminal + reframe quests as walkthrough/strategy guide

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,6 @@
 [submodule "submodules/jekyll"]
 	path = submodules/jekyll
 	url = https://github.com/jekyll/jekyll.git
+[submodule "submodules/bashcrawl"]
+	path = submodules/bashcrawl
+	url = https://github.com/bamr87/bashcrawl.git

--- a/_includes/bashcrawl-play-local.html
+++ b/_includes/bashcrawl-play-local.html
@@ -1,0 +1,66 @@
+{% comment %}
+  Bashcrawl — Install & Play Locally (Advanced Track)
+  ===================================================
+
+  The "advanced version" of the quest: install Bashcrawl and play it in a real
+  shell. Bashcrawl is vendored into this site as the `submodules/bashcrawl` git
+  submodule, so contributors who clone IT-Journey already have a copy.
+
+  Rendered as raw HTML (with a stable `id="play-locally"` anchor) so the
+  in-terminal "Install & Play Locally" link resolves regardless of how kramdown
+  slugifies headings. Usage: {% include bashcrawl-play-local.html %}
+{% endcomment %}
+
+<h2 id="play-locally">🖥️ Advanced: Install &amp; Play Locally</h2>
+
+<p>
+  The embedded terminal above is the fastest way to play — but the
+  <strong>advanced version</strong> runs Bashcrawl in a real shell on your own
+  machine, with the full Textual TUI, agent mode, and a genuine filesystem
+  sandbox. The walkthrough on this page works identically in either mode.
+</p>
+
+<h3>Option A — Clone the game</h3>
+
+<pre><code class="language-bash">git clone https://github.com/bamr87/bashcrawl.git
+cd bashcrawl
+./setup.sh        # one-time setup: dirs, permissions, help system
+./main.sh         # launch the adventure (interactive menu)
+</code></pre>
+
+<h3>Option B — It already ships with IT-Journey</h3>
+
+<p>
+  Bashcrawl lives in this repository as the <code>submodules/bashcrawl</code>
+  git submodule. If you cloned IT-Journey, pull it down and play in place:
+</p>
+
+<pre><code class="language-bash">git submodule update --init submodules/bashcrawl
+cd submodules/bashcrawl
+./setup.sh
+./main.sh --interactive
+</code></pre>
+
+<h3>Play modes</h3>
+
+<table>
+  <thead>
+    <tr><th>Command</th><th>Mode</th><th>Best for</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>./main.sh --interactive</code></td><td>Textual TUI (recommended)</td><td>A rich local interface — needs Python 3 + <code>textual</code></td></tr>
+    <tr><td><code>./main.sh --classic</code></td><td>Classic bash emulator</td><td>Systems without Python</td></tr>
+    <tr><td><code>./main.sh --native</code></td><td>Native terminal</td><td>The full real-filesystem experience</td></tr>
+    <tr><td><code>./main.sh --tutorial</code></td><td>Tutorial mode</td><td>Guided, step-by-step learning</td></tr>
+    <tr><td><code>./main.sh --agent</code></td><td>Agent mode</td><td>AI automation and screenshots</td></tr>
+    <tr><td><code>./main.sh --help</code></td><td>Help</td><td>All launcher options</td></tr>
+  </tbody>
+</table>
+
+<p>
+  Want to host the browser build yourself? From the game directory run
+  <code>make web-preview</code> and open
+  <a href="http://127.0.0.1:8000" target="_blank" rel="noopener noreferrer">http://127.0.0.1:8000</a>.
+  The same static build is what powers the embedded terminal above
+  (<a href="https://bamr87.github.io/bashcrawl/" target="_blank" rel="noopener noreferrer">bamr87.github.io/bashcrawl</a>).
+</p>

--- a/_includes/bashcrawl-terminal.html
+++ b/_includes/bashcrawl-terminal.html
@@ -1,0 +1,126 @@
+{% comment %}
+  Bashcrawl Web Terminal Embed
+  ============================
+
+  Embeds the live, browser-playable Bashcrawl terminal (the interactive web
+  TUI deployed from the bamr87/bashcrawl repository, which is vendored into
+  this site as the `submodules/bashcrawl` git submodule).
+
+  The game runs entirely client-side and starts in the Entrance chamber, so
+  each quest page passes a `room` label telling the player where to navigate
+  once the dungeon loads. The quest page itself is the walkthrough / strategy
+  guide for that chamber.
+
+  Usage:
+    {% include bashcrawl-terminal.html %}
+    {% include bashcrawl-terminal.html room="Cellar" %}
+    {% include bashcrawl-terminal.html room="The Rift" height="660" %}
+
+  Parameters (all optional):
+    room    - Display name of the chamber this page covers (used in the hint).
+    height  - Embedded terminal height in px (default 620).
+    url     - Override the terminal URL (default the live GitHub Pages build).
+{% endcomment %}
+
+{% assign bc_url = include.url | default: "https://bamr87.github.io/bashcrawl/" %}
+{% assign bc_height = include.height | default: 620 %}
+
+<div class="bashcrawl-embed">
+  <div class="bashcrawl-embed-bar">
+    <span class="bashcrawl-embed-dot" aria-hidden="true"></span>
+    <span class="bashcrawl-embed-dot" aria-hidden="true"></span>
+    <span class="bashcrawl-embed-dot" aria-hidden="true"></span>
+    <span class="bashcrawl-embed-label">🕹️ Bashcrawl — Web Terminal</span>
+    <a class="bashcrawl-embed-fullscreen" href="{{ bc_url }}" target="_blank" rel="noopener noreferrer">Open full screen ↗</a>
+  </div>
+  <iframe
+    class="bashcrawl-embed-frame"
+    src="{{ bc_url }}"
+    title="Bashcrawl interactive web terminal"
+    style="height: {{ bc_height }}px;"
+    loading="lazy"
+    referrerpolicy="no-referrer-when-downgrade"
+    allow="clipboard-write"></iframe>
+  <p class="bashcrawl-embed-note">
+    The game loads in the <strong>Entrance</strong>.
+    {% if include.room %}Use <code>cd</code> to make your way to the <strong>{{ include.room }}</strong> chamber, then follow the walkthrough below.{% else %}Type a command and press <kbd>Enter</kbd> to begin — follow the walkthrough below as your strategy guide.{% endif %}
+    Progress saves in your browser. Prefer a real shell? See
+    <a href="#play-locally">Install &amp; Play Locally</a>.
+  </p>
+</div>
+
+<style>
+.bashcrawl-embed {
+  border: 1px solid var(--border-color, #30363d);
+  border-radius: 10px;
+  overflow: hidden;
+  margin: 1.25rem 0 1.5rem;
+  background: var(--card-bg, #0d1117);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+}
+
+.bashcrawl-embed-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.85rem;
+  background: var(--code-bg, #161b22);
+  border-bottom: 1px solid var(--border-color, #30363d);
+  font-size: 0.85rem;
+}
+
+.bashcrawl-embed-dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: #ff5f56;
+  display: inline-block;
+}
+.bashcrawl-embed-dot:nth-child(2) { background: #ffbd2e; }
+.bashcrawl-embed-dot:nth-child(3) { background: #27c93f; }
+
+.bashcrawl-embed-label {
+  margin-left: 0.5rem;
+  font-weight: 600;
+  color: var(--heading-color, #c9d1d9);
+}
+
+.bashcrawl-embed-fullscreen {
+  margin-left: auto;
+  font-size: 0.8rem;
+  color: var(--link-color, #58a6ff);
+  text-decoration: none;
+  white-space: nowrap;
+}
+.bashcrawl-embed-fullscreen:hover { text-decoration: underline; }
+
+.bashcrawl-embed-frame {
+  width: 100%;
+  border: 0;
+  display: block;
+  background: #0d1117;
+}
+
+.bashcrawl-embed-note {
+  margin: 0;
+  padding: 0.6rem 0.85rem;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--text-muted, #8b949e);
+  background: var(--code-bg, #161b22);
+  border-top: 1px solid var(--border-color, #30363d);
+}
+
+.bashcrawl-embed-note code,
+.bashcrawl-embed-note kbd {
+  font-size: 0.8em;
+  padding: 0.05em 0.35em;
+  border-radius: 4px;
+  background: var(--border-color, #30363d);
+}
+
+@media (max-width: 600px) {
+  .bashcrawl-embed-frame { height: 480px !important; }
+  .bashcrawl-embed-fullscreen { display: none; }
+}
+</style>

--- a/pages/_quests/0000/bashcrawl/README.md
+++ b/pages/_quests/0000/bashcrawl/README.md
@@ -101,6 +101,14 @@ permalink: /quests/0000/bashcrawl/
 ---
 *Welcome to the Bashcrawl Catacombs — an interactive terminal dungeon where every command is a spell and every directory a new realm to explore. Nine interconnected chambers await, each a side-quest that teaches a core set of Bash skills through gameplay.*
 
+This hub is your **walkthrough and strategy guide** to the game. Play instantly in the browser below, use the nine chamber walkthroughs as your field manual, then graduate to the **advanced version** — [installing Bashcrawl](#play-locally) and playing it in a real shell.
+
+## 🕹️ Play in Your Browser
+
+The full game runs right here — no install required. Keep this guide open alongside it.
+
+{% include bashcrawl-terminal.html %}
+
 ## 🗺️ Catacombs Map
 
 ```mermaid
@@ -146,29 +154,7 @@ flowchart TD
 | 9 | 🌀 The Rift | 🔴 Hard | pipes `\|` `&&` redirection | [Rift](/quests/0000/side-quests/rift/) |
 | ★ | 🤖 Agent Mode | 🔴 Hard | `--agent` `--batch` `--screenshot-dir` | [Agent](/quests/0000/side-quests/agent-mode/) |
 
-## ⚡ Quick Start
-
-```bash
-# From this directory — choose your mode:
-./bash_crawl.sh            # Interactive menu
-./bash_crawl.sh online     # Open web browser version (no install)
-./bash_crawl.sh local      # Clone repo + launch Textual TUI
-./bash_crawl.sh classic    # Clone repo + classic Bash emulator
-./bash_crawl.sh tutorial   # Tutorial mode (step-by-step)
-./bash_crawl.sh agent      # Agent mode (AI playtesting)
-./bash_crawl.sh --quest entrance   # Print walkthrough URL then launch
-```
-
-## 🎮 Play Modes
-
-| Mode | How to Launch | Best For |
-|------|--------------|----------|
-| **Web TUI** | [bamr87.github.io/bashcrawl](https://bamr87.github.io/bashcrawl/) | First playthrough, classrooms, no-install |
-| **Textual TUI** | `./main.sh --interactive` | Beginners wanting a rich local interface |
-| **Classic Bash** | `./main.sh --classic` | Systems without Python/Textual |
-| **Native Terminal** | `./main.sh --native` | Full real-filesystem experience |
-| **Tutorial Mode** | `./main.sh --tutorial` | Guided step-by-step learning |
-| **Agent Mode** | `./main.sh --agent` | AI automation and screenshots |
+{% include bashcrawl-play-local.html %}
 
 ## 🧙 In-Game Commands
 

--- a/pages/_quests/0000/bashcrawl/agent-mode.md
+++ b/pages/_quests/0000/bashcrawl/agent-mode.md
@@ -65,6 +65,12 @@ layout: quest
 ---
 *You have conquered the Rift. But the dungeon holds one final secret — a mode where an AI plays alongside you, a mode where you automate the entire journey, a mode where you become the dungeon master. Welcome to Agent Mode.*
 
+## 🕹️ Try Bashcrawl in Your Browser
+
+This page is your **walkthrough and strategy guide**. Agent Mode itself runs locally (see [Install &amp; Play Locally](#play-locally)) — but you can explore the dungeon in the browser first.
+
+{% include bashcrawl-terminal.html %}
+
 ## 🎯 Quest Objectives
 
 - [ ] Launch Bashcrawl using `./main.sh --agent`
@@ -262,6 +268,8 @@ Complete all 10 side-quests and you have earned the right to call yourself a Bas
 - **Back to hub** → [Bashcrawl Hub](/quests/0000/bashcrawl/)
 
 ---
+
+{% include bashcrawl-play-local.html %}
 
 ## 📚 External Resources
 

--- a/pages/_quests/0000/bashcrawl/armoury.md
+++ b/pages/_quests/0000/bashcrawl/armoury.md
@@ -64,6 +64,12 @@ layout: quest
 ---
 *Racks of weapons line the walls. Suits of armour stand at attention. But every sword and potion is locked behind a permission barrier — you must learn `chmod` before you can equip a single item.*
 
+## 🕹️ Play This Chamber
+
+This page is your **walkthrough and strategy guide** — play right here in the browser, then follow the steps below.
+
+{% include bashcrawl-terminal.html room="Armoury" %}
+
 ## 🎯 Quest Objectives
 
 - [ ] Read `ls -l` output and interpret permission bits
@@ -194,6 +200,8 @@ With the sword equipped, you should win. Health permitting, the guardian falls a
 - **Back to hub** → [Bashcrawl Hub](/quests/0000/bashcrawl/)
 
 ---
+
+{% include bashcrawl-play-local.html %}
 
 ## 📚 External Resources
 

--- a/pages/_quests/0000/bashcrawl/cellar.md
+++ b/pages/_quests/0000/bashcrawl/cellar.md
@@ -70,6 +70,12 @@ layout: quest
 ---
 *The cellar reeks of wine and secrets. Barrels line the walls; cobwebs drape the ceiling. Four iron doors lead deeper into the dungeon — armoury, chapel, vault, scrap. But first you must find the emerald amulet.*
 
+## 🕹️ Play This Chamber
+
+This page is your **walkthrough and strategy guide** — play right here in the browser, then follow the steps below.
+
+{% include bashcrawl-terminal.html room="Cellar" %}
+
 ## 🎯 Quest Objectives
 
 - [ ] Identify every file type in the cellar using `ls -F`
@@ -203,6 +209,8 @@ Choose your next chamber — all four are unlocked:
 | 🗑️ Scrap Heap | Symbolic links, `ln -s` | [Scrap](/quests/0000/side-quests/scrap/) |
 
 ---
+
+{% include bashcrawl-play-local.html %}
 
 ## 📚 External Resources
 

--- a/pages/_quests/0000/bashcrawl/chamber.md
+++ b/pages/_quests/0000/bashcrawl/chamber.md
@@ -64,6 +64,12 @@ layout: quest
 ---
 *A massive stone statue dominates the Chamber, its eyes glowing with arithmetic runes. It will not yield to a sword. Only correct calculations can break the enchantment — and wrong answers deal damage.*
 
+## 🕹️ Play This Chamber
+
+This page is your **walkthrough and strategy guide** — play right here in the browser, then follow the steps below.
+
+{% include bashcrawl-terminal.html room="Chamber" %}
+
 ## 🎯 Quest Objectives
 
 - [ ] Compute values using `let`, `expr`, and `$(( ))`
@@ -187,6 +193,8 @@ Continue exploring:
 - **When all four branches complete** → [The Rift](/quests/0000/side-quests/rift/)
 
 ---
+
+{% include bashcrawl-play-local.html %}
 
 ## 📚 External Resources
 

--- a/pages/_quests/0000/bashcrawl/entrance.md
+++ b/pages/_quests/0000/bashcrawl/entrance.md
@@ -65,6 +65,12 @@ layout: quest
 ---
 *The dungeon gate groans open. Cool air pours out carrying the scent of ancient scrolls. This is where every hero begins — four commands, a brass key, and the courage to type.*
 
+## 🕹️ Play This Chamber
+
+This page is your **walkthrough and strategy guide** — play right here in the browser, then follow the steps below.
+
+{% include bashcrawl-terminal.html room="Entrance" %}
+
 ## 🎯 Quest Objectives
 
 - [ ] Print your current location with `pwd`
@@ -177,6 +183,8 @@ You are now ready to explore deeper. Choose your path:
 - **Back to hub** → [Bashcrawl Hub](/quests/0000/bashcrawl/)
 
 ---
+
+{% include bashcrawl-play-local.html %}
 
 ## 📚 External Resources
 

--- a/pages/_quests/0000/bashcrawl/hidden-chapel.md
+++ b/pages/_quests/0000/bashcrawl/hidden-chapel.md
@@ -65,6 +65,12 @@ layout: quest
 ---
 *The wine cellar wall flickers. A hidden door appears — but only `ls -a` can see it. Beyond the false stone lies a chapel with five secret areas, guarded by a monster who fears knowledge.*
 
+## 🕹️ Play This Chamber
+
+This page is your **walkthrough and strategy guide** — play right here in the browser, then follow the steps below.
+
+{% include bashcrawl-terminal.html room="Hidden Chapel" %}
+
 ## 🎯 Quest Objectives
 
 - [ ] Use `ls -a` to reveal the hidden `.CHAPEL` directory
@@ -223,6 +229,8 @@ The mausoleum is another hidden directory. Explore it for bonus lore and a secre
 - **Back to hub** → [Bashcrawl Hub](/quests/0000/bashcrawl/)
 
 ---
+
+{% include bashcrawl-play-local.html %}
 
 ## 📚 External Resources
 

--- a/pages/_quests/0000/bashcrawl/rift.md
+++ b/pages/_quests/0000/bashcrawl/rift.md
@@ -68,6 +68,12 @@ layout: quest
 ---
 *You stand at the edge of the Rift — a swirling chasm where data streams collide. The rules here are different: commands don't just run, they flow into each other. Master the pipe and you master the dungeon.*
 
+## 🕹️ Play This Chamber
+
+This page is your **walkthrough and strategy guide** — play right here in the browser, then follow the steps below.
+
+{% include bashcrawl-terminal.html room="The Rift" height="660" %}
+
 ## 🎯 Quest Objectives
 
 - [ ] Pipe command output to another command using `|`
@@ -225,6 +231,8 @@ The satellite boss is the final encounter. It uses all skills: pipe a command th
 - **Back to hub** → [Bashcrawl Hub](/quests/0000/bashcrawl/)
 
 ---
+
+{% include bashcrawl-play-local.html %}
 
 ## 📚 External Resources
 

--- a/pages/_quests/0000/bashcrawl/scrap.md
+++ b/pages/_quests/0000/bashcrawl/scrap.md
@@ -65,6 +65,12 @@ layout: quest
 ---
 *The Scrap Heap is a wasteland of discarded objects — broken swords, empty potion bottles, shattered mirrors. But hidden among the junk are portal mirrors, and learning `ln -s` lets you build instant teleportation.*
 
+## 🕹️ Play This Chamber
+
+This page is your **walkthrough and strategy guide** — play right here in the browser, then follow the steps below.
+
+{% include bashcrawl-terminal.html room="Scrap Heap" %}
+
 ## 🎯 Quest Objectives
 
 - [ ] Understand the difference between hard links and symbolic links
@@ -187,6 +193,8 @@ inventory
 - **Back to hub** → [Bashcrawl Hub](/quests/0000/bashcrawl/)
 
 ---
+
+{% include bashcrawl-play-local.html %}
 
 ## 📚 External Resources
 

--- a/pages/_quests/0000/bashcrawl/vault.md
+++ b/pages/_quests/0000/bashcrawl/vault.md
@@ -65,6 +65,12 @@ layout: quest
 ---
 *Behind a heavy iron door, the Vault holds the dungeon's most powerful secrets — not gold and jewels, but the invisible variables that shape every shell. Set them correctly, or the ghost devours you.*
 
+## 🕹️ Play This Chamber
+
+This page is your **walkthrough and strategy guide** — play right here in the browser, then follow the steps below.
+
+{% include bashcrawl-terminal.html room="Vault" %}
+
 ## 🎯 Quest Objectives
 
 - [ ] Set and read shell variables with `=` and `$VAR`
@@ -219,6 +225,8 @@ inventory
 - **Back to hub** → [Bashcrawl Hub](/quests/0000/bashcrawl/)
 
 ---
+
+{% include bashcrawl-play-local.html %}
 
 ## 📚 External Resources
 

--- a/pages/_quests/0000/bashcrawl/workshop.md
+++ b/pages/_quests/0000/bashcrawl/workshop.md
@@ -63,6 +63,12 @@ layout: quest
 ---
 *The Workshop smells of sawdust and old iron. Workbenches line the walls, covered in unfinished projects. Here, heroes learn the art of building — and destroying — the very fabric of the file system.*
 
+## 🕹️ Play This Chamber
+
+This page is your **walkthrough and strategy guide** — play right here in the browser, then follow the steps below.
+
+{% include bashcrawl-terminal.html room="Workshop" %}
+
 ## 🎯 Quest Objectives
 
 - [ ] Create a new room with `mkdir`
@@ -187,6 +193,8 @@ Before advancing:
 - **Back to hub** → [Bashcrawl Hub](/quests/0000/bashcrawl/)
 
 ---
+
+{% include bashcrawl-play-local.html %}
 
 ## 📚 External Resources
 


### PR DESCRIPTION
## Summary

Turns the **Level 0000 Bashcrawl quests** into the game's **walkthrough / strategy guide**: the playable web terminal is embedded at the top of each page, with an **advanced "install & play locally"** track below. Bashcrawl is now vendored as a git submodule.

## What changed

- **Submodule** — vendor `bamr87/bashcrawl` at `submodules/bashcrawl` (pinned on `main`), matching the existing `submodules/jekyll` convention. `submodules/` is already in Jekyll's `exclude:`, so it isn't served — it's the upstream source for the local-install track and provides version pinning/provenance.
- **`_includes/bashcrawl-terminal.html`** — themed, responsive, lazy-loaded iframe embed of the live web terminal (`bamr87.github.io/bashcrawl`). Params: `room`, `height`, `url`.
- **`_includes/bashcrawl-play-local.html`** — "Advanced: Install & Play Locally" section with a stable `id="play-locally"` anchor and **real** launcher commands (`./setup.sh`, `./main.sh --interactive|--classic|--native|--tutorial|--agent`, `make web-preview`); offers both a standalone-clone path and a "ships with IT-Journey via the submodule" path.
- **All 11 pages reframed** (hub `README.md` + 10 rooms): lead with the embedded terminal, end with the local-install track. Replaced the hub's fictional `./bash_crawl.sh …` Quick Start block (no such script exists upstream); kept the real `setup.sh`/`main.sh` maintenance commands.

## Why iframe the live site (not self-host from the submodule)

it-journey production is a **legacy GitHub Pages build** off the `gh-pages` mirror, where custom `_plugins/` don't run and `submodules/` is excluded — so reliably serving a vendored copy isn't feasible without a separate pipeline. The live site returns `200` with no `X-Frame-Options`/CSP, so it embeds cleanly.

## Verification

- `scripts/quest/validate-quest-network.py` still **PASSES** — 0 broken dependencies, no bashcrawl warnings (permalinks untouched).
- Both includes parse + render correctly (verified with the `liquid` gem); include-call syntax matches the repo's existing `{% include quest-card.html quest=quest %}` convention.
- Local-install commands cross-checked against `submodules/bashcrawl/{setup.sh,main.sh}`.
- Every one of the 11 pages has exactly one terminal include + one local include.

## CI / ops notes

- No workflow change needed: `actions/checkout` doesn't init submodules by default, but Jekyll excludes `submodules/`, so the build doesn't need them — same as the pre-existing `submodules/jekyll`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)