### PR TITLE
ci(deps): group Dependabot updates + auto-merge passing bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,60 @@
 version: 2
 updates:
-  # Keep SHA-pinned GitHub Actions current (Dependabot bumps the pin + comment).
+  # ---------------------------------------------------------------------------
+  # GitHub Actions — keep SHA-pinned actions current (Dependabot bumps the pin
+  # + the trailing version comment).
+  #
+  # Grouped so related actions move together in a single PR. This is REQUIRED
+  # for github/codeql-action: its init/autobuild/analyze steps must all run the
+  # same major version, or the workflow fails with
+  #   "Loaded a configuration file for version '4.x', but running version '3.x'".
+  # Splitting them into separate PRs (the old default) made every CodeQL bump
+  # fail. See .github/workflows/dependabot-auto-merge.yml for the merge policy.
+  # ---------------------------------------------------------------------------
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 5
     commit-message:
       prefix: ci
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      # The three CodeQL steps always travel together (any version-update type),
+      # so a 3.x -> 4.x major lands as one coherent, passing PR.
+      codeql:
+        patterns:
+          - "github/codeql-action*"
+      # Everything else: routine minor/patch bumps batched into one PR.
+      # (A non-CodeQL action's MAJOR bump still opens as its own PR so it can be
+      # reviewed individually.)
+      actions:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+        exclude-patterns:
+          - "github/codeql-action*"
 
-  # Ruby gem updates (github-pages, jekyll plugins).
+  # ---------------------------------------------------------------------------
+  # Ruby gems (github-pages, jekyll plugins). Minor/patch batched into one PR;
+  # a MAJOR gem bump (e.g. jekyll) opens individually for a deliberate review.
+  # ---------------------------------------------------------------------------
   - package-ecosystem: bundler
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 5
     commit-message:
       prefix: deps
+    labels:
+      - dependencies
+      - ruby
+    groups:
+      ruby:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,8 +28,8 @@ updates:
         patterns:
           - "github/codeql-action*"
       # Everything else: routine minor/patch bumps batched into one PR.
-      # (A non-CodeQL action's MAJOR bump still opens as its own PR so it can be
-      # reviewed individually.)
+      # (A non-CodeQL action's MAJOR bump still opens as its own PR — it then
+      # auto-merges on green CI like any other; see the auto-merge workflow.)
       actions:
         applies-to: version-updates
         update-types:
@@ -40,7 +40,7 @@ updates:
 
   # ---------------------------------------------------------------------------
   # Ruby gems (github-pages, jekyll plugins). Minor/patch batched into one PR;
