### PR TITLE
fix: render Mermaid diagrams + Obsidian quest-network graph

### DIFF
--- a/.github/workflows/frontmatter-validation.yml
+++ b/.github/workflows/frontmatter-validation.yml
@@ -45,7 +45,13 @@ jobs:
     - name: Install dependencies
       run: |
         pip install pyyaml
-    
+
+    - name: Check Mermaid render flags
+      # Fails if any page contains a Mermaid diagram but omits `mermaid: true`
+      # (the theme only loads Mermaid when that flag is set). Stdlib-only.
+      run: |
+        python3 scripts/validation/check_mermaid_flags.py
+
     - name: Get changed markdown files
       id: changed-files
       run: |

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
         quest-validate quest-network quest-network-strict quest-build-network \
         quest-audit quest-audit-strict quest-levels-data quest-nav quest-data quest-normalize \
         content-validate content-normalize content-normalize-apply content-audit \
+        mermaid-check mermaid-fix \
         cms-index cms-analyze cms-plan cms-status cms-all
 
 JEKYLL_CONFIG_DEV := _config.yml,_config_dev.yml
@@ -235,8 +236,16 @@ content-normalize-apply:
 	@python3 scripts/content/normalize-frontmatter.py pages/ --apply --quiet \
 		--report TODO/seo/data/normalize-apply.json
 
-content-audit: content-validate quest-validate quest-network
-	@echo "✅ Content audit complete — frontmatter, quests, and network validated."
+mermaid-check:
+	@echo "🧜 Checking Mermaid front-matter flags across pages/ ..."
+	@python3 scripts/validation/check_mermaid_flags.py
+
+mermaid-fix:
+	@echo "🧜 Adding missing 'mermaid: true' flags across pages/ ..."
+	@python3 scripts/validation/check_mermaid_flags.py --fix
+
+content-audit: content-validate mermaid-check quest-validate quest-network
+	@echo "✅ Content audit complete — frontmatter, mermaid, quests, and network validated."
 
 # AI-augmented CMS engine (scripts/cms/cms.py -> .cms/)
 cms-index:

