### PR TITLE
content(about): regrand the /about/ page — deepen the pillars, cut the filler

### DIFF
--- a/pages/_about/about.md
+++ b/pages/_about/about.md
@@ -1,501 +1,211 @@
 ---
-title: About
-excerpt: Discover the vision behind IT-Journey - a comprehensive learning platform that guides aspiring developers from zero to hero through open-source principles and hands-on experience.
+title: About IT-Journey — From zer0 to her0
+excerpt: IT-Journey is an open-source platform that turns curiosity into capability — a free, gamified path from your first command to systems you design yourself.
 permalink: /about/
-lastmod: '2025-11-02T15:57:16.000Z'
-slug: about
 date: '2021-09-29T15:48:23.000Z'
-description: Learn about IT-Journey's mission to democratize IT education through open-source technologies and collaborative learning.
+lastmod: '2026-06-26T00:00:00.000Z'
+author: IT-Journey Team
+slug: about
+description: An open-source platform that takes you from zer0 to her0 in IT — gamified quests, hands-on practice, and seven principles that shape how we build and learn.
 categories:
 - about
 tags:
 - about
+- mission
 - principles
 - open-source
-- collaboration
-- DRY
-- KIS
-- REnO
-- MVP
-- education
+- gamification
 - learning
-- ai-agents
 - ai-development
-- machine-learning
-- documentation
-- automated-documentation
+toc: true
 draft: false
 ---
-{% if site.description %}
-{{ site.description }}
-{% else %}
-Welcome to IT-Journey - your comprehensive guide from zero to hero in the world of Information Technology and software development.
-{% endif %}
 