-  # a MAJOR gem bump (e.g. jekyll) opens individually for a deliberate review.
+  # a MAJOR gem bump (e.g. jekyll) opens individually (and auto-merges on green CI).
   # ---------------------------------------------------------------------------
   - package-ecosystem: bundler
     directory: /

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,74 @@
+name: 🤖 Dependabot auto-merge
+
+# Keeps dependencies current with zero manual review for the routine case.
+#
+# Policy
+# ------
+#   • minor / patch bumps  -> wait for CI, then squash-merge automatically.
+#   • a check FAILS         -> stop, label `ci-failed`, leave the PR open for you.
+#   • MAJOR version bumps   -> never auto-merged; labeled `requires-review` and
+#                              left open for a deliberate look (majors are where
+#                              breakage hides, and CI can't always catch it).
+#
+# This is self-contained: it does NOT require branch protection or the repo
+# "auto-merge" setting, and it never blocks the workflows that push to `main`
+# directly. It simply watches the checks that actually run on each PR and merges
+# only when they are green.
+#
+# Security: triggered via pull_request_target so the token can merge, but it
+# never checks out or executes the PR's code — it only calls the GitHub API.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+
+concurrency:
+  group: dependabot-automerge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  auto-merge:
+    # Only act on Dependabot's own PRs.
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Hold major version bumps for review
+        if: ${{ steps.meta.outputs.update-type == 'version-update:semver-major' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          NAMES: ${{ steps.meta.outputs.dependency-names }}
+        run: |
+          gh pr edit "$PR_URL" --add-label "requires-review" || true
+          gh pr comment "$PR_URL" --body \
+            "🟠 **Major** version bump (\`$NAMES\`). Auto-merge is held — review and merge manually when you're ready."
+          echo "Major bump held for review; not auto-merging."
+
+      - name: Wait for checks, then merge
+        if: ${{ steps.meta.outputs.update-type != 'version-update:semver-major' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          # Block until every check on this PR finishes. --fail-fast exits non-zero
+          # the moment one fails, so a broken update is never merged.
+          if gh pr checks "$PR_URL" --watch --fail-fast --interval 30; then
+            gh pr merge "$PR_URL" --squash --delete-branch
+            echo "All checks green — merged ✅"
+          else
+            echo "A check failed — leaving the PR open for review."
+            gh pr edit "$PR_URL" --add-label "ci-failed" || true
+            exit 1
+          fi

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -4,16 +4,15 @@ name: 🤖 Dependabot auto-merge
 #
 # Policy
 # ------
-#   • minor / patch bumps  -> wait for CI, then squash-merge automatically.
-#   • a check FAILS         -> stop, label `ci-failed`, leave the PR open for you.
-#   • MAJOR version bumps   -> never auto-merged; labeled `requires-review` and
-#                              left open for a deliberate look (majors are where
-#                              breakage hides, and CI can't always catch it).
+#   • any Dependabot bump  -> wait for CI, then squash-merge automatically.
+#   • a check FAILS        -> stop, label `ci-failed`, leave the PR open for you.
+#
+# So the only PRs you ever look at are the ones that actually break something.
 #
 # This is self-contained: it does NOT require branch protection or the repo
 # "auto-merge" setting, and it never blocks the workflows that push to `main`
-# directly. It simply watches the checks that actually run on each PR and merges
-# only when they are green.
+# directly. It simply watches the checks that actually run on each PR (which are
+# path-filtered, so it waits for whatever is relevant) and merges only when green.
 #
 # Security: triggered via pull_request_target so the token can merge, but it
 # never checks out or executes the PR's code — it only calls the GitHub API.
@@ -38,26 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Fetch Dependabot metadata
-        id: meta
-        uses: dependabot/fetch-metadata@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Hold major version bumps for review
-        if: ${{ steps.meta.outputs.update-type == 'version-update:semver-major' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          NAMES: ${{ steps.meta.outputs.dependency-names }}
-        run: |
-          gh pr edit "$PR_URL" --add-label "requires-review" || true
-          gh pr comment "$PR_URL" --body \
-            "🟠 **Major** version bump (\`$NAMES\`). Auto-merge is held — review and merge manually when you're ready."
-          echo "Major bump held for review; not auto-merging."
-
       - name: Wait for checks, then merge
-        if: ${{ steps.meta.outputs.update-type != 'version-update:semver-major' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Goal

Stay current with dependencies **without reviewing PRs unless something breaks**. Two changes make that the default.

## 1. Group Dependabot updates (`.github/dependabot.yml`)

Today every action bump opens its own PR. That's what made the **3 open CodeQL PRs (#360 / #363 / #364) fail** — Dependabot bumped `init`, `autobuild`, and `analyze` in *separate* PRs, so each PR mixed v4 + v3 and the workflow died with:

> `Loaded a configuration file for version '4.36.2', but running version '3.36.2'`

Grouping fixes this permanently:
- **`codeql` group** — `github/codeql-action*` always bump together (so a 3→4 major lands as one passing PR).
- **`actions` group** — routine minor/patch action bumps batched into one weekly PR; a non-CodeQL major opens individually.
- **`ruby` group** — gem minor/patch batched; a gem major (e.g. jekyll) opens individually.

Result: ~1 PR/week instead of 5, and no more split-version CodeQL failures.

## 2. Auto-merge passing bumps (`.github/workflows/dependabot-auto-merge.yml`)

| Update | What happens |
|---|---|
| any bump (minor/patch/**major**) | Waits for CI → **squash-merges automatically**, deletes the branch |
| any check **fails** | Stops, labels `ci-failed`, **leaves the PR open** for you |

The only PRs you ever look at are the ones that actually break CI.

Self-contained: **no branch protection or repo auto-merge setting required**, and it never interferes with the workflows that push to `main` directly. It watches whatever checks actually run on each PR (path-filtered) and merges only when green. Runs via `pull_request_target` but never checks out or runs PR code — API calls only.

## After this merges
- The 2 currently-green minor PRs (#361, #362) get merged.
- The 3 failing CodeQL PRs (#360/#363/#364) are closed — Dependabot will reopen them as **one** grouped, passing PR (which then auto-merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)