### PR TITLE
chore(theme): track theme main via remote_theme (no gem/pin/schedule)

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -112,7 +112,7 @@ jobs:
 
         if [ "${{ github.event_name }}" = "pull_request" ]; then
           BUILD_CONFIG="_config.yml,_config_dev.yml,_config_ci.yml"
-          BUILD_LABEL="CI smoke (local theme, no preview scan)"
+          BUILD_LABEL="CI smoke (remote theme @ main, no preview scan)"
         else
           BUILD_CONFIG="_config.yml"
           BUILD_LABEL="production"

--- a/Gemfile
+++ b/Gemfile
@@ -11,10 +11,9 @@ source "https://rubygems.org"
 # Github Pages Gems - Use latest compatible version:
 gem 'github-pages'
 
-# Jekyll Theme: use local gem for dev (avoids remote_theme network download)
-gem 'jekyll-theme-zer0'
-
-# Jekyll Theme is loaded via `remote_theme` in `_config.yml` and `_config_dev.yml`.
+# Jekyll Theme: served via `remote_theme: bamr87/zer0-mistakes` in _config.yml
+# (and dev/CI via _config_dev.yml), so every build tracks the theme's main
+# branch. jekyll-remote-theme ships with the github-pages gem — no theme gem.
 
 # If you have plugins enabled in the _config.yml, add them here too:
 group :jekyll_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,8 +210,6 @@ GEM
     jekyll-theme-time-machine (0.2.0)
       jekyll (> 3.5, < 5.0)
       jekyll-seo-tag (~> 2.0)
-    jekyll-theme-zer0 (1.19.1)
-      jekyll
     jekyll-titles-from-headings (0.5.3)
       jekyll (>= 3.3, < 5.0)
     jekyll-watch (2.2.1)
@@ -288,7 +286,6 @@ DEPENDENCIES
   ffi
   github-pages
   jekyll-include-cache
-  jekyll-theme-zer0
   webrick
 
 BUNDLED WITH

--- a/_config_ci.yml
+++ b/_config_ci.yml
@@ -1,4 +1,6 @@
-# CI smoke-build override — fast PR validation without remote theme fetch.
+# CI smoke-build override — fast PR validation (skips the preview-image scan).
+# The theme is fetched via remote_theme (inherited from _config.yml), same as
+# production, so CI builds against the theme's current main branch.
 # Usage: bundle exec jekyll build --config _config.yml,_config_dev.yml,_config_ci.yml
 
 preview_images:

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,10 +1,11 @@
 # Dev config override — merged after _config.yml:
 #   bundle exec jekyll serve --config _config.yml,_config_dev.yml
 #
-# Note: Jekyll skips nil values when merging, so use "" (not null) to clear remote_theme.
-
-remote_theme             : ""
-theme                    : "jekyll-theme-zer0"
+# Theme: dev/CI inherit `remote_theme: bamr87/zer0-mistakes` from _config.yml so
+# every build tracks the theme's main branch (same as production) — no gem, no
+# pin, no version to bump. jekyll-remote-theme must stay in this file's plugins
+# list below for that to load. (Trade-off: builds fetch the theme over the
+# network instead of from a local gem.)
 
 # Allow future-dated posts to be rendered in development
 future: true
@@ -24,7 +25,9 @@ show_drafts: false
 
 # Performance: disable feed/sitemap regeneration during dev
 # These plugins regenerate fully on every change, adding ~10-20s
+# jekyll-remote-theme is required here so the inherited remote_theme loads in dev.
 plugins:
+  - jekyll-remote-theme
   - jekyll-include-cache
   - jekyll-relative-links
   - jekyll-redirect-from


### PR DESCRIPTION
## What

Make local and CI builds source the theme the same way production already does — `remote_theme: bamr87/zer0-mistakes` — and **remove the pinned theme gem entirely**. Every build now tracks the theme's `main` branch automatically, with **no version/SHA to pin and no scheduled job**.

## Why

Previously two channels diverged: prod used `remote_theme` (main HEAD) while local/CI used the pinned gem `jekyll-theme-zer0 1.19.1`. That gap is exactly what hid a theme bug from CI. Rather than add machinery to keep a pinned gem current (a scheduled `bundle update` PR), this drops the pin altogether and uses one source everywhere.

## Changes

- **Gemfile / Gemfile.lock** — remove `jekyll-theme-zer0`. The theme is served by `remote_theme`, whose plugin (`jekyll-remote-theme`) ships with `github-pages`.
- **_config_dev.yml** — stop clearing `remote_theme` / setting `theme:`; add `jekyll-remote-theme` to the dev plugins list so the inherited `remote_theme` loads in dev/CI.
- **_config_ci.yml**, **build-validation.yml** — refresh now-stale "local theme / no remote fetch" comments.

## Trade-offs (intended — "bleeding edge, mirror prod")

- Builds fetch the theme over the network each run (no offline/local-gem path).
- Not byte-reproducible across theme commits (you're always on `main` HEAD).
- A breaking theme commit surfaces on the **next** build (PR/push), not via a reviewable bump PR.

## Verification

CI-parity build (`_config.yml,_config_dev.yml,_config_ci.yml`, amd64) is **green** and logs:

```
Remote Theme: Using theme bamr87/zer0-mistakes
```

68 posts built, `Gemfile.lock` platforms unchanged. Production (`deploy.yml`, `_config.yml`) is unaffected — it already used `remote_theme`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)