-## Table of Contents
+<style>
+.itj-about-hero {
+  margin: 0.5rem 0 2.5rem;
+  padding: 3rem 1.5rem;
+  border: 1px solid var(--zer0-color-border, rgba(168,85,247,0.35));
+  border-radius: 1rem;
+  text-align: center;
+  background:
+    radial-gradient(1200px 400px at 50% -20%, rgba(168,85,247,0.22), transparent 70%),
+    linear-gradient(180deg, rgba(34,211,238,0.06), transparent 60%);
+}
+.itj-about-hero .kicker {
+  margin: 0 0 0.85rem;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--zer0-color-accent, #22d3ee);
+}
+.itj-about-hero h2 {
+  margin: 0 auto 1rem;
+  max-width: 18ch;
+  border: 0;
+  font-family: 'Cinzel', Georgia, serif;
+  font-weight: 700;
+  line-height: 1.15;
+  font-size: clamp(1.7rem, 4.2vw, 2.9rem);
+}
+.itj-about-hero p {
+  margin: 0 auto;
+  max-width: 60ch;
+  font-size: 1.08rem;
+  opacity: 0.92;
+}
+.itj-about-hero .zh {
+  color: var(--zer0-color-primary, #a855f7);
+  font-weight: 700;
+}
+.itj-pillars {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.9rem;
+  margin: 1.75rem 0 2.25rem;
+}
+.itj-pillar {
+  padding: 1.1rem 1.2rem;
+  border: 1px solid var(--zer0-color-border, rgba(148,163,184,0.25));
+  border-radius: 0.85rem;
+  background: var(--zer0-color-surface, rgba(148,163,184,0.06));
+}
+.itj-pillar .code {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  color: var(--zer0-color-accent, #22d3ee);
+}
+.itj-pillar h4 {
+  margin: 0.3rem 0 0.4rem;
+  font-family: 'Space Grotesk', system-ui, sans-serif;
+  font-size: 1.02rem;
+}
+.itj-pillar p { margin: 0; font-size: 0.92rem; opacity: 0.86; }
+.itj-pillar.approach { border-style: dashed; }
+</style>
 
-- [Table of Contents](#table-of-contents)
-- [Introduction](#introduction)
-- [Our Vision](#our-vision)
-- [Core Principles](#core-principles)
-  - [Design for Failure - DFF](#design-for-failure---dff)
-  - [Don't Repeat Yourself - DRY](#dont-repeat-yourself---dry)
-  - [Keep It Simple - KIS](#keep-it-simple---kis)
-  - [Release Early and Often - REnO](#release-early-and-often---reno)
-  - [Minimum Viable Product - MVP](#minimum-viable-product---mvp)
-  - [Collaboration - COLAB](#collaboration---colab)
-  - [AI-Powered Development - AIPD](#ai-powered-development---aipd)
-- [AI-Driven Documentation](#ai-driven-documentation)
-  - [Documentation Automation Benefits](#documentation-automation-benefits)
-  - [AI Documentation Tools \& Integration](#ai-documentation-tools--integration)
-  - [Best Practices for AI Documentation](#best-practices-for-ai-documentation)
-- [AI-Powered Testing](#ai-powered-testing)
-  - [Automated Test Generation](#automated-test-generation)
-  - [Adaptive Testing Strategies](#adaptive-testing-strategies)
-  - [Test Evolution \& Maintenance](#test-evolution--maintenance)
-  - [AI Testing Tools \& Frameworks](#ai-testing-tools--frameworks)
-  - [Best Practices for AI Testing](#best-practices-for-ai-testing)
-- [About This Project](#about-this-project)
-  - [👥 Maintainers](#-maintainers)
-  - [👥 Maintainers](#-maintainers-1)
-  - [⚡ Powered By](#-powered-by)
-  - [⚡ Powered By](#-powered-by-1)
-- [Contact](#contact)
-- [Get Involved](#get-involved)
-  - [🌟 For Learners](#-for-learners)
-  - [🛠️ For Contributors](#️-for-contributors)
-  - [🤖 For AI Enthusiasts](#-for-ai-enthusiasts)
-  - [📚 For Educators](#-for-educators)
+<div class="itj-about-hero">
+  <p class="kicker">An open-source path from zer0 to her0</p>
+  <h2>Technology should be learnable by anyone curious enough to try.</h2>
+  <p>IT-Journey turns that conviction into something you can use today: a free, open, gamified path from your first command to the systems you will one day design — and the <span class="zh">zer0&nbsp;→&nbsp;her0</span> progression that gets you there.</p>
+</div>
 
-## Introduction
+## The mission
 
-Welcome to **IT-Journey** - a comprehensive learning platform designed to guide aspiring developers and IT professionals from complete beginners to confident practitioners. This open-source educational resource covers fundamental concepts and practical tools used to build modern information systems, with a special focus on AI-powered development practices.
+The internet promised that knowledge would be free. What it delivered was an ocean of information and almost no map. The skills that decide who builds the future — writing software, running systems, reasoning with data and now with AI — sit behind paywalls, jargon, and credential gates that most people never get past. As technology grows more central to economic life, that gap widens into a divide.
 
-Our mission is to democratize IT education by utilizing open-source technologies, free services, and cutting-edge AI tools, ensuring that anyone with curiosity and dedication can learn. Whether you're looking to become a full-stack developer, understand how the internet works, harness the power of AI agents in development, or simply want better tools for everyday tasks like journaling or recipe management, this site provides the foundation you need.
+IT-Journey exists to close it. Our mission is to **democratize IT education through open-source technology and AI tools, so that anyone with curiosity and dedication can learn** — and to keep tilting the balance back toward the people who have been priced out of it. Education is the lever; open source is the fulcrum.
 
-The domain `{% if site.domain %}{{ site.domain }}{% else %}it-journey.dev{% endif %}` represents our commitment to lifelong learning and continuous growth in the ever-evolving field of technology.
+Open source is not only the price tag. It is the method. Every quest, script, and word on this site lives in a public [GitHub repository](https://github.com/bamr87/it-journey) that you can read, fork, correct, and carry with you. Nothing here is a black box, because a tool you cannot inspect is a tool you cannot truly own. The project is run as a commons: any proceeds fund only the maintenance needed to keep it running, and the goal is a platform that can operate in perpetuity, owned by no one and useful to everyone.
 
-## Our Vision
+That is the "so what" for you: this is yours. Read the source, take what helps, and leave the rest better than you found it.
 
-🎯 **Accessible Education**: Remove financial barriers to quality IT education  
-🌍 **Global Community**: Foster a worldwide community of learners and contributors  
-🔧 **Practical Learning**: Emphasize hands-on experience with real-world applications  
-📚 **Comprehensive Coverage**: Bridge theory with practical implementation  
-🚀 **Career Ready**: Prepare learners for modern development roles  
-🤖 **AI-Enhanced Learning**: Leverage AI agents to personalize and accelerate the learning journey
+## From zer0 to her0: how we teach
 
-## Core Principles
+The name is the method. **zer0** is wherever you actually are — a blank terminal, a borrowed laptop, a half-remembered idea of how the internet works. **her0** is the practitioner who can build the thing they imagined and fix it when it breaks. Between them runs a path you walk one concrete step at a time.
 
-Our development philosophy is built on seven fundamental principles that guide both the creation of this platform and the learning approach we advocate. These principles are essential for successful open-source projects and professional development practices, especially in the modern era of AI-assisted development.
+We teach by doing, because the evidence is hard to argue with. A [meta-analysis of 225 studies](https://www.pnas.org/doi/10.1073/pnas.1319030111) found that students in active-learning courses scored measurably higher on exams and were about 1.5 times less likely to fail than students sitting through traditional lectures. The companion finding from cognitive science is [retrieval practice](https://www.retrievalpractice.org/why-it-works): pulling an answer out of your own head builds far more durable memory than reading the answer again. Lectures are comfortable and forgettable. Building something is uncomfortable, and it sticks.
 
-### Design for Failure - DFF
+So the unit of learning here is the **quest**: a self-contained mission with a clear objective, a real artifact you produce, and a way to verify you got it right. Quests are organized into levels and tiers — a 4-bit map from `0000` toward her0 — so the difficulty climbs as your confidence does, and you always know the next step. That structure is not decoration. Clear goals, immediate feedback, and a staircase of increasing challenge are the same mechanics that make games hard to put down, pointed at learning instead of leaderboards.
 
-**[🔗 Learn more about resilient systems](https://en.wikipedia.org/wiki/Fault_tolerance)**
+Start where you are. [Open the quest map](/quests/), pick the level that matches your nerve, and run the first command.
 
-Design for Failure (DFF) acknowledges that in complex systems, failures are inevitable. Rather than avoiding failure, we prepare for it by building resilient systems that can gracefully handle unexpected situations.
+## The pillars
 
-<details>
-<summary>Key Concepts</summary>
+Seven principles shape this project — both the software we build and the way we teach you to build. They come from decades of hard-won practice in software engineering, and they do double duty here: each one is a rule for writing good code, a rule for learning well, and a rule for writing honestly. Three lighter heuristics round them out. Together they are the spine of every quest.
 
-- **Redundancy**: Multiple backup systems ready to take over
-- **Monitoring**: Real-time detection and alerting systems
-- **Graceful Degradation**: Reduced functionality instead of complete failure
-- **Recovery Plans**: Clear procedures for restoration after incidents
-- **Testing**: Proactive failure simulation (chaos engineering)
+<div class="itj-pillars">
+  <div class="itj-pillar"><span class="code">DFF</span><h4>Design for Failure</h4><p>Failures are inevitable; build — and learn — to handle them gracefully.</p></div>
+  <div class="itj-pillar"><span class="code">DRY</span><h4>Don't Repeat Yourself</h4><p>One authoritative source for every piece of knowledge.</p></div>
+  <div class="itj-pillar"><span class="code">KIS</span><h4>Keep It Simple</h4><p>Clarity over cleverness, every time.</p></div>
+  <div class="itj-pillar"><span class="code">REnO</span><h4>Release Early and Often</h4><p>Ship increments, gather feedback, improve.</p></div>
+  <div class="itj-pillar"><span class="code">MVP</span><h4>Minimum Viable Product</h4><p>Build the smallest thing that delivers real value.</p></div>
+  <div class="itj-pillar"><span class="code">COLAB</span><h4>Collaboration</h4><p>Collective intelligence beats lone effort.</p></div>
+  <div class="itj-pillar"><span class="code">AIPD</span><h4>AI-Powered Development</h4><p>AI accelerates the work; it does not replace your judgment.</p></div>
+  <div class="itj-pillar approach"><span class="code">PoLR · OSAP · KISS</span><h4>Three working approaches</h4><p>Path of least resistance, open source as possible, keep it stupid simple.</p></div>
+</div>
 
-</details>
+### Design for Failure — DFF
 
-This principle ensures that your applications remain operational even when individual components fail, providing a better user experience and reducing downtime.
+In any system complex enough to be interesting, failure is not an edge case; it is a certainty you plan for. [Fault-tolerant design](https://en.wikipedia.org/wiki/Fault_tolerance) means redundancy, monitoring, graceful degradation, and a tested plan for recovery — so that a failed component is an inconvenience, not an outage.
 
-### Don't Repeat Yourself - DRY
+We hold ourselves to the same standard when we teach. A quest that only shows the happy path teaches you less than one that shows the command that failed, the error it threw, and how to read your way out. Our chronicles document real work, including the dead ends — because the moment something breaks is the moment you actually learn how it works.
 
-**[🔗 Learn more about DRY principle](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)**
+### Don't Repeat Yourself — DRY
 
-Don't Repeat Yourself (DRY) emphasizes avoiding code duplication by having a single, authoritative source for every piece of knowledge in your system. This reduces maintenance burden and minimizes inconsistencies.
+[DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) says that every piece of knowledge should have one authoritative home. Duplicate it and you have signed up to keep two copies in sync forever; sooner or later they disagree, and the bug lives in the gap.
 
-<details>
-<summary>Key Benefits</summary>
+You will see this principle in how the site itself is written: guides link to the canonical explanation instead of restating it, and the brand and quest definitions live in single data files that everything else reads from. One caveat worth stating plainly — DRY governs *code and content*, not *practice*. Repetition is how skill is built. Run the command a tenth time; that repetition is the point.
 
-- **Maintainability**: Changes need to be made in only one place
-- **Consistency**: Eliminates conflicting implementations
-- **Efficiency**: Reduces development time and effort
-- **Quality**: Fewer opportunities for bugs and errors
+### Keep It Simple — KIS
 
-</details>
+The [KISS principle](https://en.wikipedia.org/wiki/KISS_principle) is a bias toward the boring, readable solution over the clever one. Simple systems are easier to understand, change, and debug — and easier to teach. Clarity over cleverness is also a writing rule here: plain words over jargon, short sentences over impressive ones. If a paragraph needs a second read to parse, it failed.
 
-**Important Note**: While keeping code DRY, remember that repetition in *learning* is beneficial - practice makes perfect!
+Simplicity is not the absence of depth. It is the discipline of finding the most direct route to a real goal and refusing to add weight that does not earn its place.
 
-### Keep It Simple - KIS
+### Release Early and Often — REnO
 
-**[🔗 Learn more about KISS principle](https://en.wikipedia.org/wiki/KISS_principle)**
+[Iterative delivery](https://en.wikipedia.org/wiki/Agile_software_development) favors small, frequent releases over a single grand unveiling. Short feedback loops catch mistakes while they are still cheap, and they keep momentum alive. The same belief shapes the content: a tight, useful quest published today beats a sprawling, perfect one that never ships. Progress over perfection — improvement is the permanent state, not a finish line.
 
-Keep It Simple (KIS) advocates for simplicity in design and implementation. Simple solutions are easier to understand, maintain, and debug than complex ones.
+### Minimum Viable Product — MVP
 
-<details>
-<summary>Core Values</summary>
+An [MVP](https://en.wikipedia.org/wiki/Minimum_viable_product) is the smallest version that delivers genuine value and lets you learn from real use. It is a discipline of focus: solve the core problem first, prove it matters, then expand. In a quest, that means covering the path that lets you actually succeed and cutting the tangents that do not serve the objective — so you reach a working result before your attention runs out.
 
-- **Clarity Over Cleverness**: Choose readable code over complex optimizations
-- **Maintainability**: Simple systems are easier to modify and extend
-- **Collaboration**: Clear code enables better teamwork
-- **User Focus**: Simple interfaces provide better user experiences
-- **Reliability**: Fewer components mean fewer failure points
+### Collaboration — COLAB
 
-</details>
+Open source runs on [collaboration](https://opensource.guide/how-to-contribute/): diverse perspectives, shared review, and the compounding returns of people building on each other's work. A community catches what a single author misses and sustains a project past any one person's attention span. So we credit our sources and contributors, and we build in the open — through [issues](https://github.com/bamr87/it-journey/issues), pull requests, and [discussions](https://github.com/bamr87/it-journey/discussions). You are invited in, not talked at.
 
-Simplicity doesn't mean avoiding sophisticated solutions - it means finding the most elegant path to achieve your goals.
+### AI-Powered Development — AIPD
 
-### Release Early and Often - REnO
+The newest pillar is the one this site practices most visibly. [AI-powered development](https://github.com/features/copilot) treats AI as a collaborator that accelerates the work — generating boilerplate, surfacing patterns, drafting documentation and tests — so you spend your attention on the parts that need judgment. The gains are real: in a [controlled study](https://arxiv.org/abs/2302.06590), developers using an AI assistant finished a programming task 55% faster than those without one, and spent the time they saved on the harder, more interesting decisions.
 
-**[🔗 Learn more about agile development](https://en.wikipedia.org/wiki/Agile_software_development)**
+The honest half of the principle matters just as much. AI is a collaborator, not an oracle. It is confidently wrong often enough that blind trust is a liability. So the rule we teach — and follow — is to keep the human review loop intact: read what the model wrote, understand it, verify it, and own the result. When AI helped with the work, we say so, and we are clear about what it got right and what it did not.
 
-Release Early and Often (REnO) promotes frequent, incremental releases rather than waiting for perfect, feature-complete versions. This approach enables faster feedback loops and continuous improvement.
+### Three working approaches
 
-<details>
-<summary>Advantages</summary>
+Beneath the principles sit three plain heuristics that decide the small calls: the **path of least resistance** (recommend the simplest route that works before reaching for the advanced one), **open source as possible** (prefer open tools and free tiers, and flag clearly when something is paid or proprietary), and **keep it stupid simple** (default to the most boring, reliable option that meets the need).
 
-- **Rapid Feedback**: Quick user insights drive better decisions
-- **Risk Reduction**: Smaller releases mean lower stakes for each change
-- **User Engagement**: Regular updates maintain interest and involvement
-- **Adaptability**: Easier to pivot based on market changes
-- **Learning Culture**: Encourages experimentation and growth
+## Built in the open — by humans and machines
 
-</details>
+IT-Journey is not just a site that talks about AI-powered development. It is one.
 
-This principle values progress over perfection and recognizes that improvement is an ongoing journey.
+Much of the content here is drafted, reviewed, and maintained with the help of AI agents working under human review and shipping through open continuous integration. A change is proposed, checked against the project's standards, read by a person, and only then merged — the same human-in-the-loop discipline the AIPD pillar describes, applied to ourselves. The entire workflow is public: the [repository on GitHub](https://github.com/bamr87/it-journey) is the system of record, and you can watch how it is made, including the parts that break.
 
-### Minimum Viable Product - MVP
+That openness is Design for Failure pointed inward. We would rather show a working example of building responsibly with AI — automation that proposes to a human gate instead of acting on its own — than publish a glossy claim you cannot inspect. Read the source, copy the pattern, and improve on it.
 
-**[🔗 Learn more about MVP methodology](https://en.wikipedia.org/wiki/Minimum_viable_product)**
+## Who this is for
 
-Minimum Viable Product (MVP) focuses on building the simplest version that delivers core value to users. This approach allows for early market validation and iterative improvement based on real user feedback.
+| If you are a… | You will find… |
+|---|---|
+| **Learner** starting from zer0 | A hands-on path that works on your machine, without gatekeeping. |
+| **Practitioner** sharpening skills | Reproducible techniques, honest trade-offs, and time saved. |
+| **Contributor** to open source | A welcoming project to improve, and collaboration patterns learned in the open. |
+| **Builder with AI** | Real patterns for building with AI, with the human-review loop kept intact. |
+| **Educator** | Accurate, open, well-structured material you can build a lesson on — and reuse freely. |
 
-<details>
-<summary>Strategic Benefits</summary>
+## Join the journey
 
-- **Core Value Focus**: Concentrate on essential functionality first
-- **Resource Efficiency**: Minimize initial investment and risk
-- **Market Validation**: Test hypotheses with real users
-- **Rapid Learning**: Gather insights before full commitment
-- **Flexibility**: Easier to pivot based on user feedback
-
-</details>
-
-The MVP approach helps you avoid building features nobody wants while ensuring you solve real problems for real users.
-
-### Collaboration - COLAB
-
-**[🔗 Learn more about open source collaboration](https://opensource.guide/how-to-contribute/)**
-
-Collaboration (COLAB) harnesses the collective intelligence and creativity of a global community. Open-source development thrives on diverse perspectives, shared knowledge, and mutual support.
-
-<details>
-<summary>Community Benefits</summary>
-
-- **Diverse Expertise**: Multiple perspectives lead to better solutions
-- **Accelerated Innovation**: Many contributors enable faster development
-- **Quality Assurance**: Community review improves code quality
-- **Knowledge Sharing**: Learn from experienced developers worldwide
-- **Sustainability**: Community support ensures project longevity
-- **Global Impact**: Address problems that transcend boundaries
-
-</details>
-
-Together, we are stronger. Collaboration transforms individual efforts into collective achievements that benefit everyone.
-
-### AI-Powered Development - AIPD
-
-**[🔗 Learn more about AI in software development](https://github.com/features/copilot)**
-
-AI-Powered Development (AIPD) leverages artificial intelligence agents and tools to guide, accelerate, and enhance the software development process. Modern AI agents serve as intelligent assistants that help developers write better code, make informed decisions, and implement best practices throughout the development lifecycle.
-
-<details>
-<summary>AI Integration Benefits</summary>
-
-- **Code Generation**: AI agents help generate boilerplate code, functions, and entire modules
-- **Code Review**: Automated analysis for bugs, security vulnerabilities, and performance issues
-- **Architecture Guidance**: AI-driven recommendations for system design and patterns
-- **Learning Acceleration**: Personalized tutorials and explanations adapted to your skill level
-- **Best Practices**: Real-time suggestions for coding standards and industry conventions
-- **Documentation**: Automated generation of comments, README files, and technical documentation
-
-</details>
-
-**Key Integration Patterns:**
-
-- **Pair Programming with AI**: Use AI agents as coding partners for real-time assistance
-- **Automated Testing**: AI-generated test cases and quality assurance workflows
-- **Code Refactoring**: Intelligent suggestions for improving code structure and performance
-- **Documentation Generation**: Automated creation of API docs, user guides, and code comments
-- **Design Pattern Recognition**: AI recommendations for appropriate architectural patterns
-- **Security Analysis**: Proactive identification of vulnerabilities and security best practices
-
-**Best Practices for AI Integration:**
-
-1. **Human-AI Collaboration**: Treat AI as a powerful assistant, not a replacement for critical thinking
-2. **Code Review**: Always review and understand AI-generated code before implementation
-3. **Context Awareness**: Provide clear context and requirements to get better AI suggestions
-4. **Iterative Refinement**: Use AI feedback loops to continuously improve code quality
-5. **Privacy Considerations**: Be mindful of sensitive data when using cloud-based AI services
-6. **Skill Development**: Use AI tools to learn new concepts rather than becoming dependent
-
-AI-powered development represents the future of software engineering, where human creativity and AI efficiency combine to build better applications faster and more reliably.
-
-## AI-Driven Documentation
-
-**[🔗 Learn more about automated documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes)**
-
-One of the most transformative applications of AI in software development is automated documentation generation. AI agents can significantly reduce the time and effort required to create and maintain comprehensive documentation while ensuring consistency and accuracy across your projects.
-
-### Documentation Automation Benefits
-
-**📝 Content Generation:**
-- **README Files**: AI can analyze your codebase and generate comprehensive README files with proper sections, installation instructions, usage examples, and feature descriptions
-- **API Documentation**: Automatically generate detailed API documentation from code comments, function signatures, and usage patterns
-- **Code Comments**: Intelligent inline documentation that explains complex logic, algorithms, and business rules
-- **User Guides**: Step-by-step tutorials and user manuals generated from application workflows and features
-
-**🔄 Maintenance & Updates:**
-- **Version Sync**: Automatically update documentation when code changes are detected
-- **Consistency Checks**: Ensure documentation style and format consistency across all project files
-- **Link Validation**: Verify and update internal and external links in documentation
-- **Translation Support**: Generate multilingual documentation for global audiences
-
-**⚡ Quality Assurance:**
-- **Grammar & Style**: AI proofreading to improve readability and professional presentation
-- **Technical Accuracy**: Cross-reference documentation with actual code implementation
-- **Completeness Analysis**: Identify missing documentation sections and suggest improvements
-- **Accessibility**: Generate documentation that meets accessibility standards and guidelines
-
-### AI Documentation Tools & Integration
-
-**Popular AI Documentation Platforms:**
-- **GitHub Copilot**: Generate README files, code comments, and documentation directly in your IDE
-- **Notion AI**: Create and maintain project wikis, specifications, and user guides
-- **GitBook AI**: Automated documentation websites with intelligent content suggestions
-- **Mintlify**: AI-powered documentation generation specifically for APIs and codebases
-- **Codeium**: Real-time documentation assistance and code explanation
-
-**Integration Workflows:**
-1. **Pre-commit Hooks**: Automatically generate or update documentation before code commits
-2. **CI/CD Pipeline Integration**: Include documentation generation in your deployment workflow
-3. **Pull Request Automation**: Generate documentation previews for code review processes
-4. **Issue Tracking**: Link documentation updates to specific issues and feature requests
-
-### Best Practices for AI Documentation
-
-**🎯 Strategic Implementation:**
-- **Start Small**: Begin with README generation and gradually expand to full documentation suites
-- **Template Creation**: Develop AI prompts and templates for consistent documentation structure
-- **Human Review**: Always review AI-generated content for accuracy and completeness
-- **Iterative Improvement**: Use feedback loops to refine AI documentation quality over time
-
-**📋 Content Guidelines:**
-- **Clear Context**: Provide AI with comprehensive project context and target audience information
-- **Structure Standards**: Maintain consistent documentation hierarchy and formatting standards
-- **Example Integration**: Include code examples, screenshots, and practical use cases
-- **Update Frequency**: Establish regular documentation review and update cycles
-
-**🔒 Quality Control:**
-- **Fact Checking**: Verify technical accuracy of AI-generated documentation
-- **User Testing**: Validate documentation effectiveness with actual users
-- **Version Control**: Track documentation changes alongside code modifications
-- **Feedback Collection**: Gather user feedback to improve documentation quality
-
-AI-driven documentation transforms the often-neglected task of documentation into an automated, consistent, and high-quality process that keeps pace with rapid development cycles while ensuring your projects remain accessible and well-documented for all stakeholders.
-
-## AI-Powered Testing
-
-**[🔗 Learn more about AI testing tools](https://github.com/microsoft/playwright)**
-
-AI-powered testing represents a paradigm shift in quality assurance, where intelligent agents generate, execute, and evolve test suites automatically as applications grow and change. This approach ensures comprehensive test coverage while reducing the manual effort traditionally required for test creation and maintenance.
-
-### Automated Test Generation
-
-**🧪 Intelligent Test Creation:**
-- **Code Analysis**: AI examines your codebase to understand functionality and automatically generates relevant test cases
-- **Behavior Mapping**: Machine learning algorithms identify user workflows and create end-to-end test scenarios
-- **Edge Case Discovery**: AI proactively identifies potential failure points and generates tests for edge cases
-- **Cross-Browser Testing**: Automated generation of tests across different browsers, devices, and platforms
-- **API Testing**: Intelligent creation of API test suites based on endpoint analysis and schema validation
-
-**📊 Coverage Optimization:**
-- **Smart Coverage Analysis**: AI identifies untested code paths and generates targeted tests to improve coverage
-- **Risk-Based Testing**: Prioritize test generation for high-risk areas based on code complexity and change frequency
-- **Regression Testing**: Automatically generate regression tests when new features are added or bugs are fixed
-- **Performance Testing**: AI-generated load and stress tests based on expected usage patterns
-
-### Adaptive Testing Strategies
-
-**🔄 Dynamic Test Evolution:**
-- **Feature Detection**: AI monitors code changes and automatically generates tests for new functionality
-- **Test Maintenance**: Automatically update existing tests when underlying code structure changes
-- **Flaky Test Resolution**: Identify and fix unstable tests through pattern analysis and intelligent retry strategies
-- **Test Optimization**: Remove redundant tests and optimize test execution order for faster feedback
-
-**🎯 Intelligent Test Execution:**
-- **Parallel Processing**: AI optimizes test distribution across multiple environments for maximum efficiency
-- **Smart Scheduling**: Execute critical tests first based on code change impact analysis
-- **Conditional Testing**: Run specific test suites based on the type and scope of code changes
-- **Resource Management**: Dynamically allocate testing resources based on project priority and deadlines
-
-### Test Evolution & Maintenance
-
-**🔧 Continuous Improvement:**
-- **Learning from Failures**: AI analyzes test failures to improve future test generation and identify patterns
-- **User Behavior Integration**: Incorporate real user data to generate more realistic test scenarios
-- **Performance Monitoring**: Continuously monitor application performance and adjust test parameters accordingly
-- **Feedback Loops**: Use production monitoring data to enhance test coverage and accuracy
-
-**📈 Quality Metrics & Analytics:**
-- **Test Effectiveness Scoring**: AI evaluates test quality and suggests improvements
-- **Coverage Gap Analysis**: Identify areas where additional testing is needed
-- **Trend Analysis**: Track testing metrics over time to identify improvement opportunities
-- **Risk Assessment**: Predict potential issues based on code changes and historical data
-
-### AI Testing Tools & Frameworks
-
-**Popular AI Testing Platforms:**
-- **Testim**: AI-powered test automation with self-healing capabilities
-- **Mabl**: Intelligent test automation for web applications
-- **Applitools**: Visual AI testing for UI validation across platforms
-- **Sauce Labs**: AI-enhanced cross-browser and mobile testing
-- **Functionize**: Natural language test creation with AI execution
-
-**Integration Workflows:**
-1. **CI/CD Integration**: Embed AI testing into continuous integration pipelines
-2. **Pull Request Validation**: Automatically generate and run tests for code changes
-3. **Production Monitoring**: Use AI to create tests based on real user interactions
-4. **Release Validation**: AI-powered smoke and sanity testing for deployment confidence
-
-### Best Practices for AI Testing
-
-**🎯 Implementation Strategy:**
-- **Start with High-Value Areas**: Begin AI testing in critical application components
-- **Gradual Adoption**: Progressively expand AI testing coverage across your application
-- **Human Oversight**: Maintain human review of AI-generated tests for accuracy and relevance
-- **Tool Integration**: Combine multiple AI testing tools for comprehensive coverage
-
-**📋 Quality Guidelines:**
-- **Test Data Management**: Ensure AI has access to realistic and diverse test data
-- **Environment Parity**: Maintain consistent testing environments for reliable AI analysis
-- **Version Control**: Track AI-generated tests alongside manual tests in version control
-- **Documentation**: Document AI testing strategies and configurations for team understanding
-
-**🔒 Reliability & Maintenance:**
-- **Regular Validation**: Periodically review AI-generated tests for continued relevance
-- **Performance Monitoring**: Track AI testing performance and adjust configurations as needed
-- **Fallback Strategies**: Maintain manual testing capabilities for critical scenarios
-- **Team Training**: Ensure team members understand AI testing tools and methodologies
-
-AI-powered testing transforms quality assurance from a reactive, manual process into a proactive, intelligent system that evolves with your application, ensuring robust testing coverage while significantly reducing the time and effort required for comprehensive quality assurance.
-
----
-
-**Additional Resources:**
-
-- [Programming Principles Wiki](https://en.wikipedia.org/wiki/Category:Programming_principles)
-- [Open Source Guides](https://opensource.guide/)
-- [The Twelve-Factor App](https://12factor.net/)
-- [GitHub Copilot Documentation](https://docs.github.com/en/copilot)
-- [AI-Powered Development Best Practices](https://github.blog/2023-06-20-how-to-write-better-prompts-for-github-copilot/)
-- [Prompt Engineering Guide](https://www.promptingguide.ai/)
-- [Writing Great Documentation](https://jacobian.org/2009/nov/10/what-to-write/)
-- [GitBook AI Documentation](https://docs.gitbook.com/getting-started/overview)
-- [Mintlify Documentation Tools](https://mintlify.com/)
-
-## About This Project
+There are two good ways in. If you want to learn, [open the quest map](/quests/) and start the level that matches where you are. If you want to build the platform itself, the project is open source and the door is unlocked — [report an issue](https://github.com/bamr87/it-journey/issues), [open a discussion](https://github.com/bamr87/it-journey/discussions), or send a pull request. New to contributing? [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/) is a kind place to begin.
 
 {% if site.founder %}
-This platform was created by **{{ site.founder }}** and is maintained by our dedicated community:
+This platform was founded by **{{ site.founder }}** — an IT nerd trying to be an IT hero — and is kept alive by a community of contributors.
 {% else %}
-This platform was created by **Amr Abdel-Motaleb** and is maintained by our dedicated community:
+This platform was founded by **Amr Abdel-Motaleb** — an IT nerd trying to be an IT hero — and is kept alive by a community of contributors.
 {% endif %}
 
 {% if site.maintainers and site.maintainers.size > 0 %}
-
-### 👥 Maintainers
-
-| Name | Profile |
-|------|---------|
-{% for maintainer in site.maintainers -%}
-| {{ maintainer.name }} | [View Profile]({{ maintainer.profile }}) |
-{% endfor %}
-
-{% else %}
-
-### 👥 Maintainers
-
-We're always looking for passionate contributors to help maintain and improve this platform. [Join us!](#get-involved)
-
+**Maintainers:** {% for maintainer in site.maintainers %}[{{ maintainer.name }}]({{ maintainer.profile }}){% unless forloop.last %} · {% endunless %}{% endfor %}
 {% endif %}
 
+**Built with open tools:**
 {% if site.powered_by and site.powered_by.size > 0 %}
-
-### ⚡ Powered By
-
-| Technology | Link |
-|------------|------|
-{% for tech in site.powered_by -%}
-| {{ tech.name }}{% if tech.version %} {{ tech.version }}{% endif %} | [Learn More]({{ tech.url }}) |
-{% endfor %}
-
+{% for tech in site.powered_by %}[{{ tech.name }}]({{ tech.url }}){% unless forloop.last %} · {% endunless %}{% endfor %}.
 {% else %}
-
-### ⚡ Powered By
-
-- **Jekyll** - Static site generator
-- **GitHub Pages** - Free hosting
-- **Bootstrap** - Responsive design framework
-- **Ruby** - Programming language
-
+[Jekyll](https://jekyllrb.com/), [GitHub Pages](https://pages.github.com/), [Bootstrap](https://getbootstrap.com/), and [Ruby](https://www.ruby-lang.org/).
 {% endif %}
 
-## Contact
+**Get in touch:** {% if site.email %}[email](mailto:{{ site.email }}){% else %}[email](mailto:contact@it-journey.dev){% endif %} · [GitHub Issues](https://github.com/bamr87/it-journey/issues) · [Discussions](https://github.com/bamr87/it-journey/discussions)
 
-Have questions, suggestions, or want to contribute? We'd love to hear from you!
-
-📧 **Email**: {% if site.email %}[{{ site.email | replace: '@', ' [at] ' | replace: '.', ' [dot] ' }}](mailto:{{ site.email }}){% else %}[Contact us](mailto:contact@it-journey.dev){% endif %}
-
-🐛 **Issues & Bugs**: [GitHub Issues](https://github.com/bamr87/it-journey/issues)
-
-💬 **Discussions**: [GitHub Discussions](https://github.com/bamr87/it-journey/discussions)
-
-## Get Involved
-
-Ready to contribute to IT-Journey? Here's how you can help:
-
-### 🌟 For Learners
-- **Star this repository** to show your support
-- **Share your feedback** through GitHub issues
-- **Suggest improvements** or new topics you'd like to see covered
-- **Join our community discussions** to connect with other learners
-
-### 🛠️ For Contributors
-
-- **Submit bug reports** when you find issues
-- **Propose new features** that would benefit the community
-- **Contribute content** by writing tutorials or documentation
-- **Improve existing content** through pull requests
-- **Help with translations** to make content accessible globally
-- **Share AI integration patterns** and best practices you've discovered
-
-### 🤖 For AI Enthusiasts
-
-- **Contribute AI-powered learning examples** and case studies
-- **Share prompt engineering techniques** for better AI assistance
-- **Document AI tool integrations** with development workflows
-- **Test and validate AI-generated content** for accuracy and quality
-
-### 📚 For Educators
-
-- **Use our content** in your courses (it's open source!)
-- **Provide feedback** on educational effectiveness
-- **Contribute curriculum ideas** based on your teaching experience
-
----
-
-**Ready to start your journey?** 🚀 [Explore our quickstart guide](/quickstart/) or [browse the documentation](/docs/) to begin learning!
-
-**New to open source?** 💡 Check out [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/) to get started.
-
-*Together, let's build something amazing and help the next generation of developers thrive!* ✨
+> The information age made knowledge abundant. We are here to make it learnable. Pick a quest, run the first command, and go from zer0 to her0.


### PR DESCRIPTION
Reviews and rewrites [`/about/`](https://it-journey.dev/about/) as a manifesto that **retains the central philosophies** (the seven principles + the democratize-IT mission) and advocates them with depth, evidence, and the brand voice.

## What changed

**Kept & deepened**
- The **seven pillars** (DFF, DRY, KIS, REnO, MVP, COLAB, AIPD) + the three approaches (PoLR, OSAP, KISS) — now each is principle → *why it matters* → *how IT-Journey lives it*, framed as one rule for code, learning, **and** writing.
- The **mission** — pulled the soul out of `purpose.md` (close the IT knowledge divide; open source as method; run as a perpetual commons) into a grand opening.

**Cut**
- The two generic AI-vendor listicles ("AI-Driven Documentation" → Notion/GitBook/Mintlify, "AI-Powered Testing" → Testim/Mabl/Applitools) — off-brand hype, not about IT-Journey. Replaced with an authentic **AIPD-by-example** section: this site *is* AI-built under human review, and says so honestly.
- Emoji-spam vision bullets, the stale hand-maintained TOC (→ `toc: true`), and the duplicate-anchor bug.

**Well-researched** — grounded the teaching claims in real, cited sources:
- Active learning: [Freeman et al. 2014, *PNAS*](https://www.pnas.org/doi/10.1073/pnas.1319030111) (225-study meta-analysis: higher exam scores, ~1.5× fewer failures).
- [Retrieval practice](https://www.retrievalpractice.org/why-it-works) for durable memory.
- AIPD productivity: a [controlled study](https://arxiv.org/abs/2302.06590) (55% faster, time reinvested in judgment) — used to make the honest case, not a hype case.

**Brand/theme/style alignment**
- **concept-essay** voice (the about page has no section guide → was defaulting to practitioner-chronicle; essay fits a manifesto). Present tense, owns the take, "so what" for the reader.
- No `discouraged` hype words, canonical spellings, emoji removed from prose.
- Tasteful scoped **hero + pillar-card grid** using the theme's `--zer0-color-*` design tokens (with fallbacks), consistent with the landing page.
- Added the required `author` key (the old page was missing it).

## Validation
- Frontmatter validator: **0 errors** (title 36, description 156, all required keys, list types).
- Brand: no discouraged words, no spelling drift, no body emoji.
- CI-parity build: **green (38s)**; hero + all 8 pillar cards render, Liquid resolves (founder/maintainers/powered-by), **0 unrendered Liquid tags**.

Preview locally with `git checkout content/about-page-rewrite` on your running server, or I can serve + screenshot it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)