### PR TITLE
feat(quest): unified Docker-based validation system + execute-the-snippets tier

### DIFF
--- a/.github/workflows/agentic-quest-review.yml
+++ b/.github/workflows/agentic-quest-review.yml
@@ -1,14 +1,18 @@
 name: 🤖 Agentic Quest Review
 
-# Tier-2 quest validation: drives Claude Code (OAuth) to play quests end-to-end
-# and score their content/commands. OPT-IN ONLY — it costs money and needs a
-# secret, so it never runs on ordinary PRs:
-#   • Manually via the Actions tab (workflow_dispatch), or
-#   • By adding the `agentic-review` label to a PR (validates that PR's changed quests).
+# Tier-2 quest validation: drives Claude Code (OAuth) to read/play quests and
+# score their content. Two modes, by trigger:
 #
-# Auth: set repository secret CLAUDE_CODE_OAUTH_TOKEN (from `claude setup-token`,
-# the OAuth/subscription path) — or fall back to ANTHROPIC_API_KEY. The runner is
-# ephemeral and disposable, so `execute` mode (real command execution) is safe here.
+#   • AUTO (advisory)  — on every PR that changes quests, Claude does a READ-ONLY
+#     `review` of the changed quests and posts findings as a sticky comment. It
+#     NEVER fails the PR (advisory) and is skipped (not failed) when no Claude
+#     secret is configured, so it's safe to leave always-on.
+#   • OPT-IN (execute) — add the `agentic-review` label to a PR, or run it
+#     manually, to let Claude actually RUN the quests' commands in the ephemeral
+#     runner sandbox. Can gate on a score threshold.
+#
+# Auth: repo secret CLAUDE_CODE_OAUTH_TOKEN (from `claude setup-token`) or
+# ANTHROPIC_API_KEY. The runner is disposable, so `execute` is safe here.
 
 on:
   workflow_dispatch:
@@ -25,7 +29,9 @@ on:
         description: 'Fail the job if any quest scores below this %% (0 = never fail)'
         default: '0'
   pull_request:
-    types: [labeled]
+    types: [opened, synchronize, reopened, labeled]
+    paths:
+      - 'pages/_quests/**/*.md'
 
 permissions:
   contents: read
@@ -38,10 +44,13 @@ jobs:
   agentic-review:
     name: Agentic Quest Review
     runs-on: ubuntu-latest
-    # Only run for manual dispatch, or when the specific label is applied.
+    # Run on manual dispatch, on quest-changing PR opens/updates (auto advisory
+    # review), and on `labeled` ONLY when the label is `agentic-review` — so a
+    # random label never triggers a paid run.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && github.event.label.name == 'agentic-review')
+      (github.event_name == 'pull_request' &&
+       (github.event.action != 'labeled' || github.event.label.name == 'agentic-review'))
     permissions:
       contents: read
       pull-requests: write
@@ -51,44 +60,76 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Verify Claude auth secret is present
+      # Decide mode + whether this run gates. Auto PR runs are advisory `review`;
+      # the `agentic-review` label or manual dispatch unlocks `execute`/gating.
+      - name: Determine run parameters
+        id: params
+        env:
+          EVENT: ${{ github.event_name }}
+          LABEL: ${{ github.event.label.name }}
+          INPUT_MODE: ${{ github.event.inputs.mode }}
+          INPUT_SAMPLE: ${{ github.event.inputs.sample }}
+          INPUT_THRESH: ${{ github.event.inputs.fail_threshold }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'agentic-review') }}
+        run: |
+          MODE=review; THRESH=0; SAMPLE="${INPUT_SAMPLE:-5}"; GATING=false
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            MODE="${INPUT_MODE:-execute}"; THRESH="${INPUT_THRESH:-0}"
+            [ "$THRESH" != "0" ] && GATING=true
+          elif [ "$HAS_LABEL" = "true" ] || [ "$LABEL" = "agentic-review" ]; then
+            MODE=execute   # opt-in deep run, still advisory unless dispatched with a threshold
+          fi
+          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+          echo "thresh=$THRESH" >> "$GITHUB_OUTPUT"
+          echo "sample=$SAMPLE" >> "$GITHUB_OUTPUT"
+          echo "gating=$GATING" >> "$GITHUB_OUTPUT"
+          echo "Mode=$MODE threshold=$THRESH sample=$SAMPLE gating=$GATING"
+
+      - name: Check for Claude credentials
+        id: auth
         env:
           OAUTH: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           APIKEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           if [ -z "$OAUTH" ] && [ -z "$APIKEY" ]; then
-            echo "::error::No Claude credentials. Set secret CLAUDE_CODE_OAUTH_TOKEN (preferred, from 'claude setup-token') or ANTHROPIC_API_KEY."
-            exit 1
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No Claude credentials (CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY) — agentic review skipped (advisory)."
+          else
+            echo "present=true" >> "$GITHUB_OUTPUT"
           fi
-          echo "Auth source: ${OAUTH:+CLAUDE_CODE_OAUTH_TOKEN}${OAUTH:+ }${APIKEY:+ANTHROPIC_API_KEY}"
 
       - name: Set up Python
+        if: steps.auth.outputs.present == 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
 
       - name: Install Python deps
+        if: steps.auth.outputs.present == 'true'
         run: pip install pyyaml
 
       - name: Set up Node
+        if: steps.auth.outputs.present == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
 
       - name: Install Claude Code CLI
+        if: steps.auth.outputs.present == 'true'
         run: |
           npm install -g @anthropic-ai/claude-code
           claude --version
 
       - name: Determine target quests
         id: targets
+        if: steps.auth.outputs.present == 'true'
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch --no-tags --depth=1 origin "$BASE_REF" || true
+            git fetch --no-tags --depth=50 origin "$BASE_REF" || true
             CHANGED=$(git diff --name-only "origin/$BASE_REF...HEAD" -- 'pages/_quests/**/*.md' \
-                      | grep -vE '/(README|index)\.md$' | head -n 8)
+                      | grep -vE '/(README|index|home)\.md$' | head -n 8)
             if [ -z "$CHANGED" ]; then
               echo "No changed quest files; nothing to review."
               echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -98,17 +139,20 @@ jobs:
           fi
 
       - name: Run agentic validation
-        if: steps.targets.outputs.skip != 'true'
+        id: run
+        if: steps.auth.outputs.present == 'true' && steps.targets.outputs.skip != 'true'
+        continue-on-error: ${{ steps.params.outputs.gating != 'true' }}
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          MODE: ${{ github.event.inputs.mode || 'execute' }}
-          SAMPLE: ${{ github.event.inputs.sample || '5' }}
-          THRESH: ${{ github.event.inputs.fail_threshold || '0' }}
+          MODE: ${{ steps.params.outputs.mode }}
+          SAMPLE: ${{ steps.params.outputs.sample }}
+          THRESH: ${{ steps.params.outputs.thresh }}
           FILES: ${{ steps.targets.outputs.files }}
         run: |
           set -o pipefail
-          ARGS="--mode $MODE --md review.md --report review.json --fail-threshold $THRESH -v"
+          # Bound runaway loops AND total spend on automatic runs.
+          ARGS="--mode $MODE --md review.md --report review.json --fail-threshold $THRESH --max-turns 30 --max-cost-usd 3.00 -v"
           if [ -n "$FILES" ]; then
             python3 test/quest-validator/agentic_validate.py $FILES $ARGS
           else
@@ -116,12 +160,12 @@ jobs:
           fi
 
       - name: Job summary
-        if: always() && steps.targets.outputs.skip != 'true'
+        if: always() && steps.auth.outputs.present == 'true' && steps.targets.outputs.skip != 'true'
         run: |
           if [ -f review.md ]; then cat review.md >> "$GITHUB_STEP_SUMMARY"; fi
 
       - name: Upload report
-        if: always() && steps.targets.outputs.skip != 'true'
+        if: always() && steps.auth.outputs.present == 'true' && steps.targets.outputs.skip != 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: agentic-quest-review
@@ -131,13 +175,17 @@ jobs:
           if-no-files-found: ignore
 
       - name: Comment on PR
-        if: github.event_name == 'pull_request' && steps.targets.outputs.skip != 'true' && always()
+        if: github.event_name == 'pull_request' && steps.auth.outputs.present == 'true' && steps.targets.outputs.skip != 'true' && always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
             if (!fs.existsSync('review.md')) return;
-            const body = "<!-- agentic-quest-review -->\n" + fs.readFileSync('review.md', 'utf8');
+            const mode = '${{ steps.params.outputs.mode }}';
+            const note = mode === 'review'
+              ? '\n\n> ℹ️ _Advisory read-only review — does not block this PR. Add the `agentic-review` label for a sandboxed `execute` run._'
+              : '';
+            const body = "<!-- agentic-quest-review -->\n" + fs.readFileSync('review.md', 'utf8') + note;
             const { owner, repo } = context.repo;
             const issue_number = context.payload.pull_request.number;
             const comments = await github.rest.issues.listComments({ owner, repo, issue_number });

--- a/.github/workflows/quest-validation.yml
+++ b/.github/workflows/quest-validation.yml
@@ -295,133 +295,48 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: '3.12'
-
-      - name: Install dependencies
-        run: pip install pyyaml
-
-      - name: Run full quest validation
+      # Heavy/scheduled audit runs in the SAME Docker image developers use
+      # locally (`make docker-validate`) so CI and local are one code path. The
+      # unified orchestrator gates content (≥70%), network integrity, AND data
+      # freshness (regenerate + diff) in a single command + report.
+      - name: Run unified quest audit (Docker)
+        id: audit
         env:
           EXCLUDE_DRAFTS: ${{ github.event.inputs.exclude_drafts }}
           FAIL_THRESHOLD: ${{ github.event.inputs.fail_threshold }}
         run: |
-          EXTRA_ARGS=""
+          EXTRA="--json quest-audit-report.json"
+          [ "$EXCLUDE_DRAFTS" = "true" ] && EXTRA="$EXTRA --exclude-drafts"
+          THRESHOLD="${FAIL_THRESHOLD:-70}"
+          EXTRA="$EXTRA --fail-threshold $THRESHOLD"
+          echo "Running: quest_audit.py $EXTRA"
+          set +e
+          docker compose run --rm quest-audit audit $EXTRA | tee /tmp/audit.txt
+          echo "rc=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+          set -e
 
-          if [ "$EXCLUDE_DRAFTS" = "true" ]; then
-            EXTRA_ARGS="$EXTRA_ARGS --exclude-drafts"
-          fi
-
-          # Default threshold = 70 (blocking). Explicit "0" disables it.
-          THRESHOLD="$FAIL_THRESHOLD"
-          if [ -z "$THRESHOLD" ]; then
-            THRESHOLD="70"
-          fi
-          if [ "$THRESHOLD" != "0" ]; then
-            EXTRA_ARGS="$EXTRA_ARGS --fail-threshold $THRESHOLD"
-          fi
-
-          python3 test/quest-validator/quest_validator.py \
-            -d pages/_quests/ \
-            --summary \
-            --report test/quest-validator/full-audit-report.json \
-            $EXTRA_ARGS
-
-          echo ""
-          echo "============================================"
-          echo "Report saved to test/quest-validator/full-audit-report.json"
-          echo "============================================"
-
-      - name: Run quest network validation
+      - name: Audit summary
+        if: always()
         run: |