--- a/_includes/content/quest-graph-obsidian.html
+++ b/_includes/content/quest-graph-obsidian.html
@@ -1,0 +1,382 @@
+{%- comment -%}
+  ===================================================================
+  quest-graph-obsidian.html — Obsidian-style quest dependency graph
+  ===================================================================
+  File: _includes/content/quest-graph-obsidian.html
+  Purpose: Renders the quest dependency network as a force-directed
+           "Obsidian graph view" using cytoscape.js — the same look &
+           feel as the site knowledge graph (_includes/obsidian/*),
+           but built from the quest registry instead of wiki-links.
+
+  This replaces the Mermaid quest graph (content/quest-graph.html) at
+  the bottom of quest pages. Unlike Mermaid, it is fully self-contained:
+  it lazy-loads cytoscape itself and does NOT depend on `page.mermaid`,
+  so it renders on every quest regardless of front matter.
+
+  Parameters:
+    include.level    (optional) — 4-digit binary level string ("0000").
+                     Filters the graph to a single level. Omit for the
+                     full cross-level network.
+    include.current  (optional) — permalink of the quest to highlight as
+                     "you are here" (e.g. page.permalink).
+
+  Data source:
+    assets/data/quest-network.json  (scripts/quest/build-quest-network.py)
+      { nodes:[{id,title,level,type,difficulty,technology}], edges:[{source,target,kind}] }
+
+  Dependencies:
+    cytoscape.js (loaded lazily from CDN with SRI, shared with the
+    theme's obsidian graph if already present).
+  ===================================================================
+{%- endcomment -%}
+
+{%- assign graph_id = include.level | default: "all" -%}
+
+<div class="quest-obsidian-graph my-3"
+     id="quest-obsidian-{{ graph_id }}"
+     data-level="{{ include.level }}"
+     data-current="{{ include.current }}"
+     data-index-url="{{ '/assets/data/quest-network.json' | relative_url }}">
+  <div class="quest-obsidian-graph__toolbar">
+    <span class="quest-obsidian-graph__status" role="status">Loading quest graph…</span>
+    <button type="button" class="btn btn-outline-secondary btn-sm quest-obsidian-graph__fit" hidden>
+      <i class="bi bi-arrows-fullscreen" aria-hidden="true"></i> Reset view
+    </button>
+  </div>
+  <div class="quest-obsidian-graph__canvas"
+       role="img"
+       aria-label="Quest dependency graph"></div>
+  <div class="quest-obsidian-graph__legend" aria-hidden="true">
+    <span><i class="dot" style="background:#4caf50"></i>🟢 Easy</span>
+    <span><i class="dot" style="background:#f9a825"></i>🟡 Medium</span>
+    <span><i class="dot" style="background:#ef5350"></i>🔴 Hard</span>
+    <span><i class="dot" style="background:#ab47bc"></i>⚔️ Epic</span>
+    <span><i class="dot dot--here"></i>You are here</span>
+    <span><i class="edge"></i>required</span>
+    <span><i class="edge edge--unlocks"></i>unlocks</span>
+    <span><i class="edge edge--dashed"></i>recommended</span>
+  </div>
+  <p class="quest-obsidian-graph__tips">
+    Click a node to open the quest · ⌘/Ctrl-click for a new tab · drag to
+    reposition · scroll to zoom.
+  </p>
+</div>
+
+<style>
+  .quest-obsidian-graph__canvas {
+    width: 100%;
+    height: 60vh;
+    min-height: 420px;
+    border: 1px solid rgba(var(--bs-border-color-rgb, 222, 226, 230), 0.55);
+    border-radius: var(--bs-border-radius-lg, .5rem);
+    background: rgba(var(--bs-body-bg-rgb, 255, 255, 255), 0.45);
+    overflow: hidden;
+    position: relative;
+  }
+  [data-bs-theme="dark"] .quest-obsidian-graph__canvas {
+    background: rgba(var(--bs-body-bg-rgb, 33, 37, 41), 0.38);
+  }
+  .quest-obsidian-graph__toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .5rem;
+    margin-bottom: .5rem;
+  }
+  .quest-obsidian-graph__status {
+    font-size: .8125rem;
+    color: var(--bs-secondary-color, #6c757d);
+  }
+  .quest-obsidian-graph__legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .4rem .75rem;
+    margin-top: .6rem;
+    font-size: .78rem;
+    color: var(--bs-body-color, #212529);
+  }
+  .quest-obsidian-graph__legend span {
+    display: inline-flex;
+    align-items: center;
+    gap: .35rem;
+  }
+  .quest-obsidian-graph__legend .dot {
+    width: .7rem; height: .7rem; border-radius: 50%;
+    display: inline-block; box-shadow: 0 0 0 1px rgba(0,0,0,.12);
+  }
+  .quest-obsidian-graph__legend .dot--here {
+    background: transparent; box-shadow: 0 0 0 2px #fd7e14;
+  }
+  .quest-obsidian-graph__legend .edge {
+    width: 1.1rem; height: 0; display: inline-block;
+    border-top: 2px solid var(--bs-secondary-color, #6c757d);
+  }
+  .quest-obsidian-graph__legend .edge--unlocks { border-top-color: #0d6efd; }
+  .quest-obsidian-graph__legend .edge--dashed { border-top-style: dashed; }
+  .quest-obsidian-graph__tips {
+    margin-top: .5rem;
+    font-size: .78rem;
+    color: var(--bs-secondary-color, #6c757d);
+  }
+</style>
+
+<script>
+(function () {
+  var CY_URL = 'https://cdn.jsdelivr.net/npm/cytoscape@3.30.0/dist/cytoscape.min.js';
+  var CY_SRI = 'sha384-kpMsYllYzyaWU69Piok08rPNktpnjqAoDMdB00fjqUkEk3lkuUbSuwJ+oXrjvN6B';
+
+  var root = document.getElementById("quest-obsidian-{{ graph_id }}");
+  if (!root) return;
+
+  var canvas = root.querySelector('.quest-obsidian-graph__canvas');
+  var statusEl = root.querySelector('.quest-obsidian-graph__status');
+  var fitBtn = root.querySelector('.quest-obsidian-graph__fit');
+  var levelFilter = root.getAttribute('data-level') || '';
+  var current = normPath(root.getAttribute('data-current') || '');
+  var dataUrl = root.getAttribute('data-index-url');
+
+  function normPath(p) {
+    if (!p) return '';
+    p = p.split('#')[0].split('?')[0];
+    if (p.length > 1 && p.charAt(p.length - 1) !== '/') p += '/';
+    return p;
+  }
+
+  function setStatus(msg) { if (statusEl) statusEl.textContent = msg || ''; }
+
+  // Difficulty emoji → node color.
+  function diffColor(d) {
+    d = d || '';
+    if (d.indexOf('🟢') !== -1) return '#4caf50'; // 🟢
+    if (d.indexOf('🟡') !== -1) return '#f9a825'; // 🟡
+    if (d.indexOf('🔴') !== -1) return '#ef5350'; // 🔴
+    if (d.indexOf('⚔') !== -1)       return '#ab47bc'; // ⚔️
+    return '#6c757d';
+  }
+
+  function readTheme() {
+    var attr = (document.documentElement.getAttribute('data-bs-theme') || '').toLowerCase();
+    var dark = attr === 'dark' || attr === 'wizard' ||
+      (!attr && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+    return dark ? {
+      label: '#e9ecef', labelOutline: '#1b1f23',
+      edge: 'rgba(173,181,189,0.45)', edgeArrow: 'rgba(173,181,189,0.65)',
+      unlock: 'rgba(125,211,252,0.55)', canvasBg: '#1b1f23',
+      nodeBorder: 'rgba(255,255,255,0.22)'
+    } : {
+      label: '#1b1f23', labelOutline: '#f8f9fa',
+      edge: 'rgba(73,80,87,0.40)', edgeArrow: 'rgba(73,80,87,0.60)',
+      unlock: 'rgba(13,110,253,0.45)', canvasBg: '#f8f9fa',
+      nodeBorder: 'rgba(0,0,0,0.20)'
+    };
+  }
+
+  function loadCytoscape(cb) {
+    if (typeof window.cytoscape === 'function') return cb();
+    // Shares the in-flight queue with the theme's obsidian-local-graph loader.
+    // Set the queue BEFORE the existing-<script> check and PUSH (never
+    // overwrite), matching obsidian-local-graph.js so the two loaders can't
+    // clobber each other's pending callbacks.
+    if (window.__obsidianCytoscapeLoading) {
+      window.__obsidianCytoscapeLoading.push(cb);
+      return;
+    }
+    window.__obsidianCytoscapeLoading = [cb];
+    function flush() {
+      (window.__obsidianCytoscapeLoading || []).forEach(function (fn) { fn(); });
+      window.__obsidianCytoscapeLoading = null;
+    }
+    var existing = document.querySelector('script[src*="cytoscape"]');
+    if (existing) {
+      existing.addEventListener('load', flush);
+      return;
+    }
+    var s = document.createElement('script');
+    s.src = CY_URL; s.integrity = CY_SRI; s.crossOrigin = 'anonymous'; s.defer = true;
+    s.onload = flush;
+    s.onerror = function () {
+      setStatus('Quest graph unavailable (could not load renderer).');
+      window.__obsidianCytoscapeLoading = null;
+    };
+    document.head.appendChild(s);
+  }
+
+  function build(data) {
+    var allNodes = (data && data.nodes) || [];
+    var nodes = levelFilter
+      ? allNodes.filter(function (n) { return n.level === levelFilter; })
+      : allNodes;
+
+    if (!nodes.length) {
+      setStatus('No quests found for this level.');
+      return;
+    }
+
+    var ids = {};
+    nodes.forEach(function (n) { ids[n.id] = true; });
+
+    var edges = ((data && data.edges) || []).filter(function (e) {
+      return ids[e.source] && ids[e.target];
+    });
+
+    var elements = [];
+    nodes.forEach(function (n) {
+      var url = normPath(n.id);
+      elements.push({
+        group: 'nodes',
+        data: {
+          id: n.id,
+          label: (n.title || n.id).substring(0, 48),
+          url: url,
+          color: diffColor(n.difficulty),
+          type: n.type || 'main_quest',
+          isCurrent: current && url === current
+        }
+      });
+    });
+    var seen = {};
+    edges.forEach(function (e) {
+      var k = e.source + '|' + e.target;
+      if (seen[k]) return;
+      seen[k] = true;
+      elements.push({
+        group: 'edges',
+        data: { id: 'qe:' + k, source: e.source, target: e.target, kind: e.kind || 'required' }
+      });
+    });
+
+    loadCytoscape(function () { render(elements); });
+  }
+
+  function render(elements) {
+    var theme = readTheme();
+    canvas.style.backgroundColor = theme.canvasBg;
+
+    var cy = window.cytoscape({
+      container: canvas,
+      elements: elements,
+      minZoom: 0.2,
+      maxZoom: 3,
+      style: [
+        {
+          selector: 'node',
+          style: {
+            'background-color': 'data(color)',
+            'label': 'data(label)',
+            'font-size': '10px',
+            'font-weight': 500,
+            'color': theme.label,
+            'text-outline-color': theme.labelOutline,
+            'text-outline-width': 2,
+            'text-valign': 'bottom',
+            'text-margin-y': 3,
+            'text-wrap': 'ellipsis',
+            'text-max-width': '120px',
+            'width': 15, 'height': 15,
+            'border-width': 1.5,
+            'border-color': theme.nodeBorder
+          }
+        },
+        {
+          // Side quests rendered as hollow / dashed-border circles.
+          selector: 'node[type = "side_quest"]',
+          style: { 'border-style': 'dashed', 'border-width': 2 }
+        },
+        {
+          selector: 'node[?isCurrent]',
+          style: {
+            'width': 24, 'height': 24,
+            'border-width': 3,
+            'border-color': '#fd7e14',
+            'font-weight': 700,
+            'z-index': 99
+          }
+        },
+        {
+          selector: 'edge',
+          style: {
+            'width': 1,
+            'line-color': theme.edge,
+            'target-arrow-color': theme.edgeArrow,
+            'target-arrow-shape': 'triangle',
+            'arrow-scale': 0.7,
+            'curve-style': 'bezier'
+          }
+        },
+        {
+          selector: 'edge[kind = "unlocks"]',
+          style: { 'line-color': theme.unlock, 'target-arrow-color': theme.unlock }
+        },
+        {
+          selector: 'edge[kind = "recommended"]',
+          style: { 'line-style': 'dashed' }
+        }
+      ],
+      layout: {
+        name: 'cose',
+        animate: false,
+        padding: 16,
+        nodeRepulsion: function () { return 7000; },
+        idealEdgeLength: function () { return 70; },
+        edgeElasticity: function () { return 60; },
+        nodeOverlap: 14,
+        gravity: 0.25,
+        numIter: 1200,
+        fit: true
+      }
+    });
+
+    root.__cy = cy;
+
+    cy.on('tap', 'node', function (evt) {
+      var d = evt.target.data();
+      if (!d.url || d.url === current) return;
+      var oe = evt.originalEvent;
+      if (oe && (oe.metaKey || oe.ctrlKey)) {
+        window.open(d.url, '_blank', 'noopener');
+      } else {
+        window.location.href = d.url;
+      }
+    });
+
+    // Focus the current quest in view if present.
+    var hereNode = current ? cy.nodes('[?isCurrent]') : cy.collection();
+    if (fitBtn) {
+      fitBtn.hidden = false;
+      fitBtn.addEventListener('click', function () { cy.fit(cy.elements(), 24); });
+    }
+
+    setStatus(cy.nodes().length + ' quests · ' + cy.edges().length + ' links' +
+      (hereNode.nonempty() ? ' · centered on this quest' : ''));
+
+    requestAnimationFrame(function () {
+      cy.resize();
+      cy.fit(cy.elements(), 24);
+      if (hereNode.nonempty()) { cy.center(hereNode); }
+    });
+
+    // Recolor on Bootstrap theme toggle without a full relayout.
+    var obs = new MutationObserver(function () {
+      var t = readTheme();
+      canvas.style.backgroundColor = t.canvasBg;
+      cy.style()
+        .selector('node').style({
+          'color': t.label, 'text-outline-color': t.labelOutline, 'border-color': t.nodeBorder
+        })
+        .selector('node[?isCurrent]').style({ 'border-color': '#fd7e14' })
+        .selector('edge').style({ 'line-color': t.edge, 'target-arrow-color': t.edgeArrow })
+        .selector('edge[kind = "unlocks"]').style({ 'line-color': t.unlock, 'target-arrow-color': t.unlock })
+        .update();
+    });
+    obs.observe(document.documentElement, { attributes: true, attributeFilter: ['data-bs-theme'] });
+  }
+
+  fetch(dataUrl, { credentials: 'same-origin' })
+    .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+    .then(build)
+    .catch(function (err) {
+      setStatus('Quest graph unavailable.');
+      console.warn('[quest-graph-obsidian] failed to load network data', err);
+    });
+})();
+</script>

--- a/_layouts/quest.html
+++ b/_layouts/quest.html
@@ -32,7 +32,7 @@ layout: default
 
       <section class="quest-page__network" aria-labelledby="quest-network-heading">
         <h2 id="quest-network-heading" class="quest-section-heading">🕸️ Quest Network</h2>
-        {% include content/quest-graph.html level=page.level %}
+        {% include content/quest-graph-obsidian.html level=page.level current=page.permalink %}
         {% include content/quest-backlinks.html %}
       </section>
     </div>

--- a/pages/_about/contribute/contributors/bamr87/README.md
+++ b/pages/_about/contribute/contributors/bamr87/README.md
@@ -7,6 +7,7 @@ username: bamr87
 contributor_data: bamr87
 permalink: /contributors/bamr87/
 lastmod: '2026-03-21T15:12:32.000Z'
+mermaid: true
 ---
 <link rel="stylesheet" href="{{ '/assets/css/contributor-profile.css' | relative_url }}">
 

--- a/pages/_docs/jekyll/mermaid-migration.md
+++ b/pages/_docs/jekyll/mermaid-migration.md
@@ -19,6 +19,7 @@ author: bamr87
 date: '2025-11-08T21:04:54.000Z'
 lastmod: '2026-05-24T00:00:00.000Z'
 draft: false
+mermaid: true
 ---
 # Mermaid Auto-Detection Migration Guide
 

--- a/pages/_posts/data-analytics/2025-03-13-excel-gurus-are-the-most-valuable-programmers.md
+++ b/pages/_posts/data-analytics/2025-03-13-excel-gurus-are-the-most-valuable-programmers.md
@@ -35,6 +35,7 @@ comments: false
 aiPrompt: I want to explore a article topic about how Microsoft Excel and people who can use Excel to its greatest extent (by using formulas and functions and some of the more advanced capabilities) have the greatest potential for becoming programmers. they are applying programming concepts and methods through Excel and visualizing it and customizing it with a great degree. Essentially, the idea is that there should be motivation for financial analysts and accountants who are advanced users in Excel to expand into computer science and other IT technologies to harness their understanding and abilities they learn from Excel. This article should show those parallels of advanced programming and advanced Microsoft Excel users and how someone could make advance their skill set with programming capabilities beyond Excel.
 section: Data & Analytics
 draft: false
+mermaid: true
 ---
 ## Abstract
 

--- a/pages/_posts/devops/2025-11-17-deploying-jekyll-sites-to-azure-cloud.md
+++ b/pages/_posts/devops/2025-11-17-deploying-jekyll-sites-to-azure-cloud.md
@@ -58,6 +58,7 @@ validation_methods:
 - Check site performance with Azure monitoring
 section: DevOps
 draft: false
+mermaid: true
 ---
 ## Introduction
 

--- a/pages/_posts/programming/2025-03-12-ais-infinite-loop-unveiling-arbitrage-in-complexity-of-models.md
+++ b/pages/_posts/programming/2025-03-12-ais-infinite-loop-unveiling-arbitrage-in-complexity-of-models.md
@@ -53,6 +53,7 @@ author:
   first: Amr
   middle: GPT
 draft: false
+mermaid: true
 ---
 ## Structured approach to a {{ page.schema }} article topic
 

--- a/pages/_posts/programming/2025-10-17-erp-stack-architecture-guide.md
+++ b/pages/_posts/programming/2025-10-17-erp-stack-architecture-guide.md
@@ -29,6 +29,7 @@ permalink: /erp-stack-architecture-guide/
 attachments: ''
 comments: true
 draft: false
+mermaid: true
 ---
 ## Introduction: Understanding Enterprise Resource Planning Systems
 

--- a/pages/_posts/tools-environment/2025-11-19-terminal-frontend-architecture.md
+++ b/pages/_posts/tools-environment/2025-11-19-terminal-frontend-architecture.md
@@ -47,6 +47,7 @@ validation_methods:
 - Build a simple wrapper script using the architecture described
 - Refactor an existing script to separate logic from input
 draft: false
+mermaid: true
 ---
 ## Introduction
 

--- a/pages/_quests/0000/README.md
+++ b/pages/_quests/0000/README.md
@@ -18,6 +18,7 @@ tags:
 - foundation
 - init
 - world
+mermaid: true
 ---
 # Level 0000: Foundation & Init World
 

--- a/pages/_quests/0000/bashcrawl/README.md
+++ b/pages/_quests/0000/bashcrawl/README.md
@@ -98,6 +98,7 @@ excerpt: Embark on an epic terminal adventure that teaches Bash commands through
 snippet: Every command is a spell, every directory a new realm to explore
 draft: false
 permalink: /quests/0000/bashcrawl/
+mermaid: true
 ---
 *Welcome to the Bashcrawl Catacombs — an interactive terminal dungeon where every command is a spell and every directory a new realm to explore. Nine interconnected chambers await, each a side-quest that teaches a core set of Bash skills through gameplay.*
 

--- a/pages/_quests/0000/git-basics.md
+++ b/pages/_quests/0000/git-basics.md
@@ -77,6 +77,7 @@ rewards:
   - Collaborative development workflows
   - Code review via pull requests
 layout: quest
+mermaid: true
 ---
 *Greetings, brave adventurer! Welcome to the Git Basics quest — where you'll learn the version control system that powers nearly every software project on the planet. Git lets you track changes, collaborate with others, and fearlessly experiment with code knowing you can always roll back. This is the single most important tool in any developer's inventory.*
 

--- a/pages/_quests/0000/hello-noob.md
+++ b/pages/_quests/0000/hello-noob.md
@@ -81,6 +81,7 @@ rewards:
   - Foundation for version control learning
 layout: quest
 sub_title: 'Level 0000 (0) Main Quest: First Steps in Digital Collaboration'
+mermaid: true
 ---
 *Welcome, brave n00b, to the beginning of your legendary IT journey! You stand at the threshold of an incredible adventure where code becomes magic, problems transform into puzzles, and you'll develop superpowers that would seem impossible to your past self.*
 

--- a/pages/_quests/0001/barodybroject-stack-analysis.md
+++ b/pages/_quests/0001/barodybroject-stack-analysis.md
@@ -63,6 +63,7 @@ layout: quest
 redirect_from:
 - /quests/0001/side-quests/barodybroject-stack-analysis/
 draft: false
+mermaid: true
 ---
 # Technology Stack Analysis: Barodybroject
 

--- a/pages/_quests/0001/forge-your-character.md
+++ b/pages/_quests/0001/forge-your-character.md
@@ -70,6 +70,7 @@ validation_criteria:
   - Character sheet renders on your profile page
   - Stats generator runs without errors for your username
 layout: quest
+mermaid: true
 ---
 # ⚔️ Forge Your Character: Crafting Your Contributor Identity
 

--- a/pages/_quests/0001/github-pages-portal.md
+++ b/pages/_quests/0001/github-pages-portal.md
@@ -60,6 +60,7 @@ rewards:
 - Understanding of static site hosting
 - Foundation for Jekyll and other SSGs
 layout: quest
+mermaid: true
 ---
 *Greetings, brave adventurer! Welcome to **The GitHub Pages Portal: Forging Your Digital Realm** - an epic journey that will transform your code into live web experiences. This quest will guide you through deploying your first website using GitHub Pages, the free hosting solution that turns your GitHub repositories into beautiful, accessible websites.*
 

--- a/pages/_quests/0001/it-journey-stack-analysis.md
+++ b/pages/_quests/0001/it-journey-stack-analysis.md
@@ -68,6 +68,7 @@ layout: quest
 redirect_from:
 - /quests/0001/side-quests/it-journey-stack-analysis/
 draft: false
+mermaid: true
 ---
 # Stack Attack Analysis: IT-Journey
 

--- a/pages/_quests/0001/kaizen.md
+++ b/pages/_quests/0001/kaizen.md
@@ -85,6 +85,7 @@ redirect_from:
 layout: quest
 sub_title: 'Level 0001 (1) Quest: Process Improvement and Team Culture Mastery'
 draft: false
+mermaid: true
 ---
 *In the ancient forges of the Digital Kingdom, where lines of code shimmer like molten steel and bugs lurk in shadowy caverns like dragons, a legendary call echoes across the realm. You, the valiant Code Alchemist—a master of algorithms and architect of systems—have been summoned by the High Council of Efficiency. The realm faces a dire threat: **stagnation**, the foul blight that turns innovative projects into bloated monoliths of inefficiency, riddled with waste and rework.*
 

--- a/pages/_quests/0001/stack-attack.md
+++ b/pages/_quests/0001/stack-attack.md
@@ -106,6 +106,7 @@ rewards:
   - AI agent prompt engineering techniques
   - Enterprise architecture pattern library
 layout: quest
+mermaid: true
 ---
 *In the age of digital empires, every great corporation requires a command center — a system that orchestrates inventory, orders, finances, human resources, and logistics into a seamless flow of operational power. This system is called an **ERP**: an Enterprise Resource Planning application. And today, brave architecht, you are tasked with constructing the most formidable enterprise fortress the open-source world has ever seen.*
 

--- a/pages/_quests/0001/stating-the-stats.md
+++ b/pages/_quests/0001/stating-the-stats.md
@@ -90,6 +90,7 @@ rewards:
   - Data-driven site optimization capabilities
 layout: quest
 draft: false
+mermaid: true
 ---
 *In the vast digital archives of IT-Journey (https://it-journey.dev), data flows like rivers of information through the site's structure. Yet this valuable knowledge remains hidden, scattered across posts, pages, and collections. Your quest: forge a powerful Stats Portal that transforms raw site data into compelling visual insights, revealing the true scope and depth of the IT-Journey knowledge base.*
 

--- a/pages/_quests/0010/README.md
+++ b/pages/_quests/0010/README.md
@@ -17,6 +17,7 @@ tags:
 - apprentice
 - terminal
 - mastery
+mermaid: true
 ---
 # Level 0010: Terminal Enhancement & Shell Mastery
 

--- a/pages/_quests/0010/oh-my-zsh-terminal-enchantment.md
+++ b/pages/_quests/0010/oh-my-zsh-terminal-enchantment.md
@@ -97,6 +97,7 @@ redirect_from:
 layout: quest
 sub_title: 'Level 0010 (2) Quest: Terminal Supercharging and Customization'
 draft: false
+mermaid: true
 ---
 ## 🌟 The Legend of Terminal Enchantment
 

--- a/pages/_quests/0010/terminal-artificer-frontend-building.md
+++ b/pages/_quests/0010/terminal-artificer-frontend-building.md
@@ -82,6 +82,7 @@ redirect_from:
 layout: quest
 sub_title: 'Level 0010 (2) Quest: Terminal Frontend Building'
 draft: false
+mermaid: true
 ---
 *In the raw chaotic energy of the command line, powerful spells (scripts) are often cast with cryptic runes (arguments) and dangerous incantations. A single typo can spell disaster. As a Terminal Artificer, you have learned that power without control is chaos. You seek to forge a "Glass Interface"—a layer of elegance and order that allows even the uninitiated to wield powerful magic safely.*
 

--- a/pages/_quests/0011/README.md
+++ b/pages/_quests/0011/README.md
@@ -17,6 +17,7 @@ tags:
 - apprentice
 - ai-assisted
 - development
+mermaid: true
 ---
 # Level 0011: Development Tools & AI Integration
 

--- a/pages/_quests/0011/prd-codex-mastery.md
+++ b/pages/_quests/0011/prd-codex-mastery.md
@@ -96,6 +96,7 @@ validation_criteria:
 draft: false
 fmContentType: quest
 layout: quest
+mermaid: true
 ---
 *Greetings, brave Scribe of the Digital Realm! You stand at the threshold of an ancient art—the distillation of scattered signals into crystalline Product Requirements. In ages past, Product Managers toiled endlessly, their PRDs growing stale mere moments after quill touched parchment. But you shall learn the secrets of the PRD MACHINE—an autonomous oracle that writes, maintains, and evolves perfect PRDs faster than any mortal hand.*
 

--- a/pages/_quests/0011/prompt-crystal-mastery-vscode-copilot.md
+++ b/pages/_quests/0011/prompt-crystal-mastery-vscode-copilot.md
@@ -97,6 +97,7 @@ rewards:
 redirect_from:
 - /quests/0011/prompt-crystal-mastery-vscode-copilot/
 layout: quest
+mermaid: true
 ---
 *In the crystalline halls of the Digital Nexus, where streams of code flow like rivers of starlight and AI spirits await human guidance, there exists a legendary discipline known to master developers as **Prompt Crystal Forging**. This ancient art transforms casual conversations with AI into precision instruments of creation—unlocking capabilities that casual users never dream possible.*
 

--- a/pages/_quests/0100/README.md
+++ b/pages/_quests/0100/README.md
@@ -17,6 +17,7 @@ tags:
 - adventurer
 - frontend
 - containers
+mermaid: true
 ---
 # Level 0100: Frontend Development & Docker
 

--- a/pages/_quests/0100/jekyll-component-refactoring.md
+++ b/pages/_quests/0100/jekyll-component-refactoring.md
@@ -74,6 +74,7 @@ validation_criteria:
 layout: quest
 redirect_from:
 - /quests/0100/side-quests/jekyll-component-refactoring/
+mermaid: true
 ---
 *Greetings, brave artisan! Welcome to The Artisan's Forge — an epic journey that will transform you from a coder who patches things together into a true component architect. This quest guides you through the real-world process of turning hard-coded, inline Jekyll theme elements into modular, configurable, and reusable components.*
 

--- a/pages/_quests/0100/side-quest-profile-themes.md
+++ b/pages/_quests/0100/side-quest-profile-themes.md
@@ -71,6 +71,7 @@ validation_criteria:
 layout: quest
 redirect_from:
 - /quests/0100/side-quests/profile-themes/
+mermaid: true
 ---
 # 🎭 Profile Themes: Unleashing the Style Sorcerer
 

--- a/pages/_quests/0101/README.md
+++ b/pages/_quests/0101/README.md
@@ -18,6 +18,7 @@ tags:
 - ci
 - cd
 - devops
+mermaid: true
 ---
 # Level 0101: Advanced Docker & DevOps
 

--- a/pages/_quests/0101/the-lazytex-of-building-a-curriculum-vitae.md
+++ b/pages/_quests/0101/the-lazytex-of-building-a-curriculum-vitae.md
@@ -56,6 +56,7 @@ redirect_from:
 layout: quest
 sub_title: 'Level 0101 (5) Quest: LaTeX Tool Mastery and CV Construction'
 draft: false
+mermaid: true
 ---
 ## 🧙‍♂️ Epic Introduction
 

--- a/pages/_quests/0110/README.md
+++ b/pages/_quests/0110/README.md
@@ -22,6 +22,7 @@ toc_sticky: true
 draft: false
 date: '2025-12-20T20:02:51.000Z'
 author: IT-Journey Team
+mermaid: true
 ---
 # Level 0110 (6) - Database Mastery
 

--- a/pages/_quests/0111/README.md
+++ b/pages/_quests/0111/README.md
@@ -22,6 +22,7 @@ toc_sticky: true
 draft: false
 date: '2025-12-20T20:02:51.000Z'
 author: IT-Journey Team
+mermaid: true
 ---
 # Level 0111 (7) - API Development
 

--- a/pages/_quests/1000/README.md
+++ b/pages/_quests/1000/README.md
@@ -23,6 +23,7 @@ toc_sticky: true
 draft: false
 date: '2025-12-20T20:02:51.000Z'
 author: IT-Journey Team
+mermaid: true
 ---
 # Level 1000 (8) - Cloud Computing Fundamentals
 

--- a/pages/_quests/1001/README.md
+++ b/pages/_quests/1001/README.md
@@ -23,6 +23,7 @@ toc_sticky: true
 draft: false
 date: '2025-12-20T20:02:51.000Z'
 author: IT-Journey Team
+mermaid: true
 ---
 # Level 1001 (9) - Kubernetes Orchestration
 

--- a/pages/_quests/1001/k8s-pods-workloads.md
+++ b/pages/_quests/1001/k8s-pods-workloads.md
@@ -81,6 +81,7 @@ rewards:
   unlocks_features:
   - Access to Services, Networking, and Configuration quests
 layout: quest
+mermaid: true
 ---
 *Welcome back, Warrior. In the previous quest you learned that a lone Pod is fragile - delete it, and it stays dead, for no controller watches over it. Now you will learn to command the **workload legions**: the controllers that create Pods, keep them at the right count, heal them when they fall, and upgrade them without downtime. This is where Kubernetes stops being a curiosity and becomes a production weapon.*
 

--- a/pages/_quests/1001/kubernetes-fundamentals.md
+++ b/pages/_quests/1001/kubernetes-fundamentals.md
@@ -83,6 +83,7 @@ rewards:
   unlocks_features:
   - Access to the rest of the Level 1001 Kubernetes Orchestration quest line
 layout: quest
+mermaid: true
 ---
 *Greetings, brave adventurer! You have ascended into the **Warrior tier**, and before you rises the **Orchestration Citadel** - a vast fortress where thousands of containers march in disciplined formation. This quest, **Kubernetes Fundamentals**, is your initiation. You will learn how a single brain - the control plane - commands an army of worker nodes, and how you, the operator, issue your will not as a stream of frantic commands but as a single, declared truth.*
 

--- a/pages/_quests/1010/README.md
+++ b/pages/_quests/1010/README.md
@@ -17,6 +17,7 @@ tags:
 - warrior
 - monitoring
 - observability
+mermaid: true
 ---
 # Level 1010: Automation & Testing
 

--- a/pages/_quests/1011/README.md
+++ b/pages/_quests/1011/README.md
@@ -17,6 +17,7 @@ tags:
 - warrior
 - security
 - compliance
+mermaid: true
 ---
 # Level 1011: Feature Development
 

--- a/pages/_quests/1011/threat-modeling.md
+++ b/pages/_quests/1011/threat-modeling.md
@@ -82,6 +82,7 @@ rewards:
   unlocks_features:
   - Ability to threat model a design before a single line of code ships
 layout: quest
+mermaid: true
 ---
 *Greetings, brave adventurer! A wise defender never waits for the siege to discover where the walls are weak. In this quest, **Threat Modeling**, you learn the cartographer's art: to draw your system as it truly is, mark every gate and trust boundary, and ask of each one - "How would I, the attacker, break in here?" You will wield **STRIDE**, the six-fold lens of threats, and the branching logic of **attack trees**.*
 

--- a/pages/_quests/1100/README.md
+++ b/pages/_quests/1100/README.md
@@ -17,6 +17,7 @@ tags:
 - master
 - data
 - engineering
+mermaid: true
 ---
 # Level 1100: Data & Templates
 

--- a/pages/_quests/1100/edgar.md
+++ b/pages/_quests/1100/edgar.md
@@ -63,6 +63,7 @@ redirect_from:
 - /quests/1100/edgar/
 layout: quest
 sub_title: 'Level 1100 (12) Quest: Epic API Data Extraction and Analysis'
+mermaid: true
 ---
 🌟 Welcome, Brave Data Sorcerer! 🌟
 

--- a/pages/_quests/1100/the-temple-of-templates.md
+++ b/pages/_quests/1100/the-temple-of-templates.md
@@ -55,6 +55,7 @@ redirect_from:
 layout: quest
 sub_title: 'Level 1100 (12) Quest: Function Crafting and Modular Abstractions'
 draft: false
+mermaid: true
 ---
 ## 🧙‍♂️ Epic Introduction
 

--- a/pages/_quests/1101/README.md
+++ b/pages/_quests/1101/README.md
@@ -27,6 +27,7 @@ toc_sticky: true
 sidebar:
   nav: quests
 draft: false
+mermaid: true
 ---
 # ⚡ Level 1101: Machine Learning & AI
 

--- a/pages/_quests/1110/404-hunting.md
+++ b/pages/_quests/1110/404-hunting.md
@@ -53,6 +53,7 @@ redirect_from:
 layout: quest
 sub_title: 'Level 1110 (14) Quest: Integration Spells for Link Integrity'
 draft: false
+mermaid: true
 ---
 *[In the digital matrix where URLs thread through luminous forests, a wraith prowls—the 404 Specter. Its hunger is broken paths; its lair, forgotten slugs. Today you rise as a Link Warden, weaving binary incantations to bind the 404 and light every trail.]*
 

--- a/pages/_quests/1110/README.md
+++ b/pages/_quests/1110/README.md
@@ -18,6 +18,7 @@ tags:
 - architecture
 - design
 - patterns
+mermaid: true
 ---
 # Level 1110: Quality Assurance
 

--- a/pages/_quests/1110/api-gateway-patterns.md
+++ b/pages/_quests/1110/api-gateway-patterns.md
@@ -81,6 +81,7 @@ rewards:
   unlocks_features:
   - The edge layer that fronts the scaling quest
 layout: quest
+mermaid: true
 ---
 *Architect, your kingdom of services now sprawls - and your clients are lost, knocking on a dozen different gates, each demanding its own credentials. An **API Gateway** is the single grand entrance to the Citadel: one address where every request arrives, is checked, is routed to the right keep, and is sent on its way. Master it, and your clients see one clean facade instead of a chaotic warren of services.*
 

--- a/pages/_quests/1110/design-patterns.md
+++ b/pages/_quests/1110/design-patterns.md
@@ -82,6 +82,7 @@ rewards:
   unlocks_features:
   - Access to the Architecture & Design Patterns quest line
 layout: quest
+mermaid: true
 ---
 *Greetings, Architect! You have ascended to the **Master tier**, where the Citadel of Architecture rises above every kingdom you have ever built. Here you do not write a single spell - you design the very grammar in which all spells are written. This quest, **Software Design Patterns**, hands you the master builder's catalog: named, battle-tested solutions to problems that have recurred in software since the first object met the first method.*
 

--- a/pages/_quests/1110/domain-driven-design.md
+++ b/pages/_quests/1110/domain-driven-design.md
@@ -82,6 +82,7 @@ rewards:
   unlocks_features:
   - Strategic design foundation for the rest of the Citadel
 layout: quest
+mermaid: true
 ---
 *Welcome back to the Citadel, Architect. You have learned to shape objects with patterns; now you must learn to shape the meaning the objects carry. **Domain-Driven Design** is the discipline of letting the business domain - not the database, not the framework - drive the design of your software. It is how a payments team and a payments codebase come to speak exactly the same language.*
 

--- a/pages/_quests/1110/event-driven-design.md
+++ b/pages/_quests/1110/event-driven-design.md
@@ -82,6 +82,7 @@ rewards:
   unlocks_features:
   - Asynchronous foundations for scaling the kingdom
 layout: quest
+mermaid: true
 ---
 *Architect, your services now stand as separate keeps - but they still shout across the courtyard, each waiting for the other to answer. **Event-Driven Design** teaches them a better way to communicate: instead of demanding answers, a service simply *announces what happened* and lets anyone who cares react. This single shift - from commands to events - is the secret behind systems that scale, decouple, and heal.*
 

--- a/pages/_quests/1110/microservices-architecture.md
+++ b/pages/_quests/1110/microservices-architecture.md
@@ -84,6 +84,7 @@ rewards:
   unlocks_features:
   - Access to the gateway, scaling, and event-driven quests
 layout: quest
+mermaid: true
 ---
 *Architect, the Citadel now turns from the design of a single keep to the design of a *kingdom*. **Microservices Architecture** is the art of splitting one application into many independently deployable services - and the wisdom to know when that splitting helps and when it merely trades simple problems for distributed ones.*
 

--- a/pages/_quests/1110/scaling-strategies.md
+++ b/pages/_quests/1110/scaling-strategies.md
@@ -82,6 +82,7 @@ rewards:
   unlocks_features:
   - The scaling toolkit needed for the system-design capstone
 layout: quest
+mermaid: true
 ---
 *Architect, your kingdom thrives - and with success comes a new siege: load. Ten users become ten thousand, and the keeps that served them gracefully now groan under the weight. **Scaling Strategies** is the discipline of growing a system to meet demand without it collapsing: adding machines, caching the hot paths, splitting the data, and balancing the flow. Master it, and traffic that would have toppled a lesser realm becomes a number on a dashboard.*
 

--- a/pages/_quests/1110/system-design-interviews.md
+++ b/pages/_quests/1110/system-design-interviews.md
@@ -82,6 +82,7 @@ rewards:
   unlocks_features:
   - The capstone of the Architecture & Design Patterns quest line
 layout: quest
+mermaid: true
 ---
 *Architect, this is the proving ground. You have mastered patterns, domains, services, events, gateways, and scale - and now you must wield them all *at once*, on a whiteboard, under a clock, while a stranger watches and asks "what happens when this fails?" The **System Design Interview** is the capstone of the Citadel: not a test of trivia, but of whether you can take a vague prompt and reason your way to a credible, defensible architecture out loud.*
 

--- a/pages/_quests/1111/README.md
+++ b/pages/_quests/1111/README.md
@@ -27,6 +27,7 @@ toc_sticky: true
 sidebar:
   nav: quests
 draft: false
+mermaid: true
 ---
 # 👑 Level 1111: Leadership & Innovation
 

--- a/pages/_quests/codex/world_map.md
+++ b/pages/_quests/codex/world_map.md
@@ -38,6 +38,7 @@ skill_focus:
 - reference
 learning_style: reading
 fmContentType: codex
+mermaid: true
 ---
 *Welcome, brave traveler, to the complete cartographical guide of the IT-Journey realm! This mystical map reveals every secret path, hidden treasure, and learning adventure across our digital kingdom.*
 

--- a/pages/_quests/templates/level-readme-template.md
+++ b/pages/_quests/templates/level-readme-template.md
@@ -34,6 +34,7 @@ skill_focus:
 learning_style: reading
 quest_type: template
 fmContentType: template
+mermaid: true
 ---
 # Level [BINARY] ([DECIMAL]) - [Level Name]
 

--- a/pages/_quests/templates/main-quest-template.md
+++ b/pages/_quests/templates/main-quest-template.md
@@ -94,6 +94,7 @@ quest_mapping:
   biome: Terminal
 comments: true
 draft: true
+mermaid: true
 ---
 *Greetings, brave adventurer! Welcome to **[Quest Name]** - an epic journey that will transform you into a master of [technology/skill]. This quest will guide you through [brief overview of what they'll accomplish], preparing you for [next steps in their IT journey].*
 

--- a/pages/_quests/tools/README.md
+++ b/pages/_quests/tools/README.md
@@ -17,6 +17,7 @@ tags:
 categories:
 - quests
 - tools
+mermaid: true
 ---
 # Tools Collection: Development Tools & Workflows
 

--- a/pages/_quests/tools/mastering-version-control-workflows.md
+++ b/pages/_quests/tools/mastering-version-control-workflows.md
@@ -96,6 +96,7 @@ validation_criteria:
   - Describe the SemVer implications of each commit type
 sub_title: 'Level 1100 (12) Quest: Main Quest - Advanced Git Mastery'
 draft: false
+mermaid: true
 ---
 *Greetings, battle-hardened code warrior! You have survived the introductory enchantments of branching and the clean-commit oath. But the realm of version control runs far deeper than a single `git push`. Today you face the Grand Merge Ritual — a trial reserved for those who would command entire release kingdoms, orchestrate fleets of pull requests, and bend the timeline of code to their will.*
 

--- a/scripts/validation/check_mermaid_flags.py
+++ b/scripts/validation/check_mermaid_flags.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""
+check_mermaid_flags.py
+
+IT-Journey Mermaid Rendering Guard
+==================================
+
+The zer0-mistakes theme only loads the Mermaid library when a page declares
+`mermaid: true` in its front matter:
+
+    {% if page.mermaid %}{% include components/mermaid.html %}{% endif %}
+
+Any content file that contains a Mermaid diagram (a ```mermaid fenced block or
+an HTML element with class="mermaid") but omits that flag will silently fail to
+render — the diagram shows up as a raw code block instead of a chart.
+
+This script scans every content file, decides whether it actually contains a
+Mermaid diagram (using a proper GFM fenced-code scanner so that *illustrative*
+mermaid examples nested inside a larger fence don't count), and reports — or
+fixes — any file whose flag is out of sync with its content.
+
+Modes
+-----
+    --check   (default) report files that need `mermaid: true`; exit 1 if any.
+    --fix     insert `mermaid: true` into the front matter of those files.
+    --prune   additionally report files that declare the flag but have no
+              diagram (informational; never auto-removed).
+
+Usage
+-----
+    python3 scripts/validation/check_mermaid_flags.py            # check
+    python3 scripts/validation/check_mermaid_flags.py --fix      # apply
+    python3 scripts/validation/check_mermaid_flags.py --json out.json
+
+Author: IT-Journey Team
+Created: 2026-06-20
+Version: 1.0.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional
+
+# --------------------------------------------------------------------------- #
+# Configuration
+# --------------------------------------------------------------------------- #
+
+# Directories to scan, relative to the repo root.
+CONTENT_GLOBS = ("pages/**/*.md", "pages/**/*.markdown", "pages/**/*.html")
+
+# Vendored / read-only content is never edited; surfaced separately.
+VENDORED_PATH_MARKERS = ("/wargames/",)
+VENDORED_FRONTMATTER_KEYS = ("source_repo",)
+
+FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?\n)---\s*\n", re.DOTALL)
+FENCE_RE = re.compile(r"^([`~]{3,})(.*)$")
+MERMAID_DIV_RE = re.compile(r"""class\s*=\s*["'][^"']*\bmermaid\b""")
+# A flag counts as "true" even with surrounding whitespace or a trailing
+# comment, so `mermaid: true  # render charts` is recognized (and never
+# duplicated). Case-insensitive; accepts true/yes.
+FLAG_TRUE_RE = re.compile(r"(?im)^mermaid:\s*(true|yes)\s*(#.*)?$")
+# Any top-level `mermaid:` key, regardless of value.
+FLAG_ANY_RE = re.compile(r"(?im)^mermaid:\s*(.+?)\s*$")
+
+
+class C:
+    """ANSI colors (no-op when not a TTY)."""
+
+    G = "\033[92m" if sys.stdout.isatty() else ""
+    Y = "\033[93m" if sys.stdout.isatty() else ""
+    R = "\033[91m" if sys.stdout.isatty() else ""
+    B = "\033[94m" if sys.stdout.isatty() else ""
+    D = "\033[2m" if sys.stdout.isatty() else ""
+    X = "\033[0m" if sys.stdout.isatty() else ""
+
+
+# --------------------------------------------------------------------------- #
+# Detection
+# --------------------------------------------------------------------------- #
+
+
+def split_frontmatter(text: str):
+    """Return (frontmatter_text_or_None, body_text)."""
+    m = FRONTMATTER_RE.match(text)
+    if not m:
+        return None, text
+    return m.group(1), text[m.end():]
+
+
+def body_has_mermaid(body: str) -> bool:
+    """
+    True when the body contains a *renderable* Mermaid diagram.
+
+    Implements GFM fenced-code semantics: the first fence of a run opens a
+    block; a closing fence must use the same character, be at least as long,
+    and carry no info string. A ```mermaid fence nested inside a larger fence
+    is literal text and does NOT count (those are tutorials showing syntax).
+    Raw HTML <... class="mermaid"> elements always count.
+    """
+    in_fence = False
+    fence_char = ""
+    fence_len = 0
+
+    for raw in body.splitlines():
+        stripped = raw.lstrip()
+        m = FENCE_RE.match(stripped)
+        if m:
+            marker, rest = m.group(1), m.group(2).strip()
+            char, length = marker[0], len(marker)
+            if not in_fence:
+                in_fence = True
+                fence_char, fence_len = char, length
+                info = rest.split()[0].lower() if rest else ""
+                if info == "mermaid":
+                    return True
+            else:
+                # A bare same-char fence of >= length closes the block.
+                if char == fence_char and length >= fence_len and rest == "":
+                    in_fence = False
+            continue
+        # Only inspect raw-HTML mermaid divs when not inside a code fence.
+        if not in_fence and MERMAID_DIV_RE.search(raw):
+            return True
+    return False
+
+
+@dataclass
+class FileResult:
+    path: str
+    has_diagram: bool
+    has_flag: bool
+    flag_value: Optional[str]  # raw value if `mermaid:` key present
+    has_frontmatter: bool
+    vendored: bool
+
+    @property
+    def needs_flag(self) -> bool:
+        # Only files with NO `mermaid:` key at all get a flag inserted. A file
+        # that has a non-true value (e.g. `mermaid: false`) is a *conflict*,
+        # routed to its own lane so --fix never emits a duplicate key.
+        return (
+            self.has_diagram
+            and self.has_frontmatter
+            and not self.has_flag
+            and self.flag_value is None
+            and not self.vendored
+        )
+
+    @property
+    def conflict(self) -> bool:
+        # Diagram present but flag explicitly set to a non-true value.
+        return (
+            self.has_diagram
+            and self.flag_value is not None
+            and not self.has_flag
+        )
+
+    @property
+    def stale_flag(self) -> bool:
+        return self.has_flag and not self.has_diagram and not self.vendored
+
+
+def analyze(path: Path) -> FileResult:
+    text = path.read_text(encoding="utf-8")
+    fm, body = split_frontmatter(text)
+    has_fm = fm is not None
+    has_diagram = body_has_mermaid(body)
+
+    flag_value = None
+    has_flag = False
+    vendored = any(marker in path.as_posix() for marker in VENDORED_PATH_MARKERS)
+    if has_fm:
+        has_flag = bool(FLAG_TRUE_RE.search(fm))
+        any_m = FLAG_ANY_RE.search(fm)
+        if any_m:
+            flag_value = any_m.group(1).strip()
+        if any(re.search(rf"(?m)^{re.escape(k)}:", fm) for k in VENDORED_FRONTMATTER_KEYS):
+            vendored = True
+
+    return FileResult(
+        path=path.as_posix(),
+        has_diagram=has_diagram,
+        has_flag=has_flag,
+        flag_value=flag_value,
+        has_frontmatter=has_fm,
+        vendored=vendored,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Fix
+# --------------------------------------------------------------------------- #
+
+
+def insert_flag(path: Path) -> bool:
+    """Insert `mermaid: true` as a top-level key just before the closing ---.
+
+    Preserves the file's existing line-ending convention (newline="" disables
+    universal-newline translation) and refuses to act if ANY `mermaid:` key is
+    already present, so it can never emit a duplicate mapping key.
+    """
+    text = path.read_text(encoding="utf-8", newline="")
+    m = FRONTMATTER_RE.match(text)
+    if not m:
+        return False
+    fm_block = m.group(0)  # includes opening/closing fences
+    if FLAG_ANY_RE.search(fm_block):
+        return False  # already declares mermaid (any value) — never duplicate
+
+    # Closing fence is the final '---' line of the matched block.
+    closing = re.search(r"\n---[ \t]*\r?\n$", fm_block) or re.search(r"\n---\s*\n$", fm_block)
+    if not closing:
+        return False
+    nl = "\r\n" if "\r\n" in fm_block else "\n"
+    insert_at = m.start() + closing.start() + 1  # right after the newline
+    new_text = text[:insert_at] + "mermaid: true" + nl + text[insert_at:]
+    path.write_text(new_text, encoding="utf-8", newline="")
+    return True
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+
+
+def collect_files(root: Path) -> List[Path]:
+    seen: set = set()
+    files: List[Path] = []
+    for pattern in CONTENT_GLOBS:
+        for p in root.glob(pattern):
+            if p.is_file() and p not in seen:
+                seen.add(p)
+                files.append(p)
+    return sorted(files)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Mermaid front-matter flag guard.")
+    ap.add_argument("--fix", action="store_true", help="insert missing flags")
+    ap.add_argument("--prune", action="store_true", help="also report stale flags")
+    ap.add_argument("--json", metavar="FILE", help="write a JSON report")
+    ap.add_argument("--root", default=".", help="repo root (default: cwd)")
+    args = ap.parse_args()
+
+    root = Path(args.root).resolve()
+    results = [analyze(p) for p in collect_files(root)]
+
+    needs = [r for r in results if r.needs_flag]
+    conflicts = [r for r in results if r.conflict]
+    stale = [r for r in results if r.stale_flag]
+    no_fm = [r for r in results if r.has_diagram and not r.has_frontmatter]
+    vendored = [r for r in results if r.has_diagram and r.vendored and not r.has_flag]
+    diagrams = [r for r in results if r.has_diagram]
+
+    def rel(p: str) -> str:
+        return str(Path(p).resolve().relative_to(root))
+
+    print(f"{C.B}Mermaid flag guard{C.X}  ·  scanned {len(results)} files, "
+          f"{len(diagrams)} contain diagrams")
+
+    fixed = 0
+    if needs:
+        verb = "Fixing" if args.fix else "Missing flag"
+        print(f"\n{C.Y}{verb} ({len(needs)}):{C.X}")
+        for r in needs:
+            if args.fix:
+                ok = insert_flag(Path(r.path))
+                fixed += int(ok)
+                mark = f"{C.G}fixed{C.X}" if ok else f"{C.R}skip{C.X}"
+                print(f"  {mark}  {rel(r.path)}")
+            else:
+                print(f"  {C.R}·{C.X} {rel(r.path)}")
+
+    if conflicts:
+        print(f"\n{C.R}Conflicts — diagram present but mermaid flag is not true "
+              f"({len(conflicts)}):{C.X}")
+        for r in conflicts:
+            print(f"  · {rel(r.path)}  (mermaid: {r.flag_value})")
+
+    if no_fm:
+        print(f"\n{C.R}Diagram but NO front matter ({len(no_fm)}):{C.X}")
+        for r in no_fm:
+            print(f"  · {rel(r.path)}")
+
+    if vendored:
+        print(f"\n{C.D}Vendored (read-only) files with diagrams, left untouched "
+              f"({len(vendored)}):{C.X}")
+        for r in vendored:
+            print(f"  · {rel(r.path)}")
+
+    if args.prune and stale:
+        print(f"\n{C.D}Stale flag — mermaid: true but no diagram ({len(stale)}):{C.X}")
+        for r in stale:
+            print(f"  · {rel(r.path)}")
+
+    if args.json:
+        payload = {
+            "scanned": len(results),
+            "with_diagrams": len(diagrams),
+            "needs_flag": [rel(r.path) for r in needs],
+            "conflicts": [{"file": rel(r.path), "value": r.flag_value} for r in conflicts],
+            "no_frontmatter": [rel(r.path) for r in no_fm],
+            "vendored_with_diagrams": [rel(r.path) for r in vendored],
+            "stale_flags": [rel(r.path) for r in stale],
+            "fixed": fixed,
+        }
+        Path(args.json).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        print(f"\n{C.D}JSON report → {args.json}{C.X}")
+
+    if args.fix:
+        print(f"\n{C.G}Applied {fixed} fix(es).{C.X}")
+        return 0
+
+    problems = len(needs) + len(conflicts) + len(no_fm)
+    if problems:
+        print(f"\n{C.R}{problems} file(s) need attention. Run with --fix to "
+              f"insert missing flags.{C.X}")
+        return 1
+    print(f"\n{C.G}All diagrams have the mermaid flag. ✔{C.X}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Fixes Mermaid diagrams that rendered as raw code blocks across the site, and replaces the bottom-of-page quest-network diagram with an Obsidian-style interactive graph. Originated from reviewing https://it-journey.dev/quests/0000/hello-noob/.

### Why
The remote theme (zer0-mistakes) only loads Mermaid when a page declares `mermaid: true` in front matter (`{% if page.mermaid %}` in `head.html`). **57 content files** — including `quests/0000/hello-noob` — had ```mermaid diagrams but omitted the flag, so the library never loaded. The layout-injected "🕸️ Quest Network" diagram was *also* Mermaid gated by the same flag, so it was broken on most quests too.

## What changed

**Mermaid rendering (`fix(content)`)**
- Added `mermaid: true` to all 57 affected files.
- New `scripts/validation/check_mermaid_flags.py` — GFM-aware scanner (ignores Mermaid examples nested inside larger code fences), `--check`/`--fix` modes, preserves line endings, never emits a duplicate YAML key.
- Wired into `Makefile` (`make mermaid-check` / `mermaid-fix`, and `content-audit`) and `frontmatter-validation.yml` so the guard runs on PRs and drift can't return.

**Obsidian quest-network graph (`feat(quests)`)**
- New `_includes/content/quest-graph-obsidian.html` — self-contained cytoscape.js force-directed graph built from `assets/data/quest-network.json`. Lazy-loads cytoscape (so it does **not** depend on `page.mermaid`), level-filtered, difficulty-colored nodes, current quest ringed as "you are here", click-to-open, theme-aware (light/dark), with required/unlocks/recommended edge styles.
- Swapped into `_layouts/quest.html` (passes `current=page.permalink`), replacing the old Mermaid include for all quests.

## Verification
- Adversarial multi-agent review (3 dimensions) surfaced 6 confirmed findings — **all fixed** (latent duplicate-YAML-key bug, CI-enforcement gap, CRLF preservation, cytoscape loader race, edge legend).
- **Live Jekyll build** of `/quests/0000/hello-noob/`: 2/2 in-content Mermaid diagrams render to SVG (0 unconverted blocks, library loaded); Obsidian graph shows 27 nodes / 72 edges with Hello n00b highlighted; 0 relevant console errors.
- `make mermaid-check` passes (656 scanned, 81 with diagrams, all flagged); all 57 edited files re-validated as valid YAML.

## Reviewer notes
- The old `_includes/content/quest-graph.html` (Mermaid) is now unused but kept (documented reusable include).
- No quest-registry fields changed (`mermaid:` isn't a registry field), so `_data/quests/*` is unaffected.
- A pre-existing local-only `Gemfile.lock` issue (yanked generic `x86_64-linux` `ffi`) blocks the Docker build; worked around temporarily during verification and reverted — it must stay for GitHub Pages CI (glibc). Worth a separate deps fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)