### PR TITLE
chore(theme): pin theme to one gem everywhere + Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,40 @@
+---
+name: 🤖 Dependabot auto-merge (theme)
+
+# Auto-merges Dependabot PRs that bump the `jekyll-theme-zer0` gem once required
+# CI checks pass — keeping the pinned theme current hands-free. Minor/patch only;
+# major bumps are left for manual review.
+#
+# Prerequisites (repo settings):
+#   • Settings → General → "Allow auto-merge" must be enabled.
+#   • Branch protection on `main` should require the Build Validation checks, so
+#     auto-merge waits for green before merging (otherwise it merges as soon as
+#     the PR is mergeable).
+
+on:
+  pull_request:
+    branches: [main]
+
+# Elevates the Dependabot GITHUB_TOKEN so it can enable auto-merge.
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    name: Enable auto-merge for theme bumps
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+
+      - name: Enable auto-merge (jekyll-theme-zer0, non-major)
+        if: >-
+          steps.meta.outputs.dependency-names == 'jekyll-theme-zer0' &&
+          steps.meta.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Gemfile
+++ b/Gemfile
@@ -11,10 +11,10 @@ source "https://rubygems.org"
 # Github Pages Gems - Use latest compatible version:
 gem 'github-pages'
 
-# Jekyll Theme: use local gem for dev (avoids remote_theme network download)
+# Jekyll Theme — pinned gem used everywhere (production + CI/dev) for
+# reproducible builds. Gemfile.lock pins the version; Dependabot + the auto-merge
+# workflow (.github/workflows/dependabot-automerge.yml) keep it current.
 gem 'jekyll-theme-zer0'
-
-# Jekyll Theme is loaded via `remote_theme` in `_config.yml` and `_config_dev.yml`.
 
 # If you have plugins enabled in the _config.yml, add them here too:
 group :jekyll_plugins do

--- a/_config.yml
+++ b/_config.yml
@@ -27,8 +27,11 @@
 # Site Settings ###################################################################
 
 founder                  : "Amr Abdel-Motaleb"
-remote_theme             : "bamr87/zer0-mistakes"
-# theme                    : "jekyll-theme-zer0"
+# Theme: the pinned `jekyll-theme-zer0` gem (version in Gemfile.lock), used in
+# production and CI/dev alike — one reproducible source, no version skew.
+# Dependabot + the auto-merge workflow keep it current.
+theme                    : "jekyll-theme-zer0"
+# remote_theme           : "bamr87/zer0-mistakes"   # was: tracked main HEAD (unpinned)
 
 ## Github Information
 github_user              : &github_user "bamr87"
@@ -190,7 +193,6 @@ powered_by:
 plugins:
   - github-pages
   - jekyll-include-cache
-  - jekyll-remote-theme
   - jekyll-feed
   - jekyll-sitemap
   - jekyll-seo-tag
@@ -218,7 +220,7 @@ gisgus:
 #   1. Add 'mermaid: true' to page front matter
 #   2. Use ```mermaid ... ``` code blocks OR <div class="mermaid">...</div>
 #
-# GitHub Pages Compatible: Yes (client-side; assets served via remote_theme)
+# GitHub Pages Compatible: Yes (client-side; assets served from the theme gem)
 
 mermaid:
   src: '/assets/vendor/mermaid/mermaid.min.js'

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,10 +1,8 @@
 # Dev config override — merged after _config.yml:
 #   bundle exec jekyll serve --config _config.yml,_config_dev.yml
 #
-# Note: Jekyll skips nil values when merging, so use "" (not null) to clear remote_theme.
-
-remote_theme             : ""
-theme                    : "jekyll-theme-zer0"
+# Theme: inherited from _config.yml (the pinned jekyll-theme-zer0 gem). Same
+# source in dev, CI, and production — no override needed here.
 
 # Allow future-dated posts to be rendered in development
 future: true


### PR DESCRIPTION
## What

Make the theme a **single, pinned source** — the `jekyll-theme-zer0` gem — used in production, CI, and local dev alike, and let **Dependabot + auto-merge** keep it current. Replaces the now-closed #354 (no-pin) per the chosen recommendation.

## Why

The repo sourced the theme two ways: prod via `remote_theme` (main HEAD, unpinned) and CI/dev via the gem. That divergence is exactly what let a theme build bug slip past CI. Pinning one gem everywhere gives reproducible builds and removes the skew entirely.

## Changes

- **_config.yml** — `theme: jekyll-theme-zer0`; remove `remote_theme` and the `jekyll-remote-theme` plugin (no longer needed). Fix a stale "assets served via remote_theme" comment.
- **_config_dev.yml** — drop the redundant `remote_theme: ""` / `theme:` overrides; theme is inherited from `_config.yml`.
- **Gemfile** — note the gem is used everywhere (lock pins the version).
- **.github/workflows/dependabot-automerge.yml** — auto-merge Dependabot's `jekyll-theme-zer0` **minor/patch** bumps once CI passes (majors stay manual). Pinned `dependabot/fetch-metadata@v3.1.0`.

`Gemfile.lock` is unchanged — it already pins `jekyll-theme-zer0 1.19.1` (the latest *published* gem; 1.20.0 is only on theme `main`, not yet released).

## Behavior notes

- **Production pins to the released gem (1.19.1)** instead of theme `main` HEAD. Unreleased `main` changes land when 1.20.x is published and Dependabot bumps the lock — that's the intended reproducible-pin trade-off.
- Auto-merge requires two repo settings to take effect: **Settings → General → Allow auto-merge**, and **branch protection on `main`** requiring the Build Validation checks (so it waits for green).

## Verification

amd64 CI-parity build is **green for both configs**:
- prod (`_config.yml`) → `PROD_OK`, 68 posts
- CI (`_config.yml,_config_dev.yml,_config_ci.yml`) → `CI_OK`, 68 posts
- No "Remote Theme" in the log (confirms the gem is the source); `Gemfile.lock` platforms unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)