-          python3 scripts/quest/validate-quest-network.py \
-            --json test/quest-validator/network-report.json
+          {
+            echo "## 🎯 Quest Audit (unified, Docker)"
+            echo ""
+            echo '```'
+            sed 's/\x1b\[[0-9;]*m//g' /tmp/audit.txt 2>/dev/null || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload network report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: quest-network-report-${{ github.run_number }}
-          path: test/quest-validator/network-report.json
-          retention-days: 90
-
-      - name: Upload audit report
+      - name: Upload consolidated report
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: quest-audit-report-${{ github.run_number }}
-          path: test/quest-validator/full-audit-report.json
+          path: quest-audit-report.json
+          if-no-files-found: ignore
           retention-days: 90
 
-      - name: Generate audit summary
+      - name: Fail if the audit did not pass
+        if: steps.audit.outputs.rc != '0'
         run: |
-          python3 -c "
-          import json
-          with open('test/quest-validator/full-audit-report.json') as f:
-              data = json.load(f)
-
-          print('## Quest Audit Summary')
-          print(f\"- **Total quests**: {data['total']}\")
-          print(f\"- **Complete**: {data['complete']}\")
-          print(f\"- **Placeholders**: {data['placeholders']}\")
-          print(f\"- **Passed**: {data['passed']}\")
-          print(f\"- **Failed**: {data['failed']}\")
-          print(f\"- **Average score**: {data['average_score']:.1f}%\")
-          print()
-          print('### Score Distribution')
-          for bucket, count in data.get('score_distribution', {}).items():
-              bar = '█' * count
-              print(f\"  {bucket:>7}: {count:3d} {bar}\")
-          print()
-          print('### Per-Level Breakdown')
-          print(f\"{'Level':<8} {'Total':>5} {'Pass':>5} {'Fail':>5} {'Avg%':>6} {'Placeholders':>12}\")
-          print('-' * 46)
-          for level, stats in sorted(data.get('level_stats', {}).items()):
-              avg = stats.get('avg_score', 0)
-              print(f\"{level:<8} {stats['total']:>5} {stats['passed']:>5} {stats['failed']:>5} {avg:>5.1f}% {stats['placeholders']:>12}\")
-          " >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Regenerate all registry-derived data
-        id: regen_network
-        run: |
-          # All four artifacts derive from scripts/quest/quest_registry.py + the
-          # quest files; regenerating proves nothing has drifted.
-          python3 scripts/quest/generate-quest-levels-data.py
-          python3 scripts/quest/generate-quest-navigation.py
-          python3 scripts/quest/build-quest-network.py \
-            --quest-dir pages/_quests \
-            --json assets/data/quest-network.json \
-            --yaml _data/quests/network.yml
-          echo "regenerated=true" >> "$GITHUB_OUTPUT"
-
-      - name: Check for stale generated data
-        run: |
-          STALE_FILES="assets/data/quest-network.json _data/quests/network.yml _data/quests/levels.yml _data/quests/tiers.yml _data/quests/order.yml _data/navigation/quests.yml"
-          if git diff --quiet $STALE_FILES 2>/dev/null; then
-            echo "✅ Generated quest data (network, levels, tiers, order, navigation) is up to date." >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "::error::Generated quest data is stale. Regenerate from the registry and commit."
-            {
-              echo ""
-              echo "## ❌ Stale Generated Quest Data"
-              echo ""
-              echo "Committed quest data (network / levels / tiers / order / navigation) does not match the registry + quest files."
-              echo ""
-              echo "To fix, run:"
-              echo "\`\`\`bash"
-              echo "make quest-data"
-              echo "git add _data/quests assets/data/quest-network.json _data/navigation/quests.yml"
-              echo "git commit -m 'chore(quests): regenerate quest data'"
-              echo "\`\`\`"
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
-
-      - name: Upload regenerated network JSON
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: quest-network-${{ github.run_number }}
-          path: |
-            assets/data/quest-network.json
-            _data/quests/network.yml
-          retention-days: 30
+          echo "::error::Unified quest audit failed (content gate, network integrity, or stale generated data). See the job summary; fix and, for stale data, run 'make quest-data' and commit."
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ Observed from Makefile, scripts, Gemfile, and workflows:
  - Test validator: `./test/quest-validator/test-validator.sh`
  - Migrate quest permalinks (dry run): `python3 scripts/quest/migrate-permalinks.py --dry-run`
  - Migrate quest permalinks (apply): `python3 scripts/quest/migrate-permalinks.py`
- - **Full quest audit before PR**: `make quest-audit` (runs build-quest-network → quest_validator → validate-quest-network). For CI parity (orphan warnings escalate to errors), use `make quest-audit-strict`. CI blocks merges on validator errors and any score below 70%.
+ - **Full quest audit before PR**: `make quest-audit` — the unified validator `scripts/quest/quest_audit.py`: tier-1 content scoring + dependency-network integrity + generated-data freshness, in one consolidated report and exit code. Run the identical audit in Docker (CI-parity, no host Python) with `make docker-validate`. If the freshness layer flags stale data, run `make quest-data` and commit. Use `make quest-audit-strict` to escalate warnings to errors. CI blocks merges on validator errors and any score below 70%.
  - Regenerate sidebar nav: `make quest-nav` (rewrites `_data/navigation/quests.yml` from the quest collection).
  - Regenerate level metadata: `make quest-levels-data` (writes `_data/quests/levels.yml` from `scripts/quest/quest_registry.py`).
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@
 .PHONY: help stats stats-update stats-show stats-clean stats-config test \
         serve build build-prod build-ci clean \
         quest-validate quest-network quest-network-strict quest-build-network \
-        quest-audit quest-audit-strict quest-levels-data quest-nav quest-data quest-normalize \
+        quest-audit quest-audit-strict quest-audit-report quest-levels-data quest-nav quest-data quest-normalize \
+        docker-validate docker-validate-strict docker-build-ci docker-audit-tier2 \
+        quest-execute quest-execute-host \
         content-validate content-normalize content-normalize-apply content-audit \
         cms-index cms-analyze cms-plan cms-status cms-all
 
@@ -39,8 +41,17 @@ help:
 	@echo "  make quest-build-network    - Rebuild quest-network.json / network.yml"
 	@echo "  make quest-levels-data      - Emit _data/quests/levels.yml from registry"
 	@echo "  make quest-nav              - Regenerate _data/navigation/quests.yml from collection"
-	@echo "  make quest-audit            - Full quest audit (validate + network + build)"
-	@echo "  make quest-audit-strict     - Full audit + strict network (matches CI behaviour)"
+	@echo "  make quest-audit            - Unified audit: content + network + data freshness (one report)"
+	@echo "  make quest-audit-strict     - Unified audit with warnings escalated to failures"
+	@echo "  make quest-audit-report     - Unified audit + JSON report (quest-audit-report.json)"
+	@echo ""
+	@echo "🐳 Dockerized Validation (CI-parity, no host Ruby/Python)"
+	@echo "  make docker-validate        - Run the unified quest audit in Docker (python:3.12-slim)"
+	@echo "  make docker-validate-strict - Dockerized audit with warnings as failures"
+	@echo "  make docker-build-ci        - CI-parity Jekyll build in Docker (ruby:3.2.3 + github-pages)"
+	@echo "  make docker-audit-tier2     - Dockerized audit + Claude tier-2 (needs CLAUDE_CODE_OAUTH_TOKEN)"
+	@echo "  make quest-execute QUEST=<path> - Claude RUNS a quest's code snippets, isolated in Docker"
+	@echo "  make quest-execute SAMPLE=N     - same, across a spread of N quests"
 	@echo ""
 	@echo "📝 Content Tooling"
 	@echo "  make content-validate          - Frontmatter validator across pages/"
@@ -198,11 +209,57 @@ quest-normalize:
 quest-data: quest-levels-data quest-nav quest-build-network
 	@echo "✅ All registry-derived quest data regenerated (levels, tiers, order, navigation, network)."
 
-quest-audit: quest-build-network quest-validate quest-network
-	@echo "✅ Quest audit complete — content, dependencies, and network artifacts validated."
+quest-audit:
+	@echo "🎯 Unified quest audit (content + network + data freshness)..."
+	@python3 scripts/quest/quest_audit.py $(EXTRA)
 
-quest-audit-strict: quest-build-network quest-validate quest-network-strict
-	@echo "✅ Strict quest audit complete (orphan warnings escalated)."
+quest-audit-strict:
+	@echo "🎯 Strict quest audit (warnings escalated to failures)..."
+	@python3 scripts/quest/quest_audit.py --strict $(EXTRA)
+
+# Run the audit the way CI / the daily loop should: deterministic layers only,
+# JSON report written for tooling to pick up.
+quest-audit-report:
+	@python3 scripts/quest/quest_audit.py --json quest-audit-report.json $(EXTRA)
+
+# ── Dockerized validation (CI-parity, no host Ruby/Python needed) ───────────
+# docker-validate : full deterministic audit in python:3.12-slim (fast).
+# docker-build-ci : real Jekyll build in the ruby:3.2.3 + github-pages image.
+# docker-audit-tier2 : audit + Claude review (needs CLAUDE_CODE_OAUTH_TOKEN).
+# Override args with EXTRA=..., e.g.  make docker-validate EXTRA=--strict
+docker-validate:
+	@echo "🐳 Quest audit in Docker (python:3.12-slim)..."
+	@docker compose run --rm quest-audit audit $(EXTRA)
+
+docker-validate-strict:
+	@docker compose run --rm quest-audit strict $(EXTRA)
+
+docker-build-ci:
+	@echo "🐳 CI-parity Jekyll build in Docker (ruby:3.2.3 + github-pages)..."
+	@docker compose run --rm quest-build
+
+docker-audit-tier2:
+	@echo "🐳 Quest audit + Claude tier-2 in Docker (needs CLAUDE_CODE_OAUTH_TOKEN)..."
+	@docker compose run --rm -e CLAUDE_CODE_OAUTH_TOKEN -e ANTHROPIC_API_KEY \
+		quest-audit tier2 $(MODE) $(EXTRA)
+
+# ── Execute a quest's code snippets with a Claude agent (isolated) ──────────
+# A Claude Code agent walks a quest and ACTUALLY RUNS its runnable code snippets
+# in a disposable Docker container (real isolation), reporting which work.
+#   make quest-execute QUEST=pages/_quests/0001/terminal-mastery.md
+#   make quest-execute SAMPLE=3            # a spread of quests across levels
+#   make quest-execute-host QUEST=...      # run on the HOST (no container) — riskier
+# Needs CLAUDE_CODE_OAUTH_TOKEN (or ANTHROPIC_API_KEY); without it, runs --mock.
+quest-execute:
+	@echo "🤖🐳 Claude executing quest code snippets in an isolated container..."
+	@if [ -n "$(QUEST)" ]; then TARGET="--changed $(QUEST)"; else TARGET="--tier2-sample $(SAMPLE)"; fi; \
+	docker compose run --rm -e CLAUDE_CODE_OAUTH_TOKEN -e ANTHROPIC_API_KEY \
+		quest-audit execute $$TARGET $(EXTRA)
+
+quest-execute-host:
+	@echo "🤖 Claude executing quest snippets on the HOST sandbox (prefer 'make quest-execute' for isolation)..."
+	@if [ -n "$(QUEST)" ]; then TARGET="$(QUEST)"; else TARGET="-d pages/_quests --sample $(SAMPLE)"; fi; \
+	python3 test/quest-validator/agentic_validate.py $$TARGET --mode execute --max-turns 40 --summary $(EXTRA)
 
 # Agentic validation (tier 2): drive Claude Code (OAuth) to play quests end-to-end.
 # SAMPLE / MODE / EXTRA are overridable, e.g.  make quest-validate-agentic SAMPLE=5 MODE=execute

--- a/_data/navigation/quests.yml
+++ b/_data/navigation/quests.yml
@@ -12,11 +12,11 @@
   icon: bi-emoji-sunglasses
   url: /quests/0000/
   children:
-  - title: Begin your IT Journey
+  - title: 'Begin Your IT Journey: Survey the Realm'
     url: /quests/0000/begin-your-it-journey/
-  - title: 'Character Building: Forge Your IT Identity and Development Environment'
+  - title: 'Character Building: Forge Your IT Hero Identity'
     url: /quests/0000/character-building/
-  - title: Character Selection
+  - title: 'Character Selection: Choose Your IT Class'
     url: /quests/0000/character-selection/
   - title: 'Git Basics: Version Control Introduction'
     url: /quests/0000/git-basics/
@@ -28,17 +28,17 @@
     url: /quests/0000/hello-noob/
   - title: 'Hello Windows: Mastering the Windows Development Environment'
     url: /quests/0000/hello-windows/
-  - title: IT Fundamentals
+  - title: 'IT Fundamentals: Your Digital Awakening Quest'
     url: /quests/0000/it-fundamentals/
-  - title: Linux Fundamentals
+  - title: 'Linux Fundamentals: Enter the Penguin''s Domain'
     url: /quests/0000/linux-fundamentals/
   - title: 'Markdown Mastery: Content Formatting Fundamentals'
     url: /quests/0000/markdown-mastery/
-  - title: OS Selection
+  - title: 'OS Selection: Choose Your Realm of Power'
     url: /quests/0000/os-selection/
   - title: 'Terminal Fundamentals: Command Line Navigation Quest'
     url: /quests/0000/terminal-fundamentals/
-  - title: 'VS Code Mastery Quest: Forge Your Ultimate Development Weapon'
+  - title: 'VS Code Mastery: Forge Your Ultimate Dev Weapon'
     url: /quests/0000/vscode-mastery/
   - title: '⚔️ Bashcrawl Agent Mode: AI Automation and Contribution'
     url: /quests/0000/agent-mode/
@@ -62,7 +62,7 @@
     url: /quests/0000/vault/
   - title: '⚔️ Bashcrawl Workshop: File Management Fundamentals'
     url: /quests/0000/workshop/
-  - title: '⚔️ Glossary '
+  - title: '⚔️ Codex Glossary: Fantasy Terms to IT Reality'
     url: /quests/codex/glossary/
 - title: Level 0001 - Web Fundamentals
   icon: bi-feather
@@ -74,7 +74,7 @@
     url: /quests/0001/analytics-integration/
   - title: 'Bootstrap Framework: Build Responsive Sites Fast'
     url: /quests/0001/bootstrap-framework/
-  - title: 'Building & Testing the Git Init Script: Headless, Interactive, Scaffolding'
+  - title: Building & Testing the Git Init Shell Script
     url: /quests/0001/git-init-testing/
   - title: 'CSS Styling Basics: Selectors, the Box Model & Layout'
     url: /quests/0001/css-styling-basics/
@@ -92,13 +92,13 @@
     url: /quests/0001/jekyll-fundamentals/
   - title: 'Jekyll Plugins: Extend Your Static Site Safely'
     url: /quests/0001/jekyll-plugins/
-  - title: 'Kaizen Quest: The Path of Continuous Improvement in Software Alchemy'
+  - title: 'Kaizen Quest: Continuous Improvement Alchemy'
     url: /quests/0001/kaizen-continuous-improvement/
   - title: 'Liquid Templating: Dynamic Content for Jekyll Sites'
     url: /quests/0001/liquid-templating/
   - title: 'SEO Optimization: Meta Tags, Sitemaps & Structured Data'
     url: /quests/0001/seo-optimization/
-  - title: 'Stack Attack: Building an Enterprise Django + React ERP with AI Agents'
+  - title: 'Stack Attack: AI-Built Django + React Enterprise ERP'
     url: /quests/0001/stack-attack/
   - title: 'Terminal Mastery: Conquering the Command-Line Realm'
     url: /quests/0001/terminal-mastery/
@@ -112,7 +112,7 @@
     url: /quests/0001/avatar-forge/
   - title: '⚔️ Badge Collector: Showcasing Your Achievements'
     url: /quests/0001/badge-collector/
-  - title: ⚔️ Personal Site
+  - title: ⚔️ Build a Personal Website with GitHub Pages
     url: /quests/0001/personal-site/
   - title: '⚔️ Stack Attack Analysis: IT-Journey'
     url: /quests/0001/it-journey-stack-analysis/
@@ -122,28 +122,27 @@
   icon: bi-terminal
   url: /quests/0010/
   children:
-  - title: Change Logs
-    url: /quests/0010/change-logs/
-  - title: Commitments to clean commits
+  - title: 'Bash Incantations: Level 0010 Scripting Quest'
+    url: /quests/0010/bash-scripting/
+  - title: 'Commit Hygiene: Crafting Clean, Atomic Commits'
     url: /quests/0010/commitments-to-clean-commits/
+  - title: Conjure a Django Project into a GitHub Vault
+    url: /quests/0010/django-and-git/
   - title: 'Forging the Prompt Crystal: Master AI Communication'
     url: /quests/0010/prompt-engineering-mastery/
+  - title: 'Level 0010: Changelogs & the Chronicles of Code'
+    url: /quests/0010/change-logs/
   - title: Mastering Branches and Pull Requests for Developers
     url: /quests/0010/branches-and-pull-requests/
-  - title: 'Mastering the Bash Incantations: Binary Level 0010 (2) Command Line Sorcery
-      Quest'
-    url: /quests/0010/bash-scripting/
-  - title: planting seeds
+  - title: 'Planting Seeds: Set Up Your Dev Toolkit'
     url: /quests/0010/planting-seeds/
   - title: 'Recursive Realms: Testing Infinite Loops with AI'
     url: /quests/0010/recursive-realms-testing/
   - title: Revolutionizing Work with AI Automation
     url: /quests/0010/revolutionizing-work-with-ai-automation/
-  - title: Setting up Django and Git
-    url: /quests/0010/django-and-git/
   - title: 'Terminal Enchantment: Oh-My-Zsh Mastery'
     url: /quests/0010/oh-my-zsh-mastery/
-  - title: 'The Diagrammatic Enchantment: Jekyll-Mermaid Integration Quest'
+  - title: 'The Diagrammatic Enchantment: Jekyll-Mermaid Integration'
     url: /quests/0010/jekyll-mermaid-integration/
   - title: Understanding Action Triggers in Depth
     url: /quests/0010/action-triggers/
@@ -163,18 +162,17 @@
   children:
   - title: 'Forging the Prompt Crystal: VS Code Copilot Mastery Quest'
     url: /quests/0011/prompt-crystal-vscode-copilot/
-  - title: 'The Epic Quest for the Hidden Gem: Unleashing GitHub Pages to Capture
-      and Conquer AI Realms'
+  - title: 'Hidden Gem Quest: Publish AI Chats on GitHub Pages'
     url: /quests/0011/github-pages-hidden-gem/
-  - title: 'The PRD Codex: Mastering the Art of Product Reality Distillation'
+  - title: 'The PRD Codex: Master Product Reality Distillation'
     url: /quests/0011/prd-codex-mastery/
 - title: Level 0100 - Frontend & Containers
   icon: bi-box-seam
   url: /quests/0100/
   children:
-  - title: 'Docker Compose Orchestration: Build Multi-Container Applications'
+  - title: 'Docker Compose Orchestration: Multi-Container Apps'
     url: /quests/0100/docker-compose-orchestration/
-  - title: 'Docker Container Fundamentals: Master Isolation & Portability for DevOps'
+  - title: 'Docker Container Fundamentals: Images to Registries'
     url: /quests/0100/container-fundamentals/
   - title: Dockering Jekyll with Bootstrap 5
     url: /quests/0100/frontend-docker/
@@ -190,25 +188,25 @@
   icon: bi-rocket-takeoff
   url: /quests/0101/
   children:
-  - title: 'Artifact Management: Build Output Storage and Dependency Caching'
+  - title: 'Artifact Management: Versioned, Signed Build Output'
     url: /quests/0101/artifact-management/
-  - title: 'CI/CD Fundamentals: Continuous Integration and Continuous Deployment Essentials'
+  - title: 'CI/CD Fundamentals: The Build-Test-Deploy Pipeline'
     url: /quests/0101/cicd-fundamentals/
-  - title: 'Deployment Pipelines: Production Release Automation Strategies'
+  - title: 'Deployment Pipelines: Production Release Automation'
     url: /quests/0101/deployment-pipelines/
   - title: 'Docker Containerization Mastery: Level 0101 (5) Quest'
     url: /quests/0101/docker-mastery/
-  - title: 'Environment Management: Dev, Staging, and Production Configuration'
+  - title: 'Environment Management: Dev, Staging, and Prod Parity'
     url: /quests/0101/environment-management/
   - title: 'Forging the La(zy)TeX CV: Binary Level 0101 (5) Quest'
     url: /quests/0101/latex-cv-forging/
   - title: 'GitHub Actions Basics: Workflow Automation for Modern DevOps'
     url: /quests/0101/github-actions-basics/
-  - title: 'Secrets Management: Secure Configuration and Credential Handling'
+  - title: 'Secrets Management: Secure CI Credentials'
     url: /quests/0101/secrets-management/
-  - title: 'Testing Integration: Automated Quality Assurance in CI/CD Pipelines'
+  - title: 'Testing Integration: Tiered CI/CD Test Gates'
     url: /quests/0101/testing-integration/
-  - title: 'Workflow Optimization: Caching Strategies and Pipeline Parallelization'
+  - title: 'Workflow Optimization: Caching and Parallel CI/CD'
     url: /quests/0101/workflow-optimization/
   - title: '⚔️ Jekyll Quest Tracking: Building Dynamic Collection Layouts'
     url: /quests/0101/jekyll-quest-tracking/
@@ -216,7 +214,7 @@
   icon: bi-database
   url: /quests/0110/
   children:
-  - title: 'Backup and Recovery: Data Protection Strategies for Databases'
+  - title: 'Backup and Recovery: Data Protection for Databases'
     url: /quests/0110/backup-recovery/
   - title: 'Connection Pooling: Efficient Database Resource Management'
     url: /quests/0110/connection-pooling/
@@ -228,9 +226,9 @@
     url: /quests/0110/database-migrations/
   - title: 'Database Security: Access Control and Data Encryption'
     url: /quests/0110/database-security/
-  - title: 'Query Optimization: Performance Tuning for Fast Database Queries'
+  - title: 'Query Optimization: Tuning Fast Database Queries'
     url: /quests/0110/query-optimization/
-  - title: 'SQL Mastery: Query Language Proficiency for Data Professionals'
+  - title: 'SQL Mastery: Query Language Proficiency'
     url: /quests/0110/sql-mastery/
 - title: Level 0111 - API Development
   icon: bi-cloud-arrow-up
@@ -258,7 +256,7 @@
   icon: bi-cloud
   url: /quests/1000/
   children:
-  - title: 'AWS Essentials: Core Services and Cloud Architecture Patterns'
+  - title: 'AWS Essentials: Core Services and Architecture'
     url: /quests/1000/aws-essentials/
   - title: 'Azure Ascension: Deploying Jekyll to the Cloud Kingdom'
     url: /quests/1000/azure-ascension-jekyll-deployment/
@@ -268,7 +266,7 @@
     url: /quests/1000/agentic-tool-selection-and-permissions/
   - title: 'Infrastructure as Code: Terraform Fundamentals and State'
     url: /quests/1000/infrastructure-as-code/
-  - title: 'The All-Seeing Eye: Observability & Control for Autonomous Agents'
+  - title: 'The All-Seeing Eye: Observability for AI Agents'
     url: /quests/1000/agentic-observability-and-control/
   - title: 'The MCP Conclave: Mastering Model Context Protocol Servers'
     url: /quests/1000/agentic-mcp-server-mastery/
@@ -278,13 +276,13 @@
   children:
   - title: 'Bind the Agent to the Realm: Dev Environment Integration'
     url: /quests/1001/agentic-dev-environment-integration/
-  - title: 'Kubernetes ConfigMaps and Secrets: Configuration Management Best Practices'
+  - title: 'Kubernetes ConfigMaps and Secrets: The Vault'
     url: /quests/1001/k8s-config-secrets/
   - title: 'Kubernetes Fundamentals: Container Orchestration Essentials'
     url: /quests/1001/kubernetes-fundamentals/
   - title: 'Kubernetes Pods and Workloads: Deployments and StatefulSets'
     url: /quests/1001/k8s-pods-workloads/
-  - title: 'Kubernetes Services and Networking: Ingress and DNS Configuration'
+  - title: 'Kubernetes Services and Networking: Ingress and DNS'
     url: /quests/1001/k8s-services-networking/
   - title: 'The Shield of Retries: Safe Execution and Error Handling'
     url: /quests/1001/agentic-safe-execution-and-error-handling/
@@ -296,23 +294,29 @@
   children:
   - title: 'Alerting Systems: Alertmanager, Routing, On-Call & Runbooks'
     url: /quests/1010/alerting-systems/
-  - title: 'Anchoring the Drifting Agent: State Persistence and Drift Prevention'
+  - title: 'Anchoring the Drifting Agent: Stop Context Drift'
     url: /quests/1010/agentic-state-persistence-and-drift/
+  - title: Automate a Weekly Traffic Report
+    url: /quests/1010/automate-traffic-report/
+  - title: Connect Google Analytics to Your AI Agent via MCP
+    url: /quests/1010/analytics-mcp-setup/
   - title: 'Crossing the Tool Planes: State Continuity Across Tools'
     url: /quests/1010/agentic-state-continuity-cross-tools/
-  - title: 'Distributed Tracing: Jaeger & OpenTelemetry Implementation Guide'
+  - title: Distributed Tracing with Jaeger & OpenTelemetry
     url: /quests/1010/distributed-tracing/
-  - title: 'ELK Stack Tutorial: Elasticsearch, Logstash & Kibana for Log Analysis'
+  - title: 'ELK Stack: Elasticsearch, Logstash & Kibana Logs'
     url: /quests/1010/elk-stack/
   - title: 'Link to the Future: Automated Hyperlink Guardian Quest'
     url: /quests/1010/automated-hyperlink-guardian/
-  - title: 'Monitoring Fundamentals: Metrics, Logs, and Traces for Observability'
+  - title: 'Monitoring Fundamentals: Metrics, Logs, and Traces'
     url: /quests/1010/monitoring-fundamentals/
   - title: 'Prometheus & Grafana: Metrics Collection and Visualization'
     url: /quests/1010/prometheus-grafana/
+  - title: Query Your Traffic with the GA MCP Tools
+    url: /quests/1010/query-traffic-with-mcp/
   - title: 'The Necromancer''s Inquest: Agent Failure Root Cause Analysis'
     url: /quests/1010/agentic-failure-root-cause-analysis/
-  - title: 'The Oracle''s Rubric: Defining Agent Success Criteria and Signals'
+  - title: 'The Oracle''s Rubric: Agent Success Signals'
     url: /quests/1010/agentic-success-criteria-and-signals/
 - title: Level 1011 - Security & Compliance
   icon: bi-shield-lock
@@ -324,11 +328,11 @@
     url: /quests/1011/compliance-standards/
   - title: 'Penetration Testing: Tools and Ethical Hacking Methodologies'
     url: /quests/1011/penetration-testing/
-  - title: 'Reforging the Agent''s Mind: Behavior Tuning Through Instructions'
+  - title: 'Reforging the Agent''s Mind: Tuning Behavior by Instruction'
     url: /quests/1011/agentic-behavior-tuning/
-  - title: 'Secure Coding Practices: OWASP Top 10 Vulnerability Prevention'
+  - title: 'Secure Coding: Preventing the OWASP Top 10'
     url: /quests/1011/secure-coding/
-  - title: 'Security Fundamentals: CIA Triad and Defense in Depth Strategies'
+  - title: 'Security Fundamentals: CIA Triad and Defense in Depth'
     url: /quests/1011/security-fundamentals/
   - title: 'The Council of Many: Multi-Agent Orchestration Patterns'
     url: /quests/1011/agentic-multi-agent-orchestration-patterns/
@@ -342,25 +346,25 @@
   icon: bi-diagram-3
   url: /quests/1100/
   children:
-  - title: 'Apache Spark Mastery: Big Data Processing with PySpark & Scala'
+  - title: 'Apache Spark Mastery: Big Data with PySpark'
     url: /quests/1100/apache-spark/
-  - title: 'Data Quality Engineering: Testing, Validation & Monitoring Frameworks'
+  - title: 'Conquer King EDGAR: Siege of the SEC Data Castle'
+    url: /quests/1100/conquer-king-edgar/
+  - title: 'Data Quality Engineering: Validation & Monitoring'
     url: /quests/1100/data-quality/
-  - title: 'Data Warehousing: Design Star Schema & Build Modern Analytics Architecture'
+  - title: 'Data Warehousing: Build a Dimensional Star Schema in SQL'
     url: /quests/1100/data-warehousing/
-  - title: 'ETL Pipeline Design: Build Scalable Data Pipelines with Python'
+  - title: 'ETL Pipeline Design: Scalable Python Data Pipelines'
     url: /quests/1100/etl-pipeline-design/
   - title: 'Mastering Version Control Workflows: The Grand Merge Ritual'
     url: /quests/1100/mastering-version-control-workflows/
-  - title: 'Quest to Conquer King EDGAR: The Epic Siege of the SEC Data Castle'
-    url: /quests/1100/conquer-king-edgar/
   - title: 'Stream Processing: Real-Time Data with Apache Kafka & Flink'
     url: /quests/1100/stream-processing/
   - title: 'The Agent Pantheon: Multi-Agent Lifecycle Management'
     url: /quests/1100/agentic-multi-agent-lifecycle-management/
   - title: 'The Autonomy Scales: Mapping Agent Autonomy Levels'
     url: /quests/1100/agentic-autonomy-levels-matrix/
-  - title: 'The Temple of Templates: Binary Abstractions and Reusable Realms'
+  - title: 'The Temple of Templates: Reusable Abstractions'
     url: /quests/1100/temple-of-templates/
   - title: 'The Warden''s Pact: Guardrails and Human-in-the-Loop Patterns'
     url: /quests/1100/agentic-guardrails-and-human-in-the-loop/
@@ -370,22 +374,21 @@
   icon: bi-cpu
   url: /quests/1101/
   children:
-  - title: 'AI Ethics and Responsible AI: Bias Detection, Fairness & Governance'
+  - title: 'AI Ethics: Bias Detection, Fairness & Governance'
     url: /quests/1101/ai-ethics/
-  - title: 'Computer Vision Mastery: Image Classification, Object Detection & Segmentation'
+  - title: 'Computer Vision Mastery: CNNs and Transfer Learning'
     url: /quests/1101/computer-vision/
-  - title: 'Deep Learning Frameworks: PyTorch vs TensorFlow Comparison & Implementation'
+  - title: 'Deep Learning Frameworks: PyTorch vs TensorFlow'
     url: /quests/1101/deep-learning-frameworks/
-  - title: 'Machine Learning Fundamentals: Supervised & Unsupervised Learning with
-      Scikit-Learn'
+  - title: Machine Learning Fundamentals with Scikit-Learn
     url: /quests/1101/ml-fundamentals/
-  - title: 'MLOps Engineering: CI/CD Pipelines for Machine Learning Production'
+  - title: 'MLOps Engineering: CI/CD Pipelines for ML in Production'
     url: /quests/1101/mlops/
-  - title: 'Natural Language Processing: Text Analysis, Transformers & LLMs with Python'
+  - title: 'Natural Language Processing: Transformers & LLMs'
     url: /quests/1101/natural-language-processing/
-  - title: 'Neural Networks Deep Dive: Neurons, Backpropagation & Gradient Descent'
+  - title: 'Neural Networks Deep Dive: Build One From Scratch'
     url: /quests/1101/neural-networks/
-  - title: 'Python for Data Science: NumPy, Pandas & Matplotlib Complete Guide'
+  - title: 'Python for Data Science: NumPy, Pandas & Matplotlib'
     url: /quests/1101/python-data-science/
 - title: Level 1110 - Architecture & Design Patterns
   icon: bi-building-gear
@@ -411,21 +414,21 @@
   icon: bi-trophy
   url: /quests/1111/
   children:
-  - title: 'Architecture Reviews: Running Reviews, ADRs, and Trade-off Facilitation'
+  - title: 'Architecture Reviews: ADRs and Trade-off Facilitation'
     url: /quests/1111/architecture-reviews/
-  - title: 'Building Technical Communities: Events, Governance, and Inclusion'
+  - title: 'Building Technical Communities: Govern and Include'
     url: /quests/1111/building-technical-communities/
-  - title: 'Career Advancement: IC vs Management Tracks, Leveling, and Negotiation'
+  - title: 'Career Advancement: IC vs Management and Leveling'
     url: /quests/1111/career-advancement/
-  - title: 'Innovation and R&D: Experimentation and Managing Technical Bets'
+  - title: 'Innovation and R&D: Experimentation and Technical Bets'
     url: /quests/1111/innovation-rnd/
-  - title: 'Mentorship Programs: Growing Engineering Talent and Sponsoring Others'
+  - title: 'Mentorship Programs: Growing Engineering Talent'
     url: /quests/1111/mentorship-programs/
-  - title: 'Open Source Contribution: Contributing, Maintaining, and Licensing'
+  - title: 'Open Source Contribution: Maintaining and Licensing'
     url: /quests/1111/open-source-contribution/
-  - title: 'Tech Speaking and Writing: RFCs, Design Docs, and Talks That Persuade'
+  - title: 'Tech Speaking and Writing: RFCs, Docs, and Talks'
     url: /quests/1111/tech-speaking-writing/
-  - title: 'Technical Leadership: Leading Without Authority and Setting Tech Vision'
+  - title: 'Technical Leadership: Leading Without a Crown'
     url: /quests/1111/technical-leadership/
 - title: Resources
   icon: bi-book

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,39 @@ services:
       PYTHONUNBUFFERED: 1
       PATH: "/opt/venv/bin:$PATH"
 
+  # ── Unified quest validation (the canonical Docker path) ──────────────────
+  # Runs scripts/quest/quest_audit.py (content + network + freshness) in a
+  # stock, fast-to-pull python:3.12-slim — no image build, no Ruby. This is
+  # what `make docker-validate` drives and what the scheduled CI audit uses for
+  # CI-parity. Tier-2 (Claude) is opt-in and degrades gracefully when the CLI
+  # is absent. Default command is a full audit; pass a subcommand to override.
+  quest-audit:
+    image: python:3.12-slim
+    platform: linux/amd64
+    working_dir: /app
+    volumes:
+      - ./:/app
+    environment:
+      PYTHONUNBUFFERED: "1"
+    entrypoint: ["bash", "scripts/quest/docker-entrypoint.sh"]
+
+  # ── CI-parity Jekyll build ────────────────────────────────────────────────
+  # Heavy path: the ruby:3.2.3 + github-pages image actually building the site
+  # the way Pages ships it. Drives `make docker-build-ci`. Uses the gems baked
+  # into the image (NOT the jekyll service's Ruby-3.1 bundle_cache volume, which
+  # would shadow them and break with GemNotFound); `bundle check || bundle
+  # install` self-heals if the committed Gemfile.lock has moved on.
+  quest-build:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: bash -c "bundle check || bundle install && bundle exec jekyll build --config _config.yml,_config_dev.yml,_config_ci.yml"
+    volumes:
+      - ./:/app
+    working_dir: /app
+    environment:
+      JEKYLL_ENV: development
+
 volumes:
   jekyll-cache:
   bundle_cache:

--- a/scripts/quest/README.md
+++ b/scripts/quest/README.md
@@ -80,16 +80,21 @@ All four are regenerated from the registry + quest files by `make quest-data`:
 | script | purpose |
 |---|---|
 | `quest_registry.py` | the single source of truth (imported by everything) |
+| `quest_lib.py` | the ONE frontmatter parser + quest-file iterator + `QuestDoc` + code-snippet extractor (`extract_code_blocks`); every validator imports it so parsing/discovery can't drift |
+| `quest_audit.py` | **the unified validation system** — runs content + network + data-freshness (+ optional Claude tier-2) in one report and exit code |
 | `generate-quest-levels-data.py` | emit `levels.yml` / `tiers.yml` / `order.yml` |
 | `generate-quest-navigation.py` | emit `_data/navigation/quests.yml` |
 | `build-quest-network.py` | emit the dependency graph (JSON + YAML) |
-| `validate-quest-network.py` | graph integrity: required-cycle, broken-dep, orphan checks |
+| `validate-quest-network.py` | graph integrity: required-cycle, broken-dep, duplicate-permalink, dangling-edge, orphan, retired-field checks (registry-driven) |
 | `normalize-quest-frontmatter.py` | the ONE idempotent frontmatter normalizer |
 | `generate-placeholder-quest.sh` | scaffold a new placeholder quest |
+| `docker-entrypoint.sh` | runs `quest_audit.py` inside the `quest-audit` Docker service |
 
 Quest **content quality** is validated by
 [`test/quest-validator/quest_validator.py`](../../test/quest-validator/quest_validator.py),
-which imports its schema from the registry.
+which imports its schema from the registry. An **optional Claude Code tier-2**
+(`test/quest-validator/agentic_validate.py`) reads/plays quests for a deeper
+quality verdict; it's advisory and opt-in (see that directory's README).
 
 ## Runbook
 
@@ -98,8 +103,27 @@ make quest-data        # regenerate all derived data from the registry + files
 make quest-normalize   # idempotently normalize quest frontmatter
 make quest-validate    # content-quality validation (quest_validator.py)
 make quest-network     # dependency-graph validation
-make quest-audit       # build network → validate content → validate network
+make quest-audit       # UNIFIED audit: content + network + data-freshness (one report)
+make docker-validate   # the same unified audit, in Docker (CI-parity, no host Python)
+make docker-audit-tier2 MODE=review   # + Claude tier-2 in a container (needs token)
+make quest-execute QUEST=pages/_quests/0001/terminal-mastery.md  # Claude RUNS the quest's snippets, isolated
 ```
+
+### Running a quest's code snippets (execute mode)
+
+`make quest-execute` has a Claude Code agent **walk a quest and actually run its
+runnable code snippets** (`bash`/`python`/`node`/…) in a disposable Docker
+container, then report which worked. The container is the isolation boundary —
+the agent's commands never touch the host. `quest_lib.extract_code_blocks()`
+deterministically inventories the runnable snippets, and the report shows
+`ran N/M` coverage with per-snippet `passed`/`failed`/`skipped`/`reasoned`
+status. It is **opt-in and advisory** (it costs money and needs
+`CLAUDE_CODE_OAUTH_TOKEN`); without a token it falls back to a no-cost mock.
+Pass `SAMPLE=N` instead of `QUEST=` to run a spread across levels, or
+`make quest-execute-host` to run on the host sandbox (no container — riskier).
+
+`make quest-audit` only **validates** (it never writes files); if its freshness
+layer reports stale data, run `make quest-data` to regenerate, then commit.
 
 Scaffold a new quest, then fill and validate it:
 

--- a/scripts/quest/docker-entrypoint.sh
+++ b/scripts/quest/docker-entrypoint.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Entrypoint for the quest-audit container (docker-compose.yml `quest-audit`).
+#
+# Runs the unified quest validation system (scripts/quest/quest_audit.py) in a
+# throwaway python:3.12-slim container so validation matches CI regardless of
+# the host's Python/Ruby. The repo is bind-mounted at /app; the audit is
+# read-only (its freshness check restores any file it regenerates).
+#
+# Usage (from the repo root):
+#   docker compose run --rm quest-audit                 # full deterministic audit
+#   docker compose run --rm quest-audit strict          # warnings fail the audit
+#   docker compose run --rm quest-audit audit --json /app/quest-audit.json
+#   docker compose run --rm quest-audit changed pages/_quests/0001/x.md
+#   docker compose run --rm quest-audit tier2 review    # + Claude (needs CLI+token)
+#   docker compose run --rm quest-audit execute --changed pages/_quests/0001/x.md
+#                                                       # Claude RUNS a quest's snippets, isolated
+#   docker compose run --rm quest-audit shell           # interactive shell
+set -euo pipefail
+
+# The deterministic audit only needs pyyaml. Installed quietly on start so the
+# image stays a stock python:3.12-slim with no custom build step.
+pip install --quiet --disable-pip-version-check --root-user-action=ignore pyyaml \
+  >/dev/null 2>&1 || pip install --quiet pyyaml
+
+AUDIT="python3 scripts/quest/quest_audit.py"
+
+# The CONTAINER is the isolation boundary for execute mode — the Claude CLI is
+# installed here (Node) so the agent's commands run inside this disposable box,
+# never on the host. Returns 0 if a usable `claude` is available, 1 otherwise.
+have_creds() { [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}${ANTHROPIC_API_KEY:-}" ]; }
+ensure_claude() {
+  command -v claude >/dev/null 2>&1 && return 0
+  echo "▶ Installing Node + Claude Code CLI in the container (one-time per run)…"
+  apt-get update -qq >/dev/null 2>&1 || true
+  apt-get install -y -qq curl >/dev/null 2>&1 || true
+  curl -fsSL https://deb.nodesource.com/setup_20.x 2>/dev/null | bash - >/dev/null 2>&1 || true
+  apt-get install -y -qq nodejs >/dev/null 2>&1 || true
+  npm install -g @anthropic-ai/claude-code >/dev/null 2>&1 || true
+  command -v claude >/dev/null 2>&1
+}
+
+cmd="${1:-audit}"
+shift || true
+
+case "$cmd" in
+  audit)
+    exec $AUDIT "$@"
+    ;;
+  strict)
+    exec $AUDIT --strict "$@"
+    ;;
+  changed)
+    exec $AUDIT --changed "$@"
+    ;;
+  tier2)
+    # First positional after `tier2` is the mode (review|execute); default review.
+    mode="${1:-review}"; shift || true
+    if ! have_creds; then
+      echo "ℹ️  No Claude credentials in the container — running tier2 in --mock (advisory, no cost)."
+      exec $AUDIT --tier2 "$mode" --tier2-mock "$@"
+    fi
+    if ! ensure_claude; then
+      echo "⚠️  claude CLI unavailable in container; running tier2 in --mock (no cost)."
+      exec $AUDIT --tier2 "$mode" --tier2-mock "$@"
+    fi
+    exec $AUDIT --tier2 "$mode" "$@"
+    ;;
+  execute)
+    # Focused: a Claude agent walks ONE quest (or a sample) and ACTUALLY RUNS its
+    # code snippets in this isolated container — no content/network/freshness.
+    #   ... execute --changed pages/_quests/0001/x.md   (one quest)
+    #   ... execute --tier2-sample 3                     (a spread of quests)
+    if ! have_creds; then
+      echo "ℹ️  No Claude credentials — running execute in --mock (no real commands run, no cost)."
+      exec $AUDIT --no-content --no-network --no-freshness --tier2 execute --tier2-mock "$@"
+    fi
+    if ! ensure_claude; then
+      echo "⚠️  claude CLI unavailable in container; running execute in --mock (no cost)."
+      exec $AUDIT --no-content --no-network --no-freshness --tier2 execute --tier2-mock "$@"
+    fi
+    exec $AUDIT --no-content --no-network --no-freshness --tier2 execute "$@"
+    ;;
+  shell)
+    exec bash "$@"
+    ;;
+  *)
+    # Unknown subcommand → treat the whole argv as quest_audit flags.
+    exec $AUDIT "$cmd" "$@"
+    ;;
+esac

--- a/scripts/quest/quest_audit.py
+++ b/scripts/quest/quest_audit.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""
+quest_audit.py — the unified IT-Journey quest validation system.
+
+ONE command, ONE consolidated report, ONE exit code. It runs every layer of
+quest validation and decides, deterministically, whether the quest tree is
+sound:
+
+  1. content    — tier-1 structural/quality scoring (quest_validator.py) over
+                  all quests (or just changed files), gated at --fail-threshold.
+  2. network    — dependency-graph integrity (validate-quest-network.py):
+                  missing deps, cycles, duplicate permalinks, dangling edges,
+                  retired fields, shipped quest-network.json soundness.
+  3. freshness  — regenerates every registry-derived data artifact to a scratch
+                  copy and diffs it against what's committed, proving the
+                  generated _data/ has not drifted (the "never hand-edit"
+                  invariant). Non-mutating: originals are always restored.
+  4. tier2      — OPTIONAL Claude Code review (agentic_validate.py). Advisory by
+                  default (never gates) so routine runs cost nothing; opt in with
+                  --tier2 review|execute, gate with --tier2-gate.
+
+Designed to be the single entry point for local dev (`make quest-audit`), the
+Docker image (`make docker-validate`), and CI. Pure-Python deterministic layers
+need only pyyaml; tier2 needs the `claude` CLI (or --tier2 mock).
+
+Examples:
+  quest_audit.py                          # full deterministic audit
+  quest_audit.py --changed a.md b.md      # only these quests (PR fast-path)
+  quest_audit.py --json report.json       # machine-readable consolidated report
+  quest_audit.py --tier2 review --tier2-sample 5   # + advisory Claude review
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+_HERE = Path(__file__).resolve().parent
+REPO_ROOT = _HERE.parents[1]
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+import quest_registry as reg  # noqa: E402
+import quest_lib  # noqa: E402
+
+QUESTS_DIR = REPO_ROOT / "pages" / "_quests"
+NETWORK_JSON = REPO_ROOT / "assets" / "data" / "quest-network.json"
+
+# Registry-derived data artifacts that must stay in sync with the registry +
+# quest files. (generator script, [output files]) — the freshness check
+# regenerates each and diffs against what's on disk.
+GENERATORS = [
+    ("generate-quest-levels-data.py", [
+        "_data/quests/levels.yml", "_data/quests/tiers.yml", "_data/quests/order.yml",
+    ]),
+    ("generate-quest-navigation.py", [
+        "_data/navigation/quests.yml",
+    ]),
+    ("build-quest-network.py", [
+        "assets/data/quest-network.json", "_data/quests/network.yml",
+    ]),
+]
+
+# ── console helpers ──────────────────────────────────────────────────────────
+_TTY = sys.stdout.isatty()
+def _c(code): return code if _TTY else ""
+RED, GREEN, YELLOW, BLUE, BOLD, NC = (
+    _c("\033[0;31m"), _c("\033[0;32m"), _c("\033[1;33m"),
+    _c("\033[0;34m"), _c("\033[1m"), _c("\033[0m"),
+)
+PASS, WARN, FAIL = f"{GREEN}✅{NC}", f"{YELLOW}⚠️{NC}", f"{RED}❌{NC}"
+
+
+@dataclass
+class Section:
+    """Result of one audit layer."""
+    name: str
+    status: str = "pass"          # pass | warn | fail | skip
+    gating: bool = True           # does a fail here fail the audit?
+    errors: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    summary: str = ""
+    detail: Dict = field(default_factory=dict)
+
+    @property
+    def passed(self) -> bool:
+        return self.status in ("pass", "warn", "skip")
+
+
+# ── lazy imports of sibling tools ────────────────────────────────────────────
+
+def _import_quest_validator():
+    qv_dir = REPO_ROOT / "test" / "quest-validator"
+    if str(qv_dir) not in sys.path:
+        sys.path.insert(0, str(qv_dir))
+    import quest_validator  # noqa
+    return quest_validator
+
+
+def _import_network_validator():
+    spec = importlib.util.spec_from_file_location(
+        "validate_quest_network", str(_HERE / "validate-quest-network.py"))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ── layer 1: content (tier 1) ────────────────────────────────────────────────
+
+def run_content(changed: Optional[List[Path]], fail_threshold: int,
+                exclude_drafts: bool, strict: bool) -> Section:
+    qv = _import_quest_validator()
+    config = REPO_ROOT / "_config.yml"
+    validator = qv.QuestValidator(
+        verbose=False, exclude_drafts=exclude_drafts,
+        fail_threshold=fail_threshold,
+        config_path=str(config) if config.exists() else None,
+    )
+    sink = io.StringIO()
+    with contextlib.redirect_stdout(sink):
+        if changed:
+            for f in changed:
+                if quest_lib.is_meta_file(f):
+                    continue
+                validator.results.append(validator.validate_quest_file(f))
+        else:
+            validator.validate_directory(QUESTS_DIR)
+    report = validator.generate_report()
+
+    sec = Section("content")
+    sec.detail = {
+        "total": report["total"], "passed": report["passed"],
+        "failed": report["failed"], "average_score": round(report["average_score"], 1),
+        "placeholders": report["placeholders"],
+    }
+    for r in report["results"]:
+        if not r.passed:
+            for e in r.errors:
+                sec.errors.append(f"{Path(r.quest_file).name}: {e}")
+        for w in r.warnings:
+            sec.warnings.append(f"{Path(r.quest_file).name}: {w}")
+    if report["failed"] > 0:
+        sec.status = "fail"
+    elif strict and report["total_warnings"] > 0:
+        sec.status = "fail"
+    elif report["total_warnings"] > 0:
+        sec.status = "warn"
+    sec.summary = (f"{report['passed']}/{report['total']} quests pass "
+                   f"(avg {report['average_score']:.1f}%), "
+                   f"{report['failed']} failed, {report['placeholders']} placeholder(s)")
+    return sec
+
+
+# ── layer 2: network ─────────────────────────────────────────────────────────
+
+def run_network(strict: bool) -> Section:
+    mod = _import_network_validator()
+    network_json = str(NETWORK_JSON) if NETWORK_JSON.exists() else None
+    res = mod.run_network_validation(
+        str(QUESTS_DIR), network_json=network_json, strict=strict, quiet=True)
+    sec = Section("network")
+    sec.errors = list(res["errors"])
+    sec.warnings = list(res["warnings"])
+    sec.detail = res["stats"]
+    if res["errors"]:
+        sec.status = "fail"
+    elif strict and res["warnings"]:
+        sec.status = "fail"
+    elif res["warnings"]:
+        sec.status = "warn"
+    s = res["stats"]
+    sec.summary = (f"{s['total_quests']} nodes, {s['broken_dependencies']} broken dep(s), "
+                   f"{s['duplicate_permalinks']} dup permalink(s), {s['orphaned_quests']} orphan(s)")
+    return sec
+
+
+# ── layer 3: data freshness ──────────────────────────────────────────────────
+
+def run_freshness(gate: bool) -> Section:
+    """Regenerate every registry-derived artifact and diff against disk.
+
+    Non-mutating: each target file is backed up in memory, regenerated, compared,
+    then restored — so a dev's working tree is never left modified, even if a
+    generator raises midway (restore happens in `finally`).
+    """
+    sec = Section("freshness", gating=gate)
+    targets = [REPO_ROOT / p for _, outs in GENERATORS for p in outs]
+    backups: Dict[Path, Optional[bytes]] = {
+        p: (p.read_bytes() if p.exists() else None) for p in targets
+    }
+    stale: List[str] = []
+    try:
+        for script, outs in GENERATORS:
+            proc = subprocess.run(
+                [sys.executable, str(_HERE / script)],
+                cwd=str(REPO_ROOT), capture_output=True, text=True)
+            if proc.returncode != 0:
+                sec.errors.append(f"generator {script} failed: "
+                                  f"{(proc.stderr or proc.stdout).strip()[-300:]}")
+        for p in targets:
+            new = p.read_bytes() if p.exists() else None
+            if new != backups[p]:
+                stale.append(str(p.relative_to(REPO_ROOT)))
+    finally:
+        for p, original in backups.items():
+            if original is None:
+                if p.exists():
+                    p.unlink()
+            else:
+                p.write_bytes(original)
+
+    sec.detail = {"stale_files": stale}
+    if sec.errors:
+        sec.status = "fail"
+    elif stale:
+        sec.status = "fail" if gate else "warn"
+        for f in stale:
+            (sec.errors if gate else sec.warnings).append(
+                f"stale generated data: {f} — run `make quest-data` and commit")
+    sec.summary = ("all generated data in sync" if not stale
+                   else f"{len(stale)} stale generated file(s): {', '.join(stale)}")
+    return sec
+
+
+# ── layer 4: tier 2 (Claude, optional + advisory) ────────────────────────────
+
+def run_tier2(mode: str, changed: Optional[List[Path]], sample: int,
+              gate: bool, fail_threshold: int, mock: bool,
+              max_cost_usd: float, max_turns: int, isolate: str) -> Section:
+    sec = Section("tier2", gating=gate)
+    av_dir = REPO_ROOT / "test" / "quest-validator"
+    cmd = [sys.executable, str(av_dir / "agentic_validate.py"),
+           "--mode", mode, "--report", "/tmp/quest-tier2.json"]
+    if mock:
+        cmd.append("--mock")
+    # Filter meta files FIRST, then decide the target. A changed set that is all
+    # meta files must NOT silently fall through to a full-tree, uncapped review
+    # against the real CLI — skip instead.
+    files = [str(f) for f in (changed or []) if not quest_lib.is_meta_file(f)]
+    if changed and not files:
+        sec.status = "skip"
+        sec.summary = "tier2 skipped: no non-meta quests in the changed set"
+        return sec
+    if files:
+        cmd += files
+    else:
+        cmd += ["-d", str(QUESTS_DIR), "--sample", str(sample)]
+    if max_cost_usd:
+        cmd += ["--max-cost-usd", str(max_cost_usd)]
+    if max_turns:
+        cmd += ["--max-turns", str(max_turns)]
+    if isolate and isolate != "none":
+        cmd += ["--isolate", isolate]
+    if gate and fail_threshold:
+        cmd += ["--fail-threshold", str(fail_threshold)]
+    try:
+        proc = subprocess.run(cmd, cwd=str(REPO_ROOT), capture_output=True, text=True)
+    except Exception as e:  # pragma: no cover
+        sec.status = "skip"
+        sec.summary = f"tier2 skipped: {e}"
+        return sec
+    rc = proc.returncode
+    data = {}
+    try:
+        data = json.loads(Path("/tmp/quest-tier2.json").read_text())
+    except Exception:
+        pass
+    counts = (data.get("counts") or {}) if isinstance(data, dict) else {}
+    # Aggregate snippet-execution coverage across quests (execute mode).
+    snip_ran = snip_runnable = snip_failed = 0
+    for r in (data.get("results") or []) if isinstance(data, dict) else []:
+        s = r.get("snippets") or {}
+        if s.get("available_runnable"):
+            snip_ran += s.get("ran", 0)
+            snip_runnable += s.get("available_runnable", 0)
+            snip_failed += s.get("failed", 0)
+    sec.detail = {
+        "schema_version": data.get("schema_version"),
+        "scored": data.get("scored"),
+        "average": data.get("average"),
+        "counts": counts,
+        "cost_usd": data.get("cost_usd"),
+        "snippets_ran": snip_ran,
+        "snippets_runnable": snip_runnable,
+        "snippets_failed": snip_failed,
+    } if isinstance(data, dict) else {}
+    snip_bit = (f" · ran {snip_ran}/{snip_runnable} snippets"
+                + (f" ({snip_failed} failed)" if snip_failed else "")) if snip_runnable else ""
+    tier2_line = (
+        f"{data.get('scored', 0)} quest(s), avg {data.get('average', 0)}% — "
+        f"{counts.get('pass', 0)} pass / {counts.get('warn', 0)} warn / "
+        f"{counts.get('fail', 0)} fail"
+        + snip_bit
+        + (f" · ~${data.get('cost_usd')}" if data.get('cost_usd') else "")
+    ) if isinstance(data, dict) and data else None
+    if rc == 2:
+        # Auth / no CLI / no quests — advisory, never fail the whole audit.
+        sec.status = "skip"
+        sec.summary = ("tier2 unavailable (no claude CLI / auth / quests) — "
+                       "advisory only; use --tier2 mock to test the pipeline")
+        return sec
+    if gate and rc == 1:
+        sec.status = "fail"
+        sec.errors.append(f"tier2 quality gate failed (threshold {fail_threshold}%)")
+    elif rc == 1:
+        sec.status = "warn"
+        sec.warnings.append("tier2 flagged quests below threshold (advisory)")
+    if gate:
+        sec.summary = (f"tier2 {mode} gate {'passed' if rc == 0 else 'failed'}"
+                       + (f" — {tier2_line}" if tier2_line else ""))
+    else:
+        sec.summary = tier2_line or f"tier2 {mode} complete (advisory)"
+    return sec
+
+
+# ── report ───────────────────────────────────────────────────────────────────
+
+def render(sections: List[Section], quiet: bool) -> int:
+    gating_fail = any(s.gating and s.status == "fail" for s in sections)
+    if not quiet:
+        print()
+        print(f"{BOLD}{'═'*72}{NC}")
+        print(f"{BOLD}  IT-JOURNEY QUEST AUDIT{NC}")
+        print(f"{BOLD}{'═'*72}{NC}")
+        for s in sections:
+            icon = {"pass": PASS, "warn": WARN, "fail": FAIL, "skip": "•"}[s.status]
+            gate = "" if s.gating else f" {BLUE}(advisory){NC}"
+            print(f"\n{icon} {BOLD}{s.name}{NC}{gate} — {s.summary}")
+            for e in s.errors[:25]:
+                print(f"    {RED}✗ {e}{NC}")
+            if len(s.errors) > 25:
+                print(f"    {RED}… and {len(s.errors)-25} more error(s){NC}")
+            for w in s.warnings[:8]:
+                print(f"    {YELLOW}~ {w}{NC}")
+            if len(s.warnings) > 8:
+                print(f"    {YELLOW}… and {len(s.warnings)-8} more warning(s){NC}")
+        print(f"\n{BOLD}{'─'*72}{NC}")
+        verdict = f"{FAIL} AUDIT FAILED" if gating_fail else f"{PASS} AUDIT PASSED"
+        print(f"{BOLD}  {verdict}{NC}")
+        print(f"{BOLD}{'═'*72}{NC}\n")
+    return 1 if gating_fail else 0
+
+
+def to_json(sections: List[Section]) -> dict:
+    gating_fail = any(s.gating and s.status == "fail" for s in sections)
+    return {
+        "passed": not gating_fail,
+        "sections": [
+            {"name": s.name, "status": s.status, "gating": s.gating,
+             "summary": s.summary, "errors": s.errors, "warnings": s.warnings,
+             "detail": s.detail}
+            for s in sections
+        ],
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description="Unified IT-Journey quest validation (content + network + freshness + optional Claude).",
+        formatter_class=argparse.RawDescriptionHelpFormatter, epilog=__doc__)
+    p.add_argument("--changed", nargs="*", metavar="FILE",
+                   help="Limit content + tier2 to these quest files (PR fast-path).")
+    p.add_argument("--fail-threshold", type=int, default=70,
+                   help="Tier-1 per-quest minimum score %% (default 70; 0 disables).")
+    p.add_argument("--exclude-drafts", action="store_true", help="Skip draft quests in tier 1.")
+    p.add_argument("--strict", action="store_true",
+                   help="Treat content/network warnings as failures.")
+    p.add_argument("--no-content", action="store_true", help="Skip tier-1 content scoring.")
+    p.add_argument("--no-network", action="store_true", help="Skip network validation.")
+    p.add_argument("--no-freshness", action="store_true", help="Skip data-freshness check.")
+    p.add_argument("--freshness-warn", action="store_true",
+                   help="Report stale generated data as a warning, not a failure.")
+    p.add_argument("--tier2", choices=["off", "review", "execute"], default="off",
+                   help="Run Claude Code review (default off). review = read-only; execute = sandboxed.")
+    p.add_argument("--tier2-sample", type=int, default=3, help="Quests to sample for tier2 (default 3).")
+    p.add_argument("--tier2-gate", action="store_true",
+                   help="Make tier2 gating (fail the audit on low scores). Default: advisory.")
+    p.add_argument("--tier2-mock", action="store_true", help="Run tier2 with synthetic verdicts (no CLI/cost).")
+    p.add_argument("--max-cost-usd", type=float, default=0.0, help="Tier2 cost ceiling (USD, 0 = none).")
+    p.add_argument("--max-turns", type=int, default=0, help="Tier2 per-quest turn ceiling (0 = none).")
+    p.add_argument("--isolate", choices=["none", "docker"], default="none",
+                   help="Tier2 execute isolation (docker = run claude in a disposable container).")
+    p.add_argument("--json", metavar="FILE", help="Write the consolidated report as JSON.")
+    p.add_argument("--quiet", action="store_true", help="Suppress the console report.")
+    args = p.parse_args()
+
+    changed = [Path(f) for f in args.changed] if args.changed else None
+    sections: List[Section] = []
+
+    if not args.no_content:
+        sections.append(run_content(changed, args.fail_threshold,
+                                    args.exclude_drafts, args.strict))
+    if not args.no_network:
+        sections.append(run_network(args.strict))
+    if not args.no_freshness:
+        # Freshness is whole-tree; skip it in changed-only mode to keep PRs fast
+        # (the scheduled/Docker audit owns the staleness gate).
+        if changed:
+            sec = Section("freshness", gating=False, status="skip",
+                          summary="skipped in --changed mode (owned by the full audit)")
+            sections.append(sec)
+        else:
+            sections.append(run_freshness(gate=not args.freshness_warn))
+
+    if args.tier2 != "off":
+        sections.append(run_tier2(
+            args.tier2, changed, args.tier2_sample, args.tier2_gate,
+            args.fail_threshold, args.tier2_mock, args.max_cost_usd,
+            args.max_turns, args.isolate))
+
+    rc = render(sections, args.quiet)
+
+    if args.json:
+        Path(args.json).write_text(json.dumps(to_json(sections), indent=2, default=str),
+                                   encoding="utf-8")
+        if not args.quiet:
+            print(f"📄 Consolidated report → {args.json}")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/quest/quest_lib.py
+++ b/scripts/quest/quest_lib.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""
+quest_lib.py — Shared parsing + discovery for the IT-Journey quest tooling.
+
+This is the *one* place that knows how to turn a markdown file on disk into a
+parsed quest. Before this module existed, the same frontmatter regex + YAML
+load was reimplemented five times (quest_validator, validate-quest-network,
+build-quest-network, generate-quest-navigation, agentic/loader) with subtly
+different error handling, and the network validator re-hardcoded the taxonomy
+instead of importing the registry. Every validator now shares these helpers so
+they can never disagree about *what a quest is* or *how to read one*.
+
+Design rules:
+  * Taxonomy/schema constants live in ``quest_registry`` (the data SSOT). This
+    module owns *behaviour* (parse, discover), never *vocabulary*.
+  * Parsing is tolerant: a BOM, CRLF line endings, or trailing whitespace after
+    the closing ``---`` must not turn a real quest into "Failed to parse
+    frontmatter". A YAML error is reported as a structured signal, not a crash.
+  * Discovery is deterministic (sorted) so callers that feed generated, diffable
+    data files stay stable.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Tuple
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - environment guard
+    print("Error: PyYAML is required but not installed (pip install pyyaml).",
+          file=sys.stderr)
+    raise
+
+# The registry is the single source of truth for taxonomy + collection rules.
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+import quest_registry as reg  # noqa: E402
+
+REPO_ROOT = _HERE.parents[1]
+QUESTS_DIR = REPO_ROOT / "pages" / "_quests"
+
+# Frontmatter delimiter. Tolerant of an optional UTF-8 BOM, CRLF endings, and
+# trailing whitespace on the fence lines. Body is captured as the remainder.
+_FM_RE = re.compile(
+    r"^﻿?---[ \t]*\r?\n(?P<fm>.*?)\r?\n---[ \t]*\r?\n?(?P<body>.*)\Z",
+    re.DOTALL,
+)
+
+
+class FrontmatterError(ValueError):
+    """Raised (or attached to a result) when YAML frontmatter cannot be parsed."""
+
+
+def parse_frontmatter(text: str) -> Tuple[Optional[Dict], str]:
+    """Split ``text`` into (frontmatter_dict, body).
+
+    Returns ``(None, original_text)`` when there is no frontmatter block at all.
+    Raises :class:`FrontmatterError` when a block exists but the YAML inside it
+    is invalid — callers decide whether that is fatal or a reported finding.
+    Normalises CRLF to LF in the returned body so downstream regexes that match
+    on ``\n`` behave identically across platforms.
+    """
+    if text is None:
+        return None, ""
+    m = _FM_RE.match(text)
+    if not m:
+        return None, text
+    raw_fm = m.group("fm")
+    body = m.group("body").replace("\r\n", "\n")
+    try:
+        fm = yaml.safe_load(raw_fm)
+    except yaml.YAMLError as e:
+        raise FrontmatterError(str(e)) from e
+    if fm is None:
+        fm = {}
+    if not isinstance(fm, dict):
+        raise FrontmatterError(
+            f"frontmatter is a {type(fm).__name__}, expected a mapping"
+        )
+    return fm, body
+
+
+def read_text(path: Path) -> str:
+    """Read a markdown file as UTF-8, replacing undecodable bytes rather than
+    failing the whole run on one mojibake file."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return path.read_text(encoding="utf-8", errors="replace")
+
+
+@dataclass
+class QuestDoc:
+    """A parsed quest-tree markdown file.
+
+    ``fm`` is the frontmatter mapping (``{}`` when absent), ``body`` the content
+    after the closing fence. Derived attributes use the registry so they match
+    every other tool. ``fm_error`` is set when frontmatter YAML was invalid.
+    """
+
+    path: Path
+    fm: Dict = field(default_factory=dict)
+    body: str = ""
+    fm_error: Optional[str] = None
+
+    @property
+    def rel_path(self) -> str:
+        try:
+            return str(self.path.relative_to(REPO_ROOT))
+        except ValueError:
+            return str(self.path)
+
+    @property
+    def title(self) -> str:
+        return str(self.fm.get("title") or self.path.stem)
+
+    @property
+    def level(self) -> str:
+        return str(self.fm.get("level") or "")
+
+    @property
+    def quest_type(self) -> str:
+        return str(self.fm.get("quest_type") or "")
+
+    @property
+    def permalink(self) -> str:
+        return str(self.fm.get("permalink") or "")
+
+    @property
+    def slug(self) -> str:
+        return reg.slug_from_filename(self.path.name)
+
+    @property
+    def theme(self) -> str:
+        return reg.theme_of(self.level) if self.level else ""
+
+    def is_quest(self) -> bool:
+        return reg.is_quest(self.fm)
+
+    def is_draft(self) -> bool:
+        return reg.is_draft(self.fm)
+
+    def is_scored(self) -> bool:
+        return reg.is_scored(self.fm)
+
+    def has_placeholder_marker(self) -> bool:
+        return reg.has_placeholder_marker(self.body)
+
+    # Directory level (the 4-bit dir a file lives under, if any) — used to
+    # cross-check the frontmatter ``level`` and to bucket reports.
+    @property
+    def dir_level(self) -> Optional[str]:
+        for part in self.path.parts:
+            if reg.LEVEL_RE.match(part):
+                return part
+        return None
+
+
+def read_quest(path) -> QuestDoc:
+    """Parse one file into a :class:`QuestDoc` (never raises on bad YAML — the
+    error is captured in ``fm_error`` so a single broken file can't abort a
+    whole-corpus audit)."""
+    p = Path(path)
+    if not p.is_absolute():
+        p = (REPO_ROOT / p).resolve()
+    text = read_text(p)
+    try:
+        fm, body = parse_frontmatter(text)
+    except FrontmatterError as e:
+        return QuestDoc(path=p, fm={}, body=text, fm_error=str(e))
+    return QuestDoc(path=p, fm=fm or {}, body=body)
+
+
+def is_meta_file(path: Path) -> bool:
+    """True when a file is collection scaffolding, not a quest page.
+
+    Mirrors the registry skip rules plus the ALL_CAPS report convention
+    (NETWORK_REPORT.md, QUEST_BUILD_PLAN.md, …). One predicate, used by every
+    tool and the CI changed-file filter, so they can never disagree.
+    """
+    stem = path.stem
+    if stem in reg.SKIP_STEMS:
+        return True
+    if stem.upper() in ("README", "INDEX", "HOME"):
+        return True
+    if stem.isupper() and "_" in stem:
+        return True
+    return False
+
+
+def is_quest_index_readme(path: Path) -> bool:
+    """True when a README/index is the *hub page* of a multi-file quest, e.g.
+    ``0000/bashcrawl/README.md`` which Jekyll serves at ``/quests/0000/bashcrawl/``.
+
+    Such a page is a real, linkable node (other quests legitimately list it as a
+    prerequisite), unlike a level-index README (``0000/README.md``) or a section
+    README (``tools/README.md``). The rule: name is README/index, the immediate
+    parent is NOT a 4-bit level dir, and the grandparent IS one.
+    """
+    if path.stem.upper() not in ("README", "INDEX"):
+        return False
+    parent = path.parent
+    grandparent = parent.parent
+    return (not reg.LEVEL_RE.match(parent.name)) and bool(reg.LEVEL_RE.match(grandparent.name))
+
+
+def iter_quest_files(
+    root=None,
+    *,
+    skip_subdirs: Optional[set] = None,
+    include_meta: bool = False,
+    include_index_readmes: bool = False,
+) -> Iterator[Path]:
+    """Yield quest-tree ``.md`` files in deterministic (sorted) order.
+
+    ``skip_subdirs`` defaults to the registry's ``SKIP_SUBDIRS`` (templates,
+    docs, inventory). Pass an explicit set to widen/narrow the exclusion (e.g.
+    the network graph historically also walks ``tools/`` and ``codex/`` because
+    those carry permalinks). When ``include_meta`` is False (default), README /
+    HOME / ALL_CAPS report files are skipped — except that
+    ``include_index_readmes`` re-admits multi-file quest *hub* READMEs
+    (``0000/bashcrawl/README.md``), which are real linkable nodes.
+    """
+    base = Path(root) if root else QUESTS_DIR
+    if not base.is_absolute():
+        base = (REPO_ROOT / base).resolve()
+    skip = reg.SKIP_SUBDIRS if skip_subdirs is None else skip_subdirs
+    for md in sorted(base.rglob("*.md")):
+        rel_parts = md.relative_to(base).parts[:-1]
+        if any(part in skip for part in rel_parts):
+            continue
+        if not include_meta and is_meta_file(md):
+            if include_index_readmes and is_quest_index_readme(md):
+                yield md
+            continue
+        yield md
+
+
+def load_quests(
+    root=None,
+    *,
+    scored_only: bool = False,
+    quests_only: bool = True,
+    include_drafts: bool = True,
+    skip_subdirs: Optional[set] = None,
+) -> List[QuestDoc]:
+    """Discover and parse quest documents under ``root``.
+
+    * ``quests_only`` (default True): keep only pages with ``fmContentType: quest``.
+    * ``scored_only``: keep only published (non-draft) quests.
+    * ``include_drafts`` is ignored when ``scored_only`` is True.
+    """
+    out: List[QuestDoc] = []
+    for path in iter_quest_files(root, skip_subdirs=skip_subdirs):
+        doc = read_quest(path)
+        if doc.fm_error:
+            # Surface parse failures as documents with no frontmatter so the
+            # caller can report them rather than silently dropping the file.
+            out.append(doc)
+            continue
+        if quests_only and not doc.is_quest():
+            continue
+        if scored_only and not doc.is_scored():
+            continue
+        if not include_drafts and doc.is_draft():
+            continue
+        out.append(doc)
+    return out
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Code-snippet extraction (for "actually run the snippets" validation)
+# ─────────────────────────────────────────────────────────────────────────────
+# Languages whose fenced blocks are commands/programs an agent can RUN.
+RUNNABLE_LANGS = {
+    "bash", "sh", "shell", "zsh", "console", "shell-session", "sh-session",
+    "python", "py", "python3", "javascript", "js", "node", "nodejs",
+    "typescript", "ts", "ruby", "rb", "go", "golang", "rust", "rs",
+    "sql", "powershell", "ps1", "fish",
+}
+# Languages that are config / markup / output — SHOWN, never executed.
+NONRUNNABLE_LANGS = {
+    "yaml", "yml", "json", "json5", "toml", "ini", "markdown", "md", "mdx",
+    "text", "txt", "plaintext", "mermaid", "html", "xml", "liquid", "handlebars",
+    "css", "scss", "less", "diff", "patch", "csv", "tsv", "dockerfile", "docker",
+    "makefile", "make", "gitignore", "env", "dotenv", "properties", "log",
+    "http", "graphql", "regex", "ascii", "",
+}
+
+
+@dataclass
+class CodeBlock:
+    """A fenced code block lifted from a quest body."""
+    lang: str
+    code: str
+    runnable: bool
+    line: int  # 1-based line of the opening fence in the body
+
+
+def is_runnable_lang(lang: str) -> bool:
+    """Whether a fenced-block language tag denotes something runnable.
+
+    Known runnable → True; known display/config → False; unknown/empty → False
+    (conservative: don't claim a fragment is runnable when we can't tell)."""
+    return (lang or "").lower() in RUNNABLE_LANGS
+
+
+def extract_code_blocks(body: str) -> List[CodeBlock]:
+    """Return the TOP-LEVEL fenced code blocks in ``body``, in order.
+
+    A block opens on a ```/~~~ fence (optionally with a language tag) and closes
+    on a fence of at least the same length with no trailing text — so a longer
+    fence used to *display* nested backticks is treated as content, not a close.
+    This mirrors the fence handling in quest_validator's code-block check.
+    """
+    blocks: List[CodeBlock] = []
+    in_block = False
+    fence = ""
+    ticks = 0
+    lang = ""
+    start = 0
+    buf: List[str] = []
+    for idx, line in enumerate((body or "").split("\n"), start=1):
+        stripped = line.strip()
+        m = re.match(r"^([`~]{3,})(.*)$", stripped)
+        if not in_block:
+            if m:
+                fence = m.group(1)[0]
+                ticks = len(m.group(1))
+                info = m.group(2).strip()
+                lang = info.split()[0].lower() if info else ""
+                start, buf, in_block = idx, [], True
+        else:
+            # Close only on the SAME fence char, length ≥ opener, and no info text.
+            if m and m.group(1)[0] == fence and len(m.group(1)) >= ticks and not m.group(2).strip():
+                blocks.append(CodeBlock(lang=lang, code="\n".join(buf),
+                                        runnable=is_runnable_lang(lang), line=start))
+                in_block = False
+            else:
+                buf.append(line)
+    if in_block:  # unclosed fence — keep what we captured
+        blocks.append(CodeBlock(lang=lang, code="\n".join(buf),
+                                runnable=is_runnable_lang(lang), line=start))
+    return blocks
+
+
+def runnable_snippets(body: str) -> List[CodeBlock]:
+    """The subset of code blocks an agent should attempt to run."""
+    return [b for b in extract_code_blocks(body) if b.runnable]
+
+
+def snippet_summary(body: str) -> Dict:
+    """A compact, deterministic inventory of a quest's code blocks.
+
+    Returns {total, runnable, by_lang: {lang: count}} — used to tell the execute
+    agent what to run and to report execution coverage.
+    """
+    blocks = extract_code_blocks(body)
+    by_lang: Dict[str, int] = {}
+    for b in blocks:
+        by_lang[b.lang or "(none)"] = by_lang.get(b.lang or "(none)", 0) + 1
+    return {
+        "total": len(blocks),
+        "runnable": sum(1 for b in blocks if b.runnable),
+        "by_lang": dict(sorted(by_lang.items())),
+    }
+
+
+if __name__ == "__main__":
+    # Smoke test: parse the whole corpus and report shape.
+    docs = load_quests(quests_only=False)
+    quests = [d for d in docs if d.is_quest()]
+    broken = [d for d in docs if d.fm_error]
+    print(f"quest-tree files scanned : {len(docs)}")
+    print(f"  fmContentType == quest : {len(quests)}")
+    print(f"  scored (published)     : {sum(1 for d in quests if d.is_scored())}")
+    print(f"  drafts                 : {sum(1 for d in quests if d.is_draft())}")
+    print(f"  frontmatter errors     : {len(broken)}")
+    for d in broken:
+        print(f"    ! {d.rel_path}: {d.fm_error}")

--- a/scripts/quest/validate-quest-network.py
+++ b/scripts/quest/validate-quest-network.py
@@ -1,454 +1,506 @@
 #!/usr/bin/env python3
 """
-validate-quest-network.py
+validate-quest-network.py — quest dependency-graph integrity checker.
 
-Validates the quest network integrity across the IT-Journey quest system.
-Checks for:
-- Required frontmatter fields
-- Quest dependencies exist
-- No circular dependencies
-- Orphaned quests
-- Broken links
-- Quest progression paths
+Validates the *relationships between* quests (the network), as opposed to the
+per-file content quality that ``test/quest-validator/quest_validator.py`` (tier
+1) scores. Concretely it checks:
+
+  * every quest-tree page that should be a graph node has a permalink;
+  * controlled-vocabulary fields (level / difficulty / quest_type) hold legal
+    values — sourced from the registry, never re-hardcoded here;
+  * no file still carries a RETIRED frontmatter field (e.g. quest_relationships);
+  * every quest_dependency (required / recommended / unlocks) resolves to a real
+    node, honouring the ``# planned quest`` forward-reference escape hatch;
+  * no duplicate permalinks (two files claiming the same node id);
+  * no circular *required* prerequisites (a learner could never start);
+  * prerequisite level monotonicity (a quest shouldn't require a higher-level one);
+  * orphaned quests (reachable from nothing) — reported as warnings;
+  * (optional) the committed quest-network.json: every edge resolves to a node,
+    no duplicate node ids — i.e. the artifact the site actually ships is sound.
+
+Taxonomy and "what is a quest" rules come from ``quest_registry`` +
+``quest_lib`` so this validator can never drift from tier 1, the generators, or
+the templates. This module is import-safe: ``run_network_validation()`` returns
+a structured result for the unified ``quest_audit`` orchestrator.
 """
 
-import os
+from __future__ import annotations
+
+import argparse
+import json
 import sys
-import re
 from pathlib import Path
-from typing import Dict, List, Set, Tuple
-from collections import defaultdict
+from typing import Dict, List, Optional
 
-# Try to import yaml, provide helpful error if not available
-try:
-    import yaml
-except ImportError:
-    print("Error: PyYAML is required but not installed.")
-    print("Install it with: pip3 install pyyaml")
-    sys.exit(1)
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+import quest_registry as reg  # noqa: E402
+import quest_lib  # noqa: E402
 
-# ANSI color codes
-RED = '\033[0;31m'
-GREEN = '\033[0;32m'
-YELLOW = '\033[1;33m'
-BLUE = '\033[0;34m'
-NC = '\033[0m'  # No Color
+# ANSI colours (suppressed when stdout is not a TTY).
+_TTY = sys.stdout.isatty()
+RED = "\033[0;31m" if _TTY else ""
+GREEN = "\033[0;32m" if _TTY else ""
+YELLOW = "\033[1;33m" if _TTY else ""
+BLUE = "\033[0;34m" if _TTY else ""
+NC = "\033[0m" if _TTY else ""
+
 
 def print_info(msg): print(f"{BLUE}[INFO]{NC} {msg}")
 def print_success(msg): print(f"{GREEN}[SUCCESS]{NC} {msg}")
 def print_warning(msg): print(f"{YELLOW}[WARNING]{NC} {msg}")
 def print_error(msg): print(f"{RED}[ERROR]{NC} {msg}")
 
-class QuestValidator:
-    def __init__(self, quest_dir: str):
+
+# Dependency buckets that form the directed graph. Sourced from the registry's
+# QUEST_DEPENDENCIES_KEYS so the edge kinds can't drift from the schema.
+_DEP_KINDS = list(reg.QUEST_DEPENDENCIES_KEYS)  # required/recommended/unlocks_quests
+# Edges that represent a hard prerequisite (used for cycle + monotonicity checks).
+_PREREQ_KEY = "required_quests"
+
+
+def _strip_planned_marker(value):
+    """Strip a trailing ``# planned quest`` / ``# planned`` inline marker.
+
+    Authors suffix a dependency URL with ``# planned quest`` to declare an
+    intentional forward reference to an unwritten quest (documented in
+    ``.github/instructions/quest.instructions.md``). Returns (clean, is_planned).
+    """
+    if not isinstance(value, str):
+        return value, False
+    stripped = value.strip()
+    import re
+    m = re.match(r"^(.*?)\s*#\s*planned(?:\s+quest)?\s*$", stripped, re.IGNORECASE)
+    if m:
+        return m.group(1).strip(), True
+    return stripped, False
+
+
+def _norm_link(value: str) -> str:
+    """Normalise a permalink to a trailing-slash node id."""
+    v = str(value).strip()
+    return v if v.endswith("/") else v + "/"
+
+
+class QuestNetworkValidator:
+    def __init__(self, quest_dir: str, network_json: Optional[str] = None):
         self.quest_dir = Path(quest_dir)
-        self.quests: Dict[str, Dict] = {}
+        self.network_json = Path(network_json) if network_json else None
+        # node id (permalink) -> {doc, frontmatter}
+        self.nodes: Dict[str, Dict] = {}
         self.errors: List[str] = []
         self.warnings: List[str] = []
         self.stats = {
-            'total_quests': 0,
-            'complete_quests': 0,
-            'placeholder_quests': 0,
-            'draft_quests': 0,
-            'orphaned_quests': 0,
-            'broken_dependencies': 0
+            "total_quests": 0,
+            "complete_quests": 0,
+            "placeholder_quests": 0,
+            "draft_quests": 0,
+            "orphaned_quests": 0,
+            "broken_dependencies": 0,
+            "duplicate_permalinks": 0,
+            "retired_fields": 0,
+            "dangling_edges": 0,
         }
-        
-        # Required frontmatter fields
-        self.required_fields = [
-            'title', 'description', 'level', 'difficulty', 
-            'estimated_time', 'quest_type', 'permalink'
-        ]
-    
-    def extract_frontmatter(self, file_path: Path) -> Tuple[Dict, str]:
-        """Extract YAML frontmatter from markdown file."""
-        with open(file_path, 'r', encoding='utf-8') as f:
-            content = f.read()
-        
-        # Match frontmatter between --- delimiters
-        match = re.match(r'^---\s*\n(.*?)\n---\s*\n(.*)', content, re.DOTALL)
-        if not match:
-            return {}, content
-        
-        try:
-            frontmatter = yaml.safe_load(match.group(1))
-            body = match.group(2)
-            return frontmatter or {}, body
-        except yaml.YAMLError as e:
-            self.errors.append(f"YAML parsing error in {file_path}: {e}")
-            return {}, content
-    
-    def scan_quests(self):
-        """Scan all quest markdown files and extract metadata."""
-        print_info("Scanning quest files...")
-        
-        def process_quest_file(md_file):
-            """Process a single quest file and store its data"""
-            try:
-                # Skip templates and non-quest meta files; include README.md files that are quest indexes
-                if any(skip in str(md_file) for skip in ['templates/', 'home.md', 'QUEST_BUILD_PLAN.md', 'PHASE1_COMPLETE.md', '/docs/', 'NETWORK_REPORT.md', 'QUEST_ORGANIZATION_SUMMARY.md']):
-                    return
-                # For README.md: only include those nested inside a quest subdirectory of a
-                # binary level directory (e.g. 0000/bashcrawl/README.md).
-                # Skip level-dir READMEs (0000/README.md) and section/root READMEs (tools/README.md).
-                if md_file.name == 'README.md':
-                    parent = md_file.parent
-                    grandparent = parent.parent
-                    # Allow only when: parent is NOT a level dir AND grandparent IS a level dir
-                    if re.match(r'^[01]{4}$', parent.name) or not re.match(r'^[01]{4}$', grandparent.name):
-                        return
-                
-                frontmatter, body = self.extract_frontmatter(md_file)
-                
-                if not frontmatter:
-                    self.warnings.append(f"No frontmatter found in {md_file}")
-                    return
-                
-                # Store quest data
-                permalink = frontmatter.get('permalink', str(md_file))
-                self.quests[permalink] = {
-                    'file_path': md_file,
-                    'frontmatter': frontmatter,
-                    'body': body
-                }
-                
-                self.stats['total_quests'] += 1
-                
-                # Track quest status (default false: published unless explicitly drafted)
-                if frontmatter.get('draft', False):
-                    self.stats['draft_quests'] += 1
-                
-                if '🔮' in body or 'Placeholder' in body:
-                    self.stats['placeholder_quests'] += 1
-                else:
-                    self.stats['complete_quests'] += 1
-                    
-            except (OSError, PermissionError) as e:
-                print_warn(f"Skipping file {md_file}: {e}")
-        
-        try:
-            # Try recursive scan first
-            for md_file in self.quest_dir.rglob('*.md'):
-                process_quest_file(md_file)
-        except (OSError, PermissionError, FileNotFoundError) as e:
-            print_error(f"Error during recursive scan: {e}")
-            print_info("Falling back to manual directory traversal...")
-            
-            # Fallback: manually traverse directories
-            def scan_directory(directory):
-                """Recursively scan a directory, skipping problematic paths"""
-                try:
-                    for item in directory.iterdir():
-                        if item.is_file() and item.suffix == '.md':
-                            process_quest_file(item)
-                        elif item.is_dir() and item.name not in ['templates', '__pycache__', '.git']:
-                            # Recursively scan subdirectories
-                            scan_directory(item)
-                except (OSError, PermissionError) as e:
-                    print_warn(f"Skipping directory {directory}: {e}")
-            
-            scan_directory(self.quest_dir)
-        
-        print_success(f"Found {self.stats['total_quests']} quests")
-    
-    def validate_frontmatter(self):
-        """Validate required frontmatter fields."""
-        print_info("Validating frontmatter...")
-        
-        for permalink, quest_data in self.quests.items():
-            frontmatter = quest_data['frontmatter']
-            file_path = quest_data['file_path']
-            
-            # Check required fields
-            missing_fields = []
-            for field in self.required_fields:
-                if field not in frontmatter:
-                    missing_fields.append(field)
-            
-            if missing_fields:
-                self.errors.append(
-                    f"{file_path}: Missing required fields: {', '.join(missing_fields)}"
-                )
-            
-            # Validate level format (should be 4 binary digits)
-            level = frontmatter.get('level', '')
-            if level and not re.match(r'^[01]{4}$', str(level)):
-                self.warnings.append(
-                    f"{file_path}: Invalid level format '{level}' (should be 4 binary digits)"
-                )
-            
-            # Validate difficulty format
-            difficulty = frontmatter.get('difficulty', '')
-            valid_difficulties = ['🟢 Easy', '🟡 Medium', '🔴 Hard', '⚔️ Epic']
-            if difficulty and difficulty not in valid_difficulties:
-                self.warnings.append(
-                    f"{file_path}: Invalid difficulty '{difficulty}'"
-                )
-            
-            # Validate quest_type
-            quest_type = frontmatter.get('quest_type', '')
-            valid_types = ['main_quest', 'side_quest', 'bonus_quest', 'epic_quest']
-            if quest_type and quest_type not in valid_types:
-                self.warnings.append(
-                    f"{file_path}: Invalid quest_type '{quest_type}'"
-                )
-    
-    @staticmethod
-    def _strip_planned_marker(value):
-        """Strip a trailing ``# planned quest`` (or ``# planned``) inline marker.
 
-        Authors may suffix a dependency URL with ``# planned quest`` to declare
-        an intentional forward reference to a quest that has not yet been
-        authored. The marker is documented in
-        ``.github/instructions/quest.instructions.md`` and must be ignored by
-        validation. Returns (clean_value, is_planned).
+    # ── discovery ────────────────────────────────────────────────────────────
+
+    def scan_quests(self):
+        """Build the node set from quest-tree files that carry a permalink.
+
+        Node set matches the network *builder* (``build-quest-network.py``):
+        skip templates/docs/inventory + meta files, include everything else that
+        has a permalink. That way the validator checks the same graph the site
+        ships, not a different one.
         """
-        if not isinstance(value, str):
-            return value, False
-        stripped = value.strip()
-        match = re.match(r'^(.*?)\s*#\s*planned(?:\s+quest)?\s*$', stripped, re.IGNORECASE)
-        if match:
-            return match.group(1).strip(), True
-        return stripped, False
+        print_info("Scanning quest files...")
+        for path in quest_lib.iter_quest_files(
+            self.quest_dir, skip_subdirs=reg.SKIP_SUBDIRS, include_index_readmes=True
+        ):
+            doc = quest_lib.read_quest(path)
+            if doc.fm_error:
+                self.errors.append(f"{doc.rel_path}: invalid frontmatter — {doc.fm_error}")
+                continue
+            permalink = doc.permalink
+            if not permalink:
+                # No permalink → invisible to the graph. Warn so it isn't a
+                # silent dead end (a quest nobody can link to).
+                self.warnings.append(f"{doc.rel_path}: no permalink — excluded from the quest network")
+                continue
+            node_id = _norm_link(permalink)
+            if node_id in self.nodes:
+                other = self.nodes[node_id]["doc"].rel_path
+                self.errors.append(
+                    f"Duplicate permalink {node_id!r}: {doc.rel_path} and {other} "
+                    f"resolve to the same node (one will silently overwrite the other)"
+                )
+                self.stats["duplicate_permalinks"] += 1
+                continue
+            self.nodes[node_id] = {"doc": doc, "frontmatter": doc.fm}
+            self.stats["total_quests"] += 1
+            if doc.is_draft():
+                self.stats["draft_quests"] += 1
+            if doc.has_placeholder_marker():
+                self.stats["placeholder_quests"] += 1
+            else:
+                self.stats["complete_quests"] += 1
+        print_success(f"Found {self.stats['total_quests']} quest nodes")
+
+    # ── frontmatter (graph-relevant only; tier 1 owns the full field gate) ────
+
+    def validate_frontmatter(self):
+        """Validate only the controlled-vocabulary fields the graph depends on.
+
+        The full required-field gate (with _config.yml default awareness) lives
+        in tier 1; duplicating it here would either drift or false-fail on
+        config-supplied fields. We validate values against the registry enums
+        (warnings) and flag retired fields.
+        """
+        print_info("Validating controlled vocabularies...")
+        for node_id, data in self.nodes.items():
+            fm = data["frontmatter"]
+            rel = data["doc"].rel_path
+
+            level = str(fm.get("level", ""))
+            if level and not reg.LEVEL_RE.match(level):
+                self.warnings.append(f"{rel}: invalid level '{level}' (expected 4-bit binary)")
+
+            difficulty = fm.get("difficulty", "")
+            if difficulty and difficulty not in reg.DIFFICULTIES:
+                self.warnings.append(
+                    f"{rel}: invalid difficulty '{difficulty}' (expected one of {reg.DIFFICULTIES})"
+                )
+
+            quest_type = fm.get("quest_type", "")
+            if quest_type and quest_type not in reg.QUEST_TYPES:
+                self.warnings.append(
+                    f"{rel}: invalid quest_type '{quest_type}' (expected one of {reg.QUEST_TYPES})"
+                )
+
+            # Flag retired fields rather than silently reading them. The
+            # normalizer (make quest-normalize) migrates + strips these.
+            present_retired = [f for f in reg.RETIRED_FIELDS if f in fm]
+            if present_retired:
+                self.stats["retired_fields"] += 1
+                self.warnings.append(
+                    f"{rel}: carries retired field(s) {present_retired} — run `make quest-normalize`"
+                )
+
+            # quest_dependencies buckets must be lists of permalinks. A scalar
+            # (e.g. `required_quests: 42`) is a schema error; warn once per file
+            # (the edge iterator tolerates it silently to stay crash-free).
+            deps = fm.get("quest_dependencies")
+            if isinstance(deps, dict):
+                for kind in _DEP_KINDS:
+                    val = deps.get(kind)
+                    if val is not None and not isinstance(val, (list, tuple, str)):
+                        self.warnings.append(
+                            f"{rel}: quest_dependencies.{kind} is "
+                            f"{type(val).__name__}, expected a list of permalinks")
+            elif deps is not None and not isinstance(deps, dict):
+                self.warnings.append(
+                    f"{rel}: quest_dependencies is {type(deps).__name__}, expected a mapping")
+
+    # ── dependency edges ─────────────────────────────────────────────────────
+
+    def _iter_edges(self, fm: dict, rel: str = ""):
+        """Yield (dep_kind, clean_target, is_planned) for each dependency edge.
+
+        Purely defensive: a scalar target is wrapped; anything that is neither a
+        string nor a list (e.g. ``required_quests: 42``) is silently skipped so a
+        malformed file can't raise out of the import-safe entry point. The
+        once-per-file schema warning is emitted by ``validate_frontmatter`` —
+        not here, since this is called by four checks per node.
+        """
+        deps = fm.get("quest_dependencies") or {}
+        if not isinstance(deps, dict):
+            return
+        for kind in _DEP_KINDS:
+            targets = deps.get(kind) or []
+            if isinstance(targets, str):
+                targets = [targets]
+            elif not isinstance(targets, (list, tuple)):
+                continue
+            for raw in targets:
+                clean, planned = _strip_planned_marker(raw)
+                if clean:
+                    yield kind, _norm_link(clean) if not planned else clean, planned
 
     def validate_dependencies(self):
-        """Validate quest dependencies and relationships."""
+        """Every required/recommended/unlocks target must resolve to a node."""
         print_info("Validating quest dependencies...")
-        
-        for permalink, quest_data in self.quests.items():
-            frontmatter = quest_data['frontmatter']
-            file_path = quest_data['file_path']
-            
-            # Check quest_dependencies
-            dependencies = frontmatter.get('quest_dependencies', {})
-            
-            for dep_type in ['required_quests', 'recommended_quests', 'unlocks_quests']:
-                dep_list = dependencies.get(dep_type, [])
-                for raw in dep_list:
-                    dep_permalink, planned = self._strip_planned_marker(raw)
-                    if planned or not dep_permalink:
-                        continue
-                    if dep_permalink not in self.quests:
-                        self.errors.append(
-                            f"{file_path}: Dependency not found: {dep_permalink} ({dep_type})"
-                        )
-                        self.stats['broken_dependencies'] += 1
-            
-            # Check quest_relationships
-            relationships = frontmatter.get('quest_relationships', {})
-            
-            for rel_type in ['parent_quest', 'child_quests', 'parallel_quests', 'sequel_quests']:
-                rel_data = relationships.get(rel_type)
-                
-                if rel_data is None:
+        for node_id, data in self.nodes.items():
+            rel = data["doc"].rel_path
+            for kind, target, planned in self._iter_edges(data["frontmatter"], rel):
+                if planned:
                     continue
-                
-                # Handle both single value and list
-                rel_list = rel_data if isinstance(rel_data, list) else [rel_data]
-                
-                for raw in rel_list:
-                    rel_permalink, planned = self._strip_planned_marker(raw)
-                    if planned or not rel_permalink:
-                        continue
-                    if rel_permalink not in self.quests:
-                        self.warnings.append(
-                            f"{file_path}: Related quest not found: {rel_permalink} ({rel_type})"
-                        )
-    
-    def detect_circular_dependencies(self):
-        """Detect circular dependencies in quest progression."""
-        print_info("Checking for circular dependencies...")
-        
-        def has_cycle(quest_permalink, visited, stack):
-            visited.add(quest_permalink)
-            stack.add(quest_permalink)
-            
-            quest_data = self.quests.get(quest_permalink, {})
-            dependencies = quest_data.get('frontmatter', {}).get('quest_dependencies', {})
+                if target not in self.nodes:
+                    self.errors.append(f"{rel}: dependency not found: {target} ({kind})")
+                    self.stats["broken_dependencies"] += 1
 
-            # Only required_quests form the true prerequisite graph; a cycle there
-            # means a learner can never start. recommended_quests are lateral
-            # "you might also like" links and may legitimately be mutual.
-            for dep_list_key in ['required_quests']:
-                for raw in dependencies.get(dep_list_key, []):
-                    dep, planned = self._strip_planned_marker(raw)
-                    if planned or not dep:
-                        continue
-                    if dep in self.quests:
-                        if dep not in visited:
-                            if has_cycle(dep, visited, stack):
-                                return True
-                        elif dep in stack:
-                            self.errors.append(f"Circular dependency detected: {quest_permalink} -> {dep}")
-                            return True
-            
-            stack.remove(quest_permalink)
-            return False
-        
-        visited = set()
-        for permalink in self.quests:
-            if permalink not in visited:
-                has_cycle(permalink, visited, set())
-    
-    def find_orphaned_quests(self):
-        """Find quests that are not referenced by any other quest."""
-        print_info("Finding orphaned quests...")
-        
-        referenced_quests = set()
-        
-        for quest_data in self.quests.values():
-            frontmatter = quest_data['frontmatter']
-            
-            def add_clean(value):
-                permalink, planned = self._strip_planned_marker(value)
-                if not planned and permalink:
-                    referenced_quests.add(permalink)
-            
-            # Collect all references
-            dependencies = frontmatter.get('quest_dependencies', {})
-            for dep_list in dependencies.values():
-                if isinstance(dep_list, list):
-                    for raw in dep_list:
-                        add_clean(raw)
-            
-            relationships = frontmatter.get('quest_relationships', {})
-            for rel_data in relationships.values():
-                if rel_data:
-                    if isinstance(rel_data, list):
-                        for raw in rel_data:
-                            add_clean(raw)
-                    else:
-                        add_clean(rel_data)
-        
-        # Find orphans (excluding level 0000 quests which are entry points)
-        for permalink, quest_data in self.quests.items():
-            level = quest_data['frontmatter'].get('level', '')
-            
-            # Skip entry-level quests (0000) as they're expected to be starting points
-            if level == '0000':
+    def validate_prerequisite_monotonicity(self):
+        """A quest's required prerequisites should not live at a *higher* level
+        than the quest itself (you can't require a harder quest to start an
+        easier one). Reported as warnings — some cross-tier prerequisites are
+        intentional, but the common case is an authoring slip."""
+        print_info("Checking prerequisite level monotonicity...")
+        for node_id, data in self.nodes.items():
+            fm = data["frontmatter"]
+            rel = data["doc"].rel_path
+            level = str(fm.get("level", ""))
+            if not reg.LEVEL_RE.match(level):
                 continue
-            
-            if permalink not in referenced_quests:
-                self.warnings.append(f"Orphaned quest (not referenced): {permalink}")
-                self.stats['orphaned_quests'] += 1
-    
+            my_rank = reg.LEVELS.get(level, {}).get("decimal")
+            if my_rank is None:
+                continue
+            for kind, target, planned in self._iter_edges(fm, rel):
+                if planned or kind != _PREREQ_KEY or target not in self.nodes:
+                    continue
+                tgt_level = str(self.nodes[target]["frontmatter"].get("level", ""))
+                tgt_rank = reg.LEVELS.get(tgt_level, {}).get("decimal")
+                if tgt_rank is not None and tgt_rank > my_rank:
+                    self.warnings.append(
+                        f"{rel}: required prerequisite {target} is at a higher level "
+                        f"({tgt_level} > {level}) — learner can't reach it first"
+                    )
+
+    def detect_circular_dependencies(self):
+        """Detect cycles in the *required* prerequisite graph (a cycle there
+        means a learner can never start). recommended/unlocks are lateral and
+        may legitimately be mutual, so they're excluded."""
+        print_info("Checking for circular dependencies...")
+
+        def required_targets(node_id):
+            data = self.nodes.get(node_id, {})
+            fm = data.get("frontmatter", {})
+            rel = data.get("doc").rel_path if data.get("doc") else node_id
+            for kind, target, planned in self._iter_edges(fm, rel):
+                if kind == _PREREQ_KEY and not planned and target in self.nodes:
+                    yield target
+
+        visited = set()
+
+        def has_cycle(node_id, stack):
+            visited.add(node_id)
+            stack.add(node_id)
+            for dep in required_targets(node_id):
+                if dep not in visited:
+                    if has_cycle(dep, stack):
+                        return True
+                elif dep in stack:
+                    self.errors.append(f"Circular dependency detected: {node_id} -> {dep}")
+                    return True
+            stack.discard(node_id)
+            return False
+
+        for node_id in self.nodes:
+            if node_id not in visited:
+                has_cycle(node_id, set())
+
+    def find_orphaned_quests(self):
+        """Quests referenced by no other quest's dependencies (warnings).
+
+        Entry-level (0000) quests are expected starting points and excluded.
+        Retired relationship fields are intentionally NOT consulted.
+        """
+        print_info("Finding orphaned quests...")
+        referenced = set()
+        for data in self.nodes.values():
+            for kind, target, planned in self._iter_edges(data["frontmatter"]):
+                if not planned:
+                    referenced.add(target)
+        for node_id, data in self.nodes.items():
+            if str(data["frontmatter"].get("level", "")) == "0000":
+                continue
+            if node_id not in referenced:
+                self.warnings.append(f"Orphaned quest (not referenced): {node_id}")
+                self.stats["orphaned_quests"] += 1
+
+    # ── shipped artifact (optional) ──────────────────────────────────────────
+
+    def validate_network_json(self):
+        """Validate the committed quest-network.json: unique node ids and every
+        edge endpoint resolves to a node. A bad graph won't fail the Jekyll
+        build, so this is the only thing that catches a shipped dangling edge."""
+        if not self.network_json:
+            return
+        if not self.network_json.exists():
+            self.warnings.append(f"network JSON not found (skipped): {self.network_json}")
+            return
+        print_info(f"Validating shipped graph: {self.network_json}")
+        try:
+            graph = json.loads(self.network_json.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as e:
+            self.errors.append(f"{self.network_json}: unreadable/invalid JSON — {e}")
+            return
+        node_ids = set()
+        for n in graph.get("nodes", []):
+            nid = n.get("id")
+            if nid in node_ids:
+                self.errors.append(f"network JSON: duplicate node id {nid!r}")
+            node_ids.add(nid)
+        # A node-set drift between the live scan and the shipped graph means the
+        # JSON is stale — surface it (the CI freshness gate is the hard stop).
+        live_ids = set(self.nodes)
+        if node_ids and live_ids and node_ids != live_ids:
+            missing = len(live_ids - node_ids)
+            extra = len(node_ids - live_ids)
+            self.warnings.append(
+                f"network JSON node set differs from live scan "
+                f"({missing} missing, {extra} stale) — run `make quest-build-network`"
+            )
+        # Dangling edges are WARNINGS here: the builder intentionally emits edges
+        # for `# planned quest` forward-references whose targets aren't nodes yet.
+        # The authoritative, planned-aware broken-dependency ERROR check is
+        # validate_dependencies() above (reads the markdown, not the artifact).
+        for e in graph.get("edges", []):
+            for end in ("source", "target"):
+                ref = e.get(end)
+                if ref and ref not in node_ids:
+                    self.warnings.append(
+                        f"network JSON: edge {end} {ref!r} ({e.get('kind','?')}) has no matching node "
+                        f"(planned forward-reference, or stale graph)"
+                    )
+                    self.stats["dangling_edges"] += 1
+
+    # ── report ───────────────────────────────────────────────────────────────
+
     def generate_report(self):
-        """Generate validation report."""
         print()
         print("=" * 80)
         print("QUEST NETWORK VALIDATION REPORT")
         print("=" * 80)
         print()
-        
-        # Statistics
-        print("📊 Quest Statistics:")
-        print(f"  Total Quests:       {self.stats['total_quests']}")
-        print(f"  Complete Quests:    {self.stats['complete_quests']}")
-        print(f"  Placeholder Quests: {self.stats['placeholder_quests']}")
-        print(f"  Draft Quests:       {self.stats['draft_quests']}")
-        print(f"  Orphaned Quests:    {self.stats['orphaned_quests']}")
-        print(f"  Broken Dependencies: {self.stats['broken_dependencies']}")
+        print("📊 Quest Network Statistics:")
+        print(f"  Total Nodes:          {self.stats['total_quests']}")
+        print(f"  Complete:             {self.stats['complete_quests']}")
+        print(f"  Placeholder:          {self.stats['placeholder_quests']}")
+        print(f"  Draft:                {self.stats['draft_quests']}")
+        print(f"  Orphaned:             {self.stats['orphaned_quests']}")
+        print(f"  Broken Dependencies:  {self.stats['broken_dependencies']}")
+        print(f"  Duplicate Permalinks: {self.stats['duplicate_permalinks']}")
+        print(f"  Dangling Edges (JSON):{self.stats['dangling_edges']}")
+        print(f"  Files w/ Retired FM:  {self.stats['retired_fields']}")
         print()
-        
-        # Errors
         if self.errors:
             print_error(f"❌ {len(self.errors)} Error(s) Found:")
-            for error in self.errors:
-                print(f"  • {error}")
+            for e in self.errors:
+                print(f"  • {e}")
             print()
         else:
             print_success("✅ No errors found!")
             print()
-        
-        # Warnings
         if self.warnings:
             print_warning(f"⚠️  {len(self.warnings)} Warning(s):")
-            for warning in self.warnings:
-                print(f"  • {warning}")
+            for w in self.warnings:
+                print(f"  • {w}")
             print()
         else:
             print_success("✅ No warnings!")
             print()
-        
-        # Overall result
         print("=" * 80)
         if not self.errors:
             print_success("VALIDATION PASSED ✅")
             return 0
-        else:
-            print_error("VALIDATION FAILED ❌")
-            return 1
-    
+        print_error("VALIDATION FAILED ❌")
+        return 1
+
     def run(self):
-        """Run all validation checks."""
         self.scan_quests()
         self.validate_frontmatter()
         self.validate_dependencies()
+        self.validate_prerequisite_monotonicity()
         self.detect_circular_dependencies()
         self.find_orphaned_quests()
+        self.validate_network_json()
         return self.generate_report()
 
-def main():
-    """Main entry point."""
-    import argparse
 
+def run_network_validation(quest_dir, network_json=None, strict=False, quiet=True) -> dict:
+    """Import-friendly entry point for the unified orchestrator.
+
+    Returns a result dict: {stats, errors, warnings, passed}. ``passed`` is
+    False if there are errors, or (when ``strict``) any warnings. ``quiet``
+    suppresses the per-check INFO chatter so the orchestrator owns all output.
+    """
+    import contextlib
+    import io
+    validator = QuestNetworkValidator(str(quest_dir), network_json=network_json)
+    sink = io.StringIO() if quiet else sys.stdout
+    with contextlib.redirect_stdout(sink):
+        # Run checks without the console report (orchestrator renders its own).
+        validator.scan_quests()
+        validator.validate_frontmatter()
+        validator.validate_dependencies()
+        validator.validate_prerequisite_monotonicity()
+        validator.detect_circular_dependencies()
+        validator.find_orphaned_quests()
+        validator.validate_network_json()
+    passed = not validator.errors and (not strict or not validator.warnings)
+    return {
+        "stats": validator.stats,
+        "errors": validator.errors,
+        "warnings": validator.warnings,
+        "passed": passed,
+    }
+
+
+def main():
     parser = argparse.ArgumentParser(
-        description='IT-Journey Quest Network Validator',
+        description="IT-Journey Quest Network Validator",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument(
-        '-d', '--directory',
-        help='Quest directory (default: auto-detect from script location)',
-    )
-    parser.add_argument(
-        '--json',
-        metavar='FILE',
-        help='Write validation results as JSON to FILE',
-    )
-    parser.add_argument(
-        '--strict',
-        action='store_true',
-        help='Exit non-zero when warnings exist (in addition to errors)',
-    )
+    parser.add_argument("-d", "--directory",
+                        help="Quest directory (default: auto-detect pages/_quests)")
+    parser.add_argument("--network-json", metavar="FILE",
+                        help="Also validate this committed quest-network.json "
+                             "(default: auto-detect assets/data/quest-network.json)")
+    parser.add_argument("--no-network-json", action="store_true",
+                        help="Skip validating the shipped quest-network.json")
+    parser.add_argument("--json", metavar="FILE", help="Write results as JSON to FILE")
+    parser.add_argument("--strict", action="store_true",
+                        help="Exit non-zero when warnings exist (in addition to errors)")
     args = parser.parse_args()
 
-    # Get quest directory
     if args.directory:
         quest_dir = Path(args.directory)
     else:
-        script_dir = Path(__file__).parent
-        project_root = script_dir.parent.parent
-        quest_dir = project_root / 'pages' / '_quests'
-
+        quest_dir = _HERE.parents[1] / "pages" / "_quests"
     if not quest_dir.exists():
         print_error(f"Quest directory not found: {quest_dir}")
         return 1
 
+    network_json = None
+    if not args.no_network_json:
+        if args.network_json:
+            network_json = args.network_json
+        else:
+            candidate = _HERE.parents[1] / "assets" / "data" / "quest-network.json"
+            network_json = str(candidate) if candidate.exists() else None
+
     print_info(f"Quest directory: {quest_dir}")
+    if network_json:
+        print_info(f"Network JSON:    {network_json}")
     print()
 
-    # Run validator
-    validator = QuestValidator(str(quest_dir))
+    validator = QuestNetworkValidator(str(quest_dir), network_json=network_json)
     exit_code = validator.run()
 
-    # Write JSON report if requested
     if args.json:
-        import json
         report = {
-            'stats': validator.stats,
-            'errors': validator.errors,
-            'warnings': validator.warnings,
-            'passed': exit_code == 0,
+            "stats": validator.stats,
+            "errors": validator.errors,
+            "warnings": validator.warnings,
+            "passed": exit_code == 0,
         }
-        with open(args.json, 'w') as f:
-            json.dump(report, f, indent=2, default=str)
+        Path(args.json).write_text(json.dumps(report, indent=2, default=str), encoding="utf-8")
         print_success(f"Network report written to {args.json}")
 
-    # --strict: treat warnings as failure
     if args.strict and validator.warnings:
         return 1
-
     return exit_code
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     sys.exit(main())

--- a/test/quest-validator/agentic/prompts.py
+++ b/test/quest-validator/agentic/prompts.py
@@ -12,8 +12,21 @@ Two modes:
 from __future__ import annotations
 
 import json
+import sys
+from pathlib import Path
 
 from . import schema
+
+# Reuse the shared deterministic snippet extractor (single source of truth for
+# "what is a runnable snippet"). loader already puts scripts/quest on the path,
+# but insert defensively so prompts can be imported standalone.
+_QUEST_DIR = Path(__file__).resolve().parents[3] / "scripts" / "quest"
+if str(_QUEST_DIR) not in sys.path:
+    sys.path.insert(0, str(_QUEST_DIR))
+try:
+    import quest_lib  # noqa: E402
+except Exception:  # pragma: no cover - prompts still work without snippet inventory
+    quest_lib = None
 
 _DIM_BLOCK = "\n".join(
     f"  - {key} ({schema.DIM_LABELS[key]}, weight {int(schema.WEIGHTS[key] * 100)}%): {schema.DIM_GUIDANCE[key]}"
@@ -35,15 +48,26 @@ def build_system_prompt(mode: str) -> str:
     schema_json = json.dumps(schema.build_json_schema(), indent=2)
     if mode == "execute":
         exec_rules = (
-            "EXECUTION POLICY (execute mode):\n"
-            "- You are in a disposable sandbox directory. You MAY run commands to verify the quest.\n"
-            "- Run ONLY safe, self-contained commands: creating/editing files inside the sandbox, "
-            "`git init`, language REPLs/one-liners, local builds, package help/version checks.\n"
-            "- Do NOT: delete or modify anything outside the sandbox, run `sudo`, reformat disks, "
-            "`rm -rf` outside cwd, send network requests that mutate remote state, or use real credentials.\n"
-            "- For commands that are destructive, require secrets/paid services, take a very long time, "
-            "or need hardware you lack: do NOT run them — mark them `reasoned` and judge correctness statically.\n"
-            "- Record each command you tried in `commands` with an honest `passed`/`failed`/`skipped`/`reasoned` status.\n"
+            "EXECUTION POLICY (execute mode — you actually RUN the quest's code):\n"
+            "- You are in a disposable, isolated sandbox directory. Your PRIMARY job is to "
+            "WORK THROUGH THE QUEST AS A LEARNER WOULD and ACTUALLY RUN its code snippets, in order, "
+            "to verify they work — not just read them.\n"
+            "- Go snippet by snippet. For EACH runnable code block (shell, python, node, ruby, sql, etc.): "
+            "actually execute it in the sandbox, observe the real output, and record the outcome. Carry state "
+            "forward between snippets (files you create, dirs you cd into) the way a learner following the quest would.\n"
+            "- Run ONLY safe, self-contained commands: creating/editing files inside the sandbox, `git init`, "
+            "language REPLs/one-liners, local builds, package help/version checks, installs into the sandbox.\n"
+            "- Do NOT: delete or modify anything outside the sandbox, run `sudo`, reformat disks, `rm -rf` outside "
+            "cwd, send network requests that mutate remote state, or use real credentials.\n"
+            "- A snippet is legitimately NOT runnable here if it: is destructive, needs secrets/paid services or "
+            "specific hardware/OS you lack, needs a tool that isn't installed and can't be safely installed, or "
+            "takes very long. For those, mark `skipped` (tool/OS/secret missing) or `reasoned` (judged statically) "
+            "with the reason — do NOT force it.\n"
+            "- Record EVERY snippet you encountered in `commands`, in quest order, each with an honest "
+            "`passed` (ran, worked) / `failed` (ran, broke) / `skipped` (couldn't safely run) / `reasoned` "
+            "(judged without running) status and a `detail` (the real error/output, or why skipped).\n"
+            "- A snippet that errors when a learner runs it as written is a `failed` command and should pull down "
+            "the `commands_work` dimension — this is the single most valuable signal you produce.\n"
             "- Set `executed: true` in your verdict.\n"
         )
     else:
@@ -69,12 +93,49 @@ def build_system_prompt(mode: str) -> str:
     )
 
 
-def build_user_prompt(quest, quest_file_name: str = "QUEST.md") -> str:
+def _snippet_block(quest, mode: str) -> str:
+    """A deterministic inventory of the quest's code snippets, so the agent has a
+    concrete checklist of what to run (execute) or reason about (review)."""
+    if quest_lib is None:
+        return ""
+    try:
+        summary = quest_lib.snippet_summary(quest.body)
+    except Exception:
+        return ""
+    if not summary["total"]:
+        return "\nThis quest contains no fenced code blocks — assess its instructions and concepts.\n"
+    by_lang = ", ".join(f"{k}×{v}" for k, v in summary["by_lang"].items())
+    verb = "RUN each runnable one in the sandbox" if mode == "execute" else "judge whether each WOULD run"
+    return (
+        f"\nCode snippets (deterministic count): {summary['total']} fenced block(s), "
+        f"{summary['runnable']} runnable [{by_lang}].\n"
+        f"Treat these as a checklist — {verb}, and record every one in `commands` in quest order.\n"
+    )
+
+
+def build_user_prompt(quest, quest_file_name: str = "QUEST.md", mode: str = "review") -> str:
     meta = quest.to_meta()
     objectives = quest.objectives()
     obj_block = ""
     if objectives:
         obj_block = "\nStated objectives:\n" + "\n".join(f"  - {o}" for o in objectives)
+    snippet_block = _snippet_block(quest, mode)
+    if mode == "execute":
+        steps = (
+            f"1. Read ./{quest_file_name} in full.\n"
+            f"2. Work through it as a learner would, in order, ACTUALLY RUNNING each runnable code "
+            f"snippet in the sandbox and observing the real result (carry state forward between steps).\n"
+            f"3. Evaluate it against the dimensions from the evidence you gathered by running it.\n"
+            f"4. Record every snippet in `commands` (passed/failed/skipped/reasoned + detail), then emit "
+            f"the single JSON verdict block per the schema. No prose after it."
+        )
+    else:
+        steps = (
+            f"1. Read ./{quest_file_name} in full.\n"
+            f"2. Walk through it as a learner would, in order.\n"
+            f"3. Evaluate it against the dimensions, gathering concrete evidence.\n"
+            f"4. Emit the single JSON verdict block per the schema. No prose after it."
+        )
     return (
         f"Review the quest in `./{quest_file_name}` (in your current directory).\n\n"
         f"Quest metadata:\n"
@@ -82,10 +143,8 @@ def build_user_prompt(quest, quest_file_name: str = "QUEST.md") -> str:
         f"  - Level: {meta['level']}  ({meta['theme']})\n"
         f"  - Difficulty: {meta['difficulty'] or 'unspecified'}\n"
         f"  - Type: {meta['quest_type'] or 'unspecified'}\n"
-        f"{obj_block}\n\n"
+        f"{obj_block}\n"
+        f"{snippet_block}\n"
         f"Steps:\n"
-        f"1. Read ./{quest_file_name} in full.\n"
-        f"2. Walk through it as a learner would, in order.\n"
-        f"3. Evaluate it against the dimensions, gathering concrete evidence.\n"
-        f"4. Emit the single JSON verdict block per the schema. No prose after it."
+        f"{steps}"
     )

--- a/test/quest-validator/agentic/report.py
+++ b/test/quest-validator/agentic/report.py
@@ -19,6 +19,7 @@ def aggregate(results: List[dict]) -> dict:
     avg = round(sum(r["overall"] for r in scored) / len(scored), 1) if scored else 0.0
     cost = sum((r.get("meta", {}).get("cost_usd") or 0.0) for r in results)
     return {
+        "schema_version": schema.SCHEMA_VERSION,
         "total": len(results), "scored": len(scored), "errored": len(errored),
         "average": avg, "counts": counts, "cost_usd": round(cost, 4),
         "results": results,
@@ -44,6 +45,14 @@ def render_console(agg: dict, verbose: bool = False) -> str:
             for k in schema.DIM_KEYS
         )
         lines.append(f"      {dim_bits}   executed={v.get('executed')}")
+        snip = r.get("snippets") or {}
+        if snip.get("available_runnable") is not None:
+            ran, runnable = snip.get("ran", 0), snip.get("available_runnable", 0)
+            lines.append(
+                f"      snippets: ran {ran}/{runnable} runnable "
+                f"({snip.get('passed',0)} ok, {snip.get('failed',0)} failed, "
+                f"{snip.get('skipped',0)} skipped, {snip.get('reasoned',0)} reasoned)"
+            )
         if v.get("summary"):
             lines.append(f"      {v['summary']}")
         recs = v.get("recommendations") or []
@@ -81,7 +90,7 @@ def render_markdown(agg: dict, title: str = "Agentic Quest Review") -> str:
                f"avg **{agg['average']}%**"
                + (f" · ~${agg['cost_usd']}" if agg["cost_usd"] else ""))
     out.append("")
-    out.append("| | Score | Quest | Level | Executed | Summary |")
+    out.append("| | Score | Quest | Level | Snippets run | Summary |")
     out.append("|---|--:|---|---|:-:|---|")
     for r in agg["results"]:
         m = r["quest"]
@@ -91,8 +100,15 @@ def render_markdown(agg: dict, title: str = "Agentic Quest Review") -> str:
             continue
         v = r.get("verdict_obj") or {}
         summ = (v.get("summary") or "").replace("|", "\\|").replace("\n", " ")
+        snip = r.get("snippets") or {}
+        if snip.get("available_runnable"):
+            run_cell = f"{snip.get('ran',0)}/{snip['available_runnable']}"
+            if snip.get("failed"):
+                run_cell += f" ({snip['failed']}✗)"
+        else:
+            run_cell = "yes" if v.get("executed") else "no"
         out.append(f"| {emoji} | {r.get('overall',0):.0f} | {m['title']} | {m['level']} | "
-                   f"{'yes' if v.get('executed') else 'no'} | {summ} |")
+                   f"{run_cell} | {summ} |")
     out.append("")
     # Detailed recommendations for non-passing quests.
     flagged = [r for r in agg["results"]

--- a/test/quest-validator/agentic/runner.py
+++ b/test/quest-validator/agentic/runner.py
@@ -19,17 +19,29 @@ command + prompts without invoking anything.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 import time
 from pathlib import Path
 from typing import List, Optional
 
 from . import prompts, schema
+
+# Shared deterministic snippet extractor (single source of truth for "runnable
+# snippet"), used to report how much of the quest's code the agent actually ran.
+_QUEST_DIR = Path(__file__).resolve().parents[3] / "scripts" / "quest"
+if str(_QUEST_DIR) not in sys.path:
+    sys.path.insert(0, str(_QUEST_DIR))
+try:
+    import quest_lib  # noqa: E402
+except Exception:  # pragma: no cover
+    quest_lib = None
 
 _FENCE_RE = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL)
 
@@ -54,13 +66,17 @@ class AuthError(RunnerError):
 def _looks_like_auth_failure(text: str) -> bool:
     t = (text or "").lower()
     return ("401" in t and "auth" in t) or "failed to authenticate" in t \
-        or "invalid authentication" in t or "invalid api key" in t
+        or "invalid authentication" in t or "invalid api key" in t \
+        or "invalid x-api-key" in t or "no credentials" in t \
+        or ("oauth" in t and "token" in t and ("expired" in t or "invalid" in t)) \
+        or "please run" in t and "login" in t
 
 
 class AgenticRunner:
     def __init__(self, mode: str = "review", model: Optional[str] = None,
                  timeout: int = 600, claude_bin: str = "claude",
-                 mock: bool = False, dry_run: bool = False, verbose: bool = False):
+                 mock: bool = False, dry_run: bool = False, verbose: bool = False,
+                 max_turns: int = 0):
         if mode not in ("review", "execute"):
             raise ValueError(f"mode must be 'review' or 'execute', got {mode!r}")
         self.mode = mode
@@ -70,6 +86,9 @@ class AgenticRunner:
         self.mock = mock
         self.dry_run = dry_run
         self.verbose = verbose
+        # Per-quest turn ceiling (0 = CLI default). Bounds runaway agent loops
+        # and is the cheapest cost governor: fewer turns ≈ less spend.
+        self.max_turns = max_turns
 
     # ---- public ---------------------------------------------------------
 
@@ -83,7 +102,7 @@ class AgenticRunner:
         try:
             (sandbox / "QUEST.md").write_text(quest.body, encoding="utf-8")
             system_prompt = prompts.build_system_prompt(self.mode)
-            user_prompt = prompts.build_user_prompt(quest)
+            user_prompt = prompts.build_user_prompt(quest, mode=self.mode)
             cmd = self._build_cmd(system_prompt, user_prompt)
 
             if self.dry_run:
@@ -125,6 +144,8 @@ class AgenticRunner:
                 "--allowedTools", "Read",
                 "--disallowedTools", "Bash", "Write", "Edit", "WebFetch", "WebSearch",
             ]
+        if self.max_turns and self.max_turns > 0:
+            cmd += ["--max-turns", str(self.max_turns)]
         if self.model:
             cmd += ["--model", self.model]
         return cmd
@@ -156,6 +177,17 @@ class AgenticRunner:
             raise RunnerError(f"claude exited {proc.returncode}: {tail}")
 
         envelope = self._parse_envelope(proc.stdout)
+        # The CLI signals failures (incl. the --max-turns cap) with is_error=true
+        # and a subtype, often WITH returncode 0. Surface it as a real error
+        # rather than letting it fall through to "couldn't parse a verdict" —
+        # otherwise the --max-turns governor's own trip is invisible.
+        err = self._error_from_envelope(envelope)
+        if err:
+            meta = {"mock": False, "cost_usd": envelope.get("total_cost_usd"),
+                    "turns": envelope.get("num_turns"),
+                    "session_id": envelope.get("session_id"), "duration_s": dur}
+            return self._finalize(quest, None, meta=meta, error=err,
+                                  raw=json.dumps(envelope)[:2000])
         verdict, raw = self._extract_verdict(envelope)
         meta = {
             "mock": False,
@@ -187,6 +219,17 @@ class AgenticRunner:
                     except json.JSONDecodeError:
                         continue
             raise RunnerError("claude stdout was not valid JSON")
+
+    @staticmethod
+    def _error_from_envelope(envelope: dict) -> Optional[str]:
+        """Return an error string if the CLI envelope signals a failure
+        (``is_error: true``, e.g. ``subtype: error_max_turns``), else None.
+        Pulled out as a pure function so the contract test can pin it."""
+        if not isinstance(envelope, dict) or not envelope.get("is_error"):
+            return None
+        subtype = envelope.get("subtype") or "error"
+        detail = str(envelope.get("result") or envelope.get("error") or "")[:200]
+        return f"agent run failed ({subtype}): {detail}"
 
     @classmethod
     def _extract_verdict(cls, envelope: dict):
@@ -235,7 +278,32 @@ class AgenticRunner:
         result["per_dimension"] = scored["per_dimension"]
         result["weight_covered"] = scored["weight_covered"]
         result["verdict"] = schema.verdict_label(scored["overall"])
+        result["snippets"] = self._snippet_coverage(quest, verdict)
         return result
+
+    @staticmethod
+    def _snippet_coverage(quest, verdict: dict) -> dict:
+        """Cross the deterministic snippet inventory with what the agent reported
+        running, so a report can show 'ran N/M runnable snippets'."""
+        total = runnable = None
+        if quest_lib is not None:
+            try:
+                s = quest_lib.snippet_summary(getattr(quest, "body", "") or "")
+                total, runnable = s["total"], s["runnable"]
+            except Exception:
+                pass
+        cmds = verdict.get("commands") or []
+        status = {"passed": 0, "failed": 0, "skipped": 0, "reasoned": 0}
+        for c in cmds:
+            st = (c.get("status") if isinstance(c, dict) else None)
+            if st in status:
+                status[st] += 1
+        return {
+            "available_total": total, "available_runnable": runnable,
+            "recorded": len(cmds), "ran": status["passed"] + status["failed"],
+            **status,
+            "executed": bool(verdict.get("executed")),
+        }
 
     # ---- mock ----------------------------------------------------------
 
@@ -244,18 +312,37 @@ class AgenticRunner:
         """Deterministic synthetic verdict derived from the quest text so the
         full pipeline (parse → score → report) can be tested offline."""
         body = quest.body or ""
-        # Cheap, deterministic signals — NOT a real assessment.
-        h = abs(hash((quest.slug, len(body)))) % 3
+        # Cheap, DETERMINISTIC signals — NOT a real assessment. Uses sha256 (not
+        # Python's salted hash()) so the same quest always yields the same mock
+        # verdict across processes — required for a reproducible offline pipeline
+        # test and the envelope contract test.
+        digest = hashlib.sha256(f"{quest.slug}:{len(body)}".encode("utf-8")).digest()
+        h = digest[0] % 3
         base = 4 if len(body) > 4000 else 3
         dims = {}
         for i, key in enumerate(schema.DIM_KEYS):
             s = max(0, min(schema.MAX_DIM, base + ((i + h) % 2)))
             dims[key] = {"score": s, "findings": [f"[mock] {key}: synthetic score {s} (offline pipeline test)."]}
+        # Snippet-aware synthetic commands so the coverage report is exercisable
+        # offline. Mock doesn't run anything, so each is `reasoned`.
+        commands = [{"command": "(mock) no commands run", "status": "reasoned",
+                     "detail": "Mock mode — pipeline test only."}]
+        if quest_lib is not None:
+            try:
+                snips = quest_lib.runnable_snippets(body)
+                if snips:
+                    commands = [
+                        {"command": (b.code.splitlines()[0][:80] if b.code.splitlines() else b.lang),
+                         "status": "reasoned",
+                         "detail": f"[mock] {b.lang} snippet at line {b.line} (not run in mock)."}
+                        for b in snips[:25]
+                    ]
+            except Exception:
+                pass
         return {
             "executed": False,
             "dimensions": dims,
-            "commands": [{"command": "(mock) no commands run", "status": "reasoned",
-                          "detail": "Mock mode — pipeline test only."}],
+            "commands": commands,
             "recommendations": ([] if base + h >= 5 else
                                 [{"priority": "low", "area": "mock",
                                   "suggestion": "Run without --mock for a real assessment."}]),

--- a/test/quest-validator/agentic/schema.py
+++ b/test/quest-validator/agentic/schema.py
@@ -32,6 +32,10 @@ WEIGHTS = {d[0]: d[2] for d in DIMENSIONS}
 DIM_GUIDANCE = {d[0]: d[3] for d in DIMENSIONS}
 MAX_DIM = 5  # each dimension scored 0..5
 
+# Verdict schema version. Bump when DIMENSIONS / weights / the JSON shape change
+# so persisted reports and the envelope contract test can detect a mismatch.
+SCHEMA_VERSION = "1.0.0"
+
 VERDICT_PASS, VERDICT_WARN, VERDICT_FAIL = "pass", "warn", "fail"
 VERDICT_EMOJI = {VERDICT_PASS: "✅", VERDICT_WARN: "⚠️", VERDICT_FAIL: "❌"}
 

--- a/test/quest-validator/agentic/test_envelope.py
+++ b/test/quest-validator/agentic/test_envelope.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""
+Offline contract test for the agentic validator's CLI-envelope handling.
+
+The agentic runner depends on the *shape* of what `claude -p --output-format
+json` prints and on `--json-schema` structured output. Those are undocumented
+and unpinned, so a CLI release could silently change them and break scoring
+without any test noticing — the failure mode the synthesis called out.
+
+This test pins the contract with NO network and NO `claude` process: it feeds
+the runner's pure parsing/scoring/mock functions every envelope shape we know
+the CLI can emit and asserts they're handled. Run it in CI before the agentic
+job so a CLI drift is caught as a red test, not a wrong score.
+
+    python3 test/quest-validator/agentic/test_envelope.py     # exit 0 = contract holds
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# Import the agentic package whether run as a file or a module.
+_PKG_DIR = Path(__file__).resolve().parent
+_QV_DIR = _PKG_DIR.parent
+if str(_QV_DIR) not in sys.path:
+    sys.path.insert(0, str(_QV_DIR))
+
+from agentic import runner, schema  # noqa: E402
+from agentic.runner import AgenticRunner, RunnerError  # noqa: E402
+
+_failures = []
+
+
+def check(name, cond):
+    print(("  ✅ " if cond else "  ❌ ") + name)
+    if not cond:
+        _failures.append(name)
+
+
+def expect_raises(name, fn):
+    try:
+        fn()
+        check(name, False)
+    except RunnerError:
+        check(name, True)
+    except Exception as e:  # wrong exception type
+        print(f"  ❌ {name} (raised {type(e).__name__}, expected RunnerError)")
+        _failures.append(name)
+
+
+class _StubQuest:
+    """Minimal Quest stand-in for the mock-determinism check."""
+    def __init__(self, slug, body):
+        self.slug = slug
+        self.body = body
+        self.title = slug
+        self.level = "0000"
+
+    def to_meta(self):
+        return {"path": f"{self.slug}.md", "title": self.title, "level": self.level,
+                "theme": "", "difficulty": "", "quest_type": "main_quest", "slug": self.slug}
+
+
+def test_parse_envelope():
+    print("\n_parse_envelope — stdout shapes the CLI can emit:")
+    # 1) Single JSON object (the common --output-format json case).
+    obj = AgenticRunner._parse_envelope(json.dumps({"result": "ok", "num_turns": 3}))
+    check("single JSON object", obj.get("num_turns") == 3)
+    # 2) Streamed JSON lines — last object line wins.
+    streamed = '{"type":"system"}\n{"type":"assistant"}\n{"result":"done","total_cost_usd":0.01}'
+    obj = AgenticRunner._parse_envelope(streamed)
+    check("streamed JSON lines → last object", obj.get("result") == "done")
+    # 3) Empty stdout → RunnerError.
+    expect_raises("empty stdout raises", lambda: AgenticRunner._parse_envelope("   "))
+    # 4) Pure non-JSON → RunnerError.
+    expect_raises("non-JSON stdout raises", lambda: AgenticRunner._parse_envelope("not json at all"))
+
+
+def test_extract_verdict():
+    print("\n_extract_verdict — every structured-output shape:")
+    verdict = {"executed": False, "dimensions": {}, "commands": [],
+               "recommendations": [], "summary": "x"}
+    # 1) Native structured_output key.
+    v, _ = AgenticRunner._extract_verdict({"structured_output": verdict})
+    check("structured_output key", v == verdict)
+    # 2) camelCase variant.
+    v, _ = AgenticRunner._extract_verdict({"structuredOutput": verdict})
+    check("structuredOutput key", v == verdict)
+    # 3) result is already a dict.
+    v, _ = AgenticRunner._extract_verdict({"result": verdict})
+    check("result is dict", v == verdict)
+    # 4) result is a JSON string.
+    v, _ = AgenticRunner._extract_verdict({"result": json.dumps(verdict)})
+    check("result is JSON string", v == verdict)
+    # 5) result wraps the verdict in a fenced ```json block.
+    fenced = f"Here is my verdict:\n```json\n{json.dumps(verdict)}\n```\n"
+    v, _ = AgenticRunner._extract_verdict({"result": fenced})
+    check("result has fenced json block", v == verdict)
+    # 6) Nothing parseable → (None, text).
+    v, raw = AgenticRunner._extract_verdict({"result": "no verdict here"})
+    check("unparseable → None", v is None and "no verdict" in raw)
+
+
+def test_error_envelopes():
+    print("\nerror-envelope detection (is_error / max-turns cap):")
+    # A success envelope is NOT an error.
+    check("success envelope → no error",
+          AgenticRunner._error_from_envelope({"result": "{}", "is_error": False}) is None)
+    # The --max-turns cap shape the CLI emits with returncode 0.
+    cap = {"subtype": "error_max_turns", "is_error": True,
+           "result": "Reached maximum number of turns"}
+    err = AgenticRunner._error_from_envelope(cap)
+    check("error_max_turns → classified as error",
+          err is not None and "error_max_turns" in err)
+    # Generic error envelope.
+    err = AgenticRunner._error_from_envelope({"is_error": True, "result": "boom"})
+    check("generic is_error → error string", err is not None and "boom" in err)
+    # A plain envelope with no is_error key is fine.
+    check("no is_error key → None",
+          AgenticRunner._error_from_envelope({"result": "ok"}) is None)
+
+
+def test_schema_and_scoring():
+    print("\nschema + deterministic scoring:")
+    js = schema.build_json_schema()
+    check("schema has required keys", set(js.get("required", [])) >=
+          {"executed", "dimensions", "commands", "recommendations", "summary"})
+    check("schema dimensions match DIM_KEYS",
+          set(js["properties"]["dimensions"]["required"]) == set(schema.DIM_KEYS))
+    # All-5 verdict → 100%; all-0 → 0%.
+    full = {"dimensions": {k: {"score": 5, "findings": []} for k in schema.DIM_KEYS}}
+    zero = {"dimensions": {k: {"score": 0, "findings": []} for k in schema.DIM_KEYS}}
+    check("all-5 scores → 100.0", schema.score_verdict(full)["overall"] == 100.0)
+    check("all-0 scores → 0.0", schema.score_verdict(zero)["overall"] == 0.0)
+    check("weights sum to 1.0", abs(sum(schema.WEIGHTS.values()) - 1.0) < 1e-9)
+    check("schema_version present", bool(getattr(schema, "SCHEMA_VERSION", "")))
+
+
+def test_snippet_extraction():
+    print("\ncode-snippet extraction (drives execute mode):")
+    import importlib, sys as _sys
+    qd = str(Path(__file__).resolve().parents[3] / "scripts" / "quest")
+    if qd not in _sys.path:
+        _sys.path.insert(0, qd)
+    ql = importlib.import_module("quest_lib")
+    body = (
+        "Intro\n\n```bash\necho hi\nls -la\n```\n\n"
+        "Config:\n```yaml\nkey: value\n```\n\n"
+        "```python\nprint('x')\n```\n"
+    )
+    blocks = ql.extract_code_blocks(body)
+    check("extracts all fenced blocks", len(blocks) == 3)
+    check("classifies bash/python runnable, yaml not",
+          [b.runnable for b in blocks] == [True, False, True])
+    s = ql.snippet_summary(body)
+    check("summary counts runnable", s["total"] == 3 and s["runnable"] == 2)
+    check("longer display fence not mis-closed",
+          len(ql.extract_code_blocks("````md\n```bash\nx\n```\n````\n")) == 1)
+
+
+def test_mock_determinism():
+    print("\nmock determinism (sha256, not salted hash()):")
+    q = _StubQuest("terminal-mastery", "x" * 5000)
+    r1 = AgenticRunner(mode="review", mock=True)
+    r2 = AgenticRunner(mode="review", mock=True)
+    v1 = r1._mock_verdict(q)
+    v2 = r2._mock_verdict(q)
+    check("same quest → identical mock verdict across runner instances", v1 == v2)
+    # A different quest should (almost always) differ in at least one dimension.
+    other = AgenticRunner(mode="review", mock=True)._mock_verdict(_StubQuest("yaml-config", "y" * 100))
+    check("different quest → different verdict", other != v1)
+
+
+def main():
+    print("=" * 64)
+    print("AGENTIC ENVELOPE CONTRACT TEST (offline, no claude, no cost)")
+    print("=" * 64)
+    test_parse_envelope()
+    test_extract_verdict()
+    test_error_envelopes()
+    test_snippet_extraction()
+    test_schema_and_scoring()
+    test_mock_determinism()
+    print("\n" + "=" * 64)
+    if _failures:
+        print(f"❌ {len(_failures)} contract check(s) FAILED: {_failures}")
+        return 1
+    print("✅ All envelope/scoring contract checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/quest-validator/agentic_validate.py
+++ b/test/quest-validator/agentic_validate.py
@@ -73,6 +73,14 @@ def main():
                         "execute = run safe commands in a sandbox (use in CI/containers).")
     p.add_argument("--model", help="Model override passed to claude (e.g. an alias).")
     p.add_argument("--timeout", type=int, default=600, help="Per-quest timeout in seconds (default 600).")
+    p.add_argument("--max-turns", type=int, default=0,
+                   help="Per-quest agent turn ceiling (0 = CLI default). Bounds runaway loops.")
+    p.add_argument("--max-cost-usd", type=float, default=0.0,
+                   help="Abort the batch once cumulative reported cost exceeds this (0 = no ceiling).")
+    p.add_argument("--isolate", choices=["none", "docker"], default="none",
+                   help="execute-mode isolation. 'docker' is provided by running this whole "
+                        "validator inside a container (see `make docker-audit-tier2`); accepted "
+                        "here so callers can pass it through without erroring.")
     p.add_argument("--claude-bin", default="claude", help="Path to the claude CLI.")
     p.add_argument("--mock", action="store_true",
                    help="Synthetic deterministic verdicts (no CLI, no cost) — for pipeline testing.")
@@ -101,7 +109,7 @@ def main():
     r = runner.AgenticRunner(
         mode=args.mode, model=args.model, timeout=args.timeout,
         claude_bin=args.claude_bin, mock=args.mock, dry_run=args.dry_run,
-        verbose=args.verbose,
+        verbose=args.verbose, max_turns=args.max_turns,
     )
 
     if not (args.mock or args.dry_run) and not r.available():
@@ -125,11 +133,20 @@ def main():
         sys.exit(0)
 
     results = []
+    spent = 0.0
+    truncated = False
     for i, q in enumerate(quests, 1):
+        if args.max_cost_usd and spent >= args.max_cost_usd:
+            print(f"\n💰 Cost ceiling reached (${spent:.4f} ≥ ${args.max_cost_usd}); "
+                  f"stopping after {i - 1}/{len(quests)} quest(s).", file=sys.stderr)
+            truncated = True
+            break
         if not args.mock:
             print(f"[{i}/{len(quests)}] {args.mode}: {q.rel_path} …", file=sys.stderr, flush=True)
         try:
-            results.append(r.run(q))
+            res = r.run(q)
+            results.append(res)
+            spent += (res.get("meta", {}) or {}).get("cost_usd") or 0.0
         except runner.AuthError as e:
             # Auth won't fix itself between quests — abort the whole batch.
             print(f"\n❌ {e}", file=sys.stderr)
@@ -140,7 +157,16 @@ def main():
                             "verdict_obj": None})
 
     agg = report.aggregate(results)
+    if truncated:
+        # Record partial coverage so a cost-truncated batch is never mistaken
+        # for full, clean coverage (by a human or the gate below).
+        agg["truncated"] = True
+        agg["evaluated"] = len(results)
+        agg["requested"] = len(quests)
     print("\n" + report.render_console(agg, verbose=args.verbose))
+    if truncated:
+        print(f"\n⚠️  BATCH TRUNCATED by cost ceiling — evaluated {len(results)}/{len(quests)} quest(s). "
+              f"The score gate covers only the evaluated subset.", file=sys.stderr)
 
     if args.report:
         Path(args.report).write_text(report.render_json(agg), encoding="utf-8")
@@ -156,6 +182,13 @@ def main():
         below = [r for r in results if r.get("overall", 0) < args.fail_threshold]
         if below:
             print(f"\n❌ {len(below)} quest(s) below {args.fail_threshold}%.", file=sys.stderr)
+            sys.exit(1)
+        # A truncated batch cannot certify the quests it never evaluated, so a
+        # gated run must NOT report success on partial coverage.
+        if truncated:
+            print(f"\n❌ Cannot certify a cost-truncated batch against a "
+                  f"{args.fail_threshold}% gate ({len(results)}/{len(quests)} evaluated).",
+                  file=sys.stderr)
             sys.exit(1)
     if agg["scored"] == 0:
         sys.exit(1)

--- a/test/quest-validator/test-agentic.sh
+++ b/test/quest-validator/test-agentic.sh
@@ -72,6 +72,28 @@ echo "── 6. exit-code gating ──"
 "$PY" "$CLI" pages/_quests/0101/docker-mastery-example.md --mock --fail-threshold 80 >/dev/null 2>&1
 [ $? -eq 0 ] && ok "above-threshold -> exit 0" || bad "threshold 80 should pass"
 
+echo "── 7. envelope/scoring contract test ──"
+"$PY" "$HERE/agentic/test_envelope.py" >/dev/null 2>&1 && ok "envelope contract holds" || bad "envelope contract drift"
+
+echo "── 8. cost/turn governors ──"
+"$PY" "$CLI" pages/_quests/0101/docker-mastery-example.md --max-turns 7 --dry-run 2>/dev/null \
+  | grep -q -- '--max-turns 7' && ok "max-turns reaches the claude command" || bad "max-turns not wired"
+"$PY" "$CLI" -d pages/_quests --sample 2 --mock --max-cost-usd 1 >/dev/null 2>&1 \
+  && ok "max-cost-usd accepted" || bad "max-cost-usd rejected"
+
+echo "── 9. execute mode drives snippet execution ──"
+dr=$("$PY" "$CLI" pages/_quests/0101/docker-mastery-example.md --mode execute --dry-run 2>/dev/null)
+echo "$dr" | grep -q 'ACTUALLY RUN' && echo "$dr" | grep -qiE 'Code snippets \(determ' \
+  && ok "execute prompt lists snippets + says run them" || bad "execute prompt missing snippet drive"
+"$PY" "$CLI" pages/_quests/0101/docker-mastery-example.md --mode execute --mock --report /tmp/_exec_selftest.json >/dev/null 2>&1
+"$PY" - <<'PY' && ok "execute report carries snippet coverage" || bad "snippet coverage missing"
+import json
+d=json.load(open("/tmp/_exec_selftest.json"))
+s=d["results"][0]["snippets"]
+assert s["available_runnable"] is not None and s["available_runnable"]>=1, s
+assert s["recorded"]>=1 and "ran" in s, s
+PY
+
 echo ""
 echo "════════════════════════════════════════"
 echo "agentic self-test: $pass passed, $fail failed"


### PR DESCRIPTION
## Summary

Rebuilds the IT-Journey quest validation system as a **unified, registry-driven engine that runs in Docker, with Claude Code wired in** — and adds a new option to have a **Claude agent walk a quest and actually run its code snippets** in an isolated container.

Scope was deliberately bounded to *engine + Docker + Claude (lower risk)*: README status-table staleness and broader CI drift are intentionally left in place.

## What's in it

### Engine — consolidated onto the registry
- **`scripts/quest/quest_lib.py`** (new) — the *one* CRLF/BOM-tolerant frontmatter parser + registry-driven quest iterator + `QuestDoc` + deterministic code-snippet extractor. Every validator imports it, so parsing/discovery can't drift.
- **`scripts/quest/validate-quest-network.py`** — rewritten onto `quest_registry` (drops the hardcoded field/enum/regex lists and the retired `quest_relationships` field). Adds **duplicate-permalink, dangling-edge, prerequisite-level-monotonicity, retired-field, and malformed-dependency** checks; exposes an import-safe `run_network_validation()`.
- **`scripts/quest/quest_audit.py`** (new) — **the unified entrypoint**: content (tier-1) + network + data-freshness (+ optional Claude tier-2) in one report and one exit code. The freshness check is **non-mutating** (regenerate → in-memory backup → diff → restore). `make quest-audit` now runs this.

### Docker — `make docker-validate`
- **`scripts/quest/docker-entrypoint.sh`** (new) + compose `quest-audit` (python:3.12-slim, fast) and `quest-build` (ruby:3.2.3 CI-parity) services.
- `make docker-validate` / `docker-build-ci` / `docker-audit-tier2`. The scheduled CI audit now runs in Docker; the PR fast-path stays on setup-python.

### Claude Code tier-2 — hardened + auto-wired (advisory)
- Deterministic sha256 mock (was a salted `hash()`), `--max-turns` / `--max-cost-usd` governors (a cost-truncated batch can no longer falsely certify a gate), `is_error`/`error_max_turns` envelope handling, a `SCHEMA_VERSION`, and an **offline envelope contract test** guarding against `claude` CLI output-shape drift.
- `agentic-quest-review.yml` now **auto-runs advisory read-only review** on quest PRs (non-blocking, cost-capped, skips cleanly with no token). The `agentic-review` label/dispatch still unlocks sandboxed `execute`.

### Execute the snippets (the new option)
- **`make quest-execute QUEST=<path>`** (or `SAMPLE=N`): a Claude agent walks a quest and **actually runs its runnable code snippets** in a disposable Docker container (the container *is* the isolation boundary), reporting `ran N/M` with per-snippet `passed`/`failed`/`skipped`/`reasoned`. Opt-in/advisory; falls back to a no-cost mock without a token.

## Notable fix
Regenerates **`_data/navigation/quests.yml`**, which was genuinely stale on `main` (generator is deterministic; committed copy differed).

## Verification
- Deterministic audit green on **host and in Docker**; non-mutating freshness confirmed.
- Agentic self-test **13/13**; offline envelope/snippet contract test passing.
- **6-lens adversarial review** workflow → 5 blockers found and fixed.
- **Live agent run**: executed 5/5 runnable snippets on an example quest and correctly flagged a failing one (scored it a FAIL).

## How to try it
```bash
make quest-audit                                                  # unified audit (content + network + freshness)
make docker-validate                                              # same audit, in Docker (CI-parity)
make quest-execute QUEST=pages/_quests/0001/terminal-mastery.md   # Claude runs the quest's snippets, isolated
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)