### PR TITLE
chore(deps): update bundled gems to latest (fix nokogiri/faraday Dependabot alerts)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,22 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.2.3.1)
+    activesupport (8.1.3)
       base64
-      benchmark (>= 0.3)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      json
       logger (>= 1.4.2)
-      minitest (>= 5.1, < 6)
+      minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     base64 (0.3.0)
-    benchmark (0.5.0)
     bigdecimal (4.1.2)
     coffee-script (2.4.1)
       coffee-script-source
@@ -25,7 +25,7 @@ GEM
     colorator (1.1.0)
     commonmarker (0.23.12)
     concurrent-ruby (1.3.6)
-    connection_pool (2.5.5)
+    connection_pool (3.0.2)
     csv (3.3.5)
     dnsruby (1.73.1)
       base64 (>= 0.2)
@@ -40,11 +40,11 @@ GEM
       logger
     eventmachine (1.2.7)
     execjs (2.10.1)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.4)
       net-http (~> 0.5)
     ffi (1.17.4-x86_64-linux-gnu)
     ffi (1.17.4-x86_64-linux-musl)
@@ -220,7 +220,7 @@ GEM
       gemoji (>= 3, < 5)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    json (2.19.5)
+    json (2.19.9)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -236,18 +236,21 @@ GEM
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    minitest (5.27.0)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    nokogiri (1.18.10-x86_64-linux-gnu)
+    nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.18.10-x86_64-linux-musl)
+    nokogiri (1.19.3-x86_64-linux-musl)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    prism (1.9.0)
     public_suffix (5.1.1)
     racc (1.8.1)
     rb-fsevent (0.11.2)


### PR DESCRIPTION
## Summary

Refreshes `Gemfile.lock` to the latest gem versions allowed by the **github-pages 232** dependency set, resolving **all 4 open Dependabot alerts**.

| Gem | Before | After | Alert |
|-----|--------|-------|-------|
| nokogiri | 1.18.10 | **1.19.3** | high + medium + medium |
| faraday | 2.14.1 | **2.14.2** | low |

Transitive refreshes: `activesupport 7.2.3.1 → 8.1.3`, `connection_pool`, `faraday-net_http`, `json`, `minitest`, `prism` (new); `benchmark` dropped.

## Invariants preserved

GitHub Pages-critical pins are **unchanged** — `github-pages 232`, `jekyll 3.10.0`, `kramdown 2.4.0`, `jekyll-include-cache 0.2.1`, `jekyll-theme-zer0 1.18.1`. `PLATFORMS` (`x86_64-linux`, `x86_64-linux-musl`) and `BUNDLED WITH 2.3.25` are preserved. (`github-pages 232` is already the latest release; it constrains nokogiri loosely at `>= 1.16.2, < 2.0`, so the patched versions fit without breaking GH Pages compatibility.)

## How it was produced & verified

Resolved on **Ruby 3.2** (matching `Dockerfile`'s `ruby:3.2.3`) inside a container via `bundle lock --update` — local macOS system Ruby is 2.6 and mis-resolves. Verified with:
- `bundle install` **(frozen)** → exit 0 — lockfile is internally consistent and installs on the CI/Docker platform.
- `bundle exec jekyll doctor --config _config.yml,_config_dev.yml,_config_ci.yml` → "Everything looks fine" (jekyll 3.10.0 + new gem set, incl. activesupport 8, load cleanly).

The `build-validation` CI workflow will run the full page render on this PR.

> Note: GitHub Pages' production build uses GitHub's own server-side gem environment and ignores this `Gemfile.lock`; this update is for local dev, the `build-validation` CI, and clearing the Dependabot alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)