### PR TITLE
ci: prune, fix, and optimize GitHub Actions workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,288 +1,100 @@
-# AI-Powered Content Review and Frontmatter Management
-
-This documentation describes the AI-powered workflows for automated content review and frontmatter management in the IT-Journey repository.
-
-## Overview
-
-The repository now includes two automated workflows that help maintain content quality and consistency:
-
-1. **AI Content Review Workflow** - Analyzes content quality using AI and provides improvement suggestions
-2. **Frontmatter Validation Workflow** - Validates and automatically fixes frontmatter issues
-3. **Link Health Guardian Workflow** - Checks links and produces a summarized health report
-
-## AI Content Review Workflow
-
-### File: `.github/workflows/ai-content-review.yml`
-
-This workflow automatically reviews markdown files in the `pages/` directory using OpenAI's GPT-4 API whenever:
-- A pull request is opened or updated with markdown file changes
-- Changes are pushed to the main branch
-
-### Features
-
-- **Automatic Trigger**: Runs on PR creation/updates and pushes to main
-- **AI Analysis**: Uses GPT-4 to analyze content quality, SEO, and technical accuracy
-- **PR Comments**: Posts review results as comments on pull requests
-- **Issue Creation**: Creates improvement suggestion issues for main branch pushes
-- **Artifact Storage**: Saves review results for 30 days
-
-### Setup Requirements
-
-1. **OpenAI API Key**: Add `OPENAI_API_KEY` to repository secrets
-   - Go to Repository Settings > Secrets and Variables > Actions
-   - Add new repository secret: `OPENAI_API_KEY`
-   - Get your API key from [OpenAI Platform](https://platform.openai.com/api-keys)
-
-2. **GitHub Token**: Uses built-in `GITHUB_TOKEN` (automatically available)
-
-### Review Criteria
-
-The AI reviews content based on:
-
-- **Frontmatter Completeness**: Checks required fields (title, description, date, author, categories, tags)
-- **Content Quality**: Assesses writing quality, structure, and technical accuracy
-- **SEO Optimization**: Suggests improvements for discoverability
-- **Accessibility**: Checks heading structure and alt text
-- **Technical Accuracy**: Reviews code examples and technical content
-
-### Output
-
-The workflow generates:
-- Overall quality score (1-10)
-- List of positive aspects
-- Priority action items
-- Frontmatter issues
-- Content suggestions
-- SEO improvements
-
-## Frontmatter Validation Workflow
-
-### File: `.github/workflows/frontmatter-validation.yml`
-
-This workflow validates frontmatter fields and can automatically fix common issues.
-
-### Triggers
-
-- **Pull Request**: Validates changed markdown files
-- **Manual Trigger**: Can be run manually with option to apply fixes
-  - Go to Actions > Frontmatter Validation > Run workflow
-  - Choose whether to apply automatic fixes
-
-### Features
-
-- **Validation**: Checks for missing required fields and formatting issues
-- **Auto-Fix**: Can automatically add missing fields like dates, authors, categories
-- **Reports**: Generates detailed validation reports
-- **Safe Operations**: Preview mode shows what would be changed before applying
-
-### Required Fields
-
-The workflow enforces these required frontmatter fields:
-- `title` - Post/page title
-- `description` - Meta description for SEO
-- `date` - Publication date (ISO 8601 format)
-- `author` - Content author
-- `categories` - Content categories (list)
-- `tags` - Content tags (list)
-
-### Recommended Fields
-
-Additional fields that improve content management:
-- `excerpt` - Short summary
-- `lastmod` - Last modification date
-- `draft` - Draft status (true/false)
-
-### Auto-Fix Capabilities
-
-When enabled, the workflow can automatically:
-- Extract dates from filenames (e.g., `2024-01-01-title.md`)
-- Generate descriptions from content
-- Infer categories from directory structure
-- Add default author information
-- Set appropriate draft status
-- Add modification timestamps
-
-## Usage Examples
-
-### Running Manual Frontmatter Validation
-
-1. Go to Actions tab in GitHub
-2. Select "Frontmatter Validation and Auto-Fix"
-3. Click "Run workflow"
-4. Choose "true" for `apply_fixes` to apply automatic fixes
-5. Review the results in the workflow run
-
-### Setting Up AI Review
-
-1. Obtain OpenAI API key
-2. Add to repository secrets as `OPENAI_API_KEY`
-3. Create a pull request with markdown changes
-4. Review the AI-generated feedback in PR comments
-
-### Interpreting Results
-
-#### Quality Scores
-- **8-10**: Excellent content, minimal improvements needed
-- **6-7**: Good content, some enhancements suggested
-- **4-5**: Fair content, several improvements recommended
-- **1-3**: Poor content, significant improvements required
-
-#### Common Issues and Fixes
-
-| Issue | Auto-Fix | Manual Action Required |
-|-------|----------|----------------------|
-| Missing date | ✅ Extracts from filename or uses file timestamp | - |
-| Missing author | ✅ Sets to default author | Update if incorrect |
-| Missing categories | ✅ Infers from directory structure | Review and refine |
-| Missing description | ✅ Generates from content | Review and improve |
-| Missing tags | ✅ Basic inference from content | Add relevant tags |
-| Content too short | ❌ | Expand with more details |
-| Missing headers | ❌ | Add section headers |
-| Broken links | ❌ | Fix or remove broken links |
-
-## Link Health Guardian Workflow
-
-### File: `.github/workflows/link-checker.yml`
-
-This workflow runs the Link Health Guardian to validate links across the site and generate a workflow summary, even when link checks fail.
-
-### Triggers
-
-- **Schedule**: Mondays at 6 AM UTC, Fridays at 6 PM UTC
-- **Manual Trigger**: Configurable scope, analysis level, timeouts, and AI analysis
-
-### Output
-
-- Link statistics exported via `statistics.env`
-- Markdown summary in the Actions run summary
-- Artifact archive under `link-check-results/`
-
-## Best Practices
-
-### For Content Creators
-
-1. **Use Descriptive Titles**: 30-60 characters for optimal SEO
-2. **Write Meta Descriptions**: 120-160 characters summarizing content
-3. **Structure Content**: Use headers (H1, H2, H3) to organize information
-4. **Add Alt Text**: Provide descriptive alt text for all images
-5. **Include Examples**: Add code examples and practical demonstrations
-6. **Link Appropriately**: Include relevant internal and external links
-
-### For Repository Maintainers
-
-1. **Monitor Workflow Runs**: Check for failures and address API issues
-2. **Review AI Suggestions**: Not all suggestions may be applicable
-3. **Update Required Fields**: Modify validation rules as needed
-4. **Manage API Costs**: Monitor OpenAI API usage
-5. **Train Contributors**: Help team members understand quality standards
-
-## Troubleshooting
-
-### Common Issues
-
-#### AI Review Not Working
-- Check if `OPENAI_API_KEY` secret is set correctly
-- Verify API key has sufficient credits
-- Check workflow logs for error messages
-
-#### Frontmatter Validation Fails
-- Ensure YAML syntax is correct in frontmatter
-- Check for special characters that need escaping
-- Verify file encoding is UTF-8
-
-#### Build Failures After Auto-Fix
-- Review changes made by auto-fix
-- Check Jekyll build logs for specific errors
-- Verify frontmatter follows Jekyll conventions
-
-### Getting Help
-
-1. Check workflow run logs in GitHub Actions
-2. Review generated reports and artifacts
-3. Create an issue with workflow logs if problems persist
-4. Refer to Jekyll and GitHub Actions documentation
-
-## Configuration
-
-### Customizing Validation Rules
-
-Edit `frontmatter-validation.yml` to modify:
-- Required fields list
-- Default values
-- Validation criteria
-- File selection patterns
-
-### Customizing AI Review
-
-Edit `ai-content-review.yml` to modify:
-- AI model used (currently GPT-4)
-- Review criteria prompts
-- Output format
-- Trigger conditions
-
-## Future Enhancements
-
-Planned improvements include:
-- Integration with additional AI providers
-- More sophisticated content analysis
-- Automated content improvement suggestions
-- Integration with content management tools
-- Performance optimization for large repositories
-
-## Related Documentation
-
-For comprehensive workflow documentation, see:
-- **[GitHub Actions Guide](../../docs/workflows/GITHUB_ACTIONS.md)** - Complete workflow documentation
-- **[Link Checker Resolution](../../docs/workflows/LINK_CHECKER_FIX_RESOLUTION.md)** - Link health fixes
-- **[Link Checker Validation](../../docs/workflows/LINK_CHECKER_VALIDATION.md)** - Validation results
-- **[Testing Frameworks](../../docs/testing/TESTING_FRAMEWORKS.md)** - Test infrastructure
-- **[Contributing Guide](../../docs/CONTRIBUTING_DEVELOPER.md)** - Contribution workflow
-
-## Deployment
-
-Production (`it-journey.dev`) deploys via **GitHub Pages from Actions**:
-[`deploy.yml`](deploy.yml) builds with `JEKYLL_ENV=production` on every push to
-`main` and publishes through `actions/deploy-pages`. Set the Pages source to
-**"GitHub Actions"** in repo Settings → Pages. There is no longer an Azure
-target or a weekly `gh-pages` cron.
+# GitHub Actions Workflows
+
+This directory holds every CI/CD and automation workflow for IT-Journey. This
+README is the **inventory + map**; each workflow file has a header comment with
+its own rationale.
+
+> Keep this file in sync when you add, remove, or repurpose a workflow.
+
+## Conventions (all workflows)
+
+- **Least privilege.** Default `permissions: contents: read`; write is granted
+  only on the job that needs it.
+- **Pinned actions.** Third-party actions are pinned to a full commit SHA;
+  [Dependabot](../dependabot.yml) keeps them current.
+- **Concurrency.** Each workflow declares a `concurrency:` group. Fast PR checks
+  cancel in-progress runs; mutating/long jobs (auto-merge, CMS loop, contributor
+  refresh) use `cancel-in-progress: false`.
+- **Untrusted input.** `github.event.*` values are passed through `env:`, never
+  interpolated directly into `run:`.
+- **AI is opt-in.** Every Claude-powered workflow gates on a `*_ENABLED` repo
+  variable **and** the `CLAUDE_CODE_OAUTH_TOKEN`/`ANTHROPIC_API_KEY` secret, so
+  nothing AI runs until both are present (see `scripts/ai/README.md`).
+
+## Inventory
+
+### Build & validation (PR gates)
+
+| Workflow | Triggers | What it does |
+|---|---|---|
+| `build-validation.yml` | PR + push on build inputs; dispatch | Jekyll build (CI-parity) on every relevant change. The **Docker build** and the **3-OS cross-platform matrix** only run when `Gemfile`/`Dockerfile`/`docker-compose.yml` change or on manual dispatch — a `detect-changes` job gates them so content-only pushes don't spin up Windows/macOS runners. |
+| `frontmatter-validation.yml` | PR on `pages/**/*.md`; dispatch | Validation-only gate. Runs the canonical `scripts/validation/frontmatter-validator.py` (same code as `make content-validate`) on changed **non-quest** pages, plus the Mermaid-flag check, and comments results on the PR. Mechanical auto-fixing lives in `cms-daily-loop.yml`, not here. |
+| `quest-validation.yml` | PR/push on `pages/_quests/**`; weekly; dispatch | Quest content scoring (≥70%), network integrity, and stale generated-data check (the weekly/push full audit runs the unified Docker audit = `make docker-validate`). |
+| `validate-solutions.yml` | PR/push on `test/quest-solutions/**`; dispatch | Structural validation of quest solution fixtures. |
+| `codeql-analysis.yml` | push/PR to main; weekly | CodeQL security analysis (JavaScript, Python, Ruby). |
+
+### Content quality & AI fleet (opt-in)
+
+These implement the AI-augmented CMS described in the root `CLAUDE.md` and
+`scripts/ai/README.md`.
+
+| Workflow | Triggers | What it does |
+|---|---|---|
+| `content-quality.yml` | PR on content | Deterministic brand lint (`scripts/ci/brand_lint.py`). **Spelling drift fails** the check; hype terms warn. No AI, no cost. |
+| `content-review.yml` | PR on content (gated) | `content-reviewer` agent editorial pass; applies small on-brand fixes, posts bigger ideas as comments. Never merges. |
+| `content-factory.yml` | daily 08:00 UTC (gated) | `content-curator` improves one page per collection from the `.cms` worklist → one `auto:content` PR each. |
+| `content-auto-merge.yml` | content PR events | Smuggle-guard (`scripts/ci/classify_changes.py`, content-only) + all checks green → squash-merge. |
+| `cms-daily-loop.yml` | daily 09:00 UTC; dispatch | **Lane A** deterministic normalization (`make content-normalize-apply`, free) → PR; **Lane B** (gated) agentic `cms-curator` pass → PR for review. |
+| `agentic-quest-review.yml` | dispatch; PR on quests; `agentic-review` label | Agentic quest review/execute (`test/quest-validator/agentic_validate.py`); spend-capped. |
+| `agent-audit.yml` | weekly; dispatch (gated) | `agent-auditor` checks the AI fleet (`.claude/agents`, skills, workflows) for drift; opens at most one tightening PR. |
+
+### Scheduled maintenance & generation
+
+| Workflow | Triggers | What it does |
+|---|---|---|
+| `dependency-checker.yml` | push on `Gemfile*`; weekly; dispatch | **Security-only**: `bundler-audit`, outdated-gem report, workflow-YAML lint, and a single deduped tracking issue. Build/Docker compatibility is owned by `build-validation.yml`. |
+| `link-checker.yml` | PR on `*.md`/`*.html`; twice weekly; dispatch | Incremental link check on PRs; full Link Health Guardian sweep on schedule. |
+| `sync-github.yml` | daily; dispatch; on script change | Regenerates GitHub-derived site data (`scripts/generation/sync_github.py`). |
+| `update-contributor-profiles.yml` | **weekly** (Mon 05:00 UTC); dispatch | Refreshes `_data/contributors/*.yml`. (Previously ran on every push to main — now weekly, since the stats barely move per-commit.) |
+| `update-settings.yml` | push on `_config.yml`; dispatch | Regenerates the settings/tree/sitemap docs under `pages/_about/settings/` (`scripts/deployment/update-settings.sh`). |
+| `prd-sync.yml` | PR merged to main; dispatch | Keeps the PRD in sync with merged changes (`scripts/prd-machine/prd-machine.py`). |
+
+### Issue / PR automation
+
+| Workflow | Triggers | What it does |
+|---|---|---|
+| `new-feature-request.yml` | issue labeled `approved` | Appends the approved feature to the features page (`scripts/development/content/append_feature.py`). |
+| `dependabot-auto-merge.yml` | Dependabot PRs | Enables auto-merge for passing Dependabot PRs. |
 
 ## Required vs advisory checks
 
 Mark these as **required status checks** in branch protection for `main`
-(Settings → Branches → Branch protection / Rulesets). They block merge:
+(Settings → Branches / Rulesets). They block merge:
 
-| Required check | Workflow |
+| Required check | Workflow (job) |
 |---|---|
-| Jekyll build (`make build-ci` parity) | `build-validation.yml` |
+| Jekyll build (CI-parity) | `build-validation.yml` (`🏗️ Jekyll Build Test`) |
 | Quest content + network + stale-data | `quest-validation.yml` |
-| Frontmatter validation | `frontmatter-validation.yml` |
-| Posts markdown lint | `posts-markdown-lint.yml` |
+| Frontmatter validation | `frontmatter-validation.yml` (`validate-frontmatter`) |
+| Content brand lint | `content-quality.yml` |
 | CodeQL | `codeql-analysis.yml` |
 
-**Advisory** (run but non-blocking; review before merge): `link-checker.yml`
-(PR incremental), `ai-content-review.yml`, the scheduled `dependency-checker.yml`
-security scan.
+**Advisory** (run but non-blocking): `link-checker.yml` (PR incremental),
+`content-review.yml`, `agentic-quest-review.yml`, and the scheduled
+`dependency-checker.yml` security scan.
 
-Also enable **"Require review from Code Owners"** (see [CODEOWNERS](../CODEOWNERS))
-and let **Dependabot** ([dependabot.yml](../dependabot.yml)) keep the SHA-pinned
-actions and gems current.
+Also enable **"Require review from Code Owners"** (see [CODEOWNERS](../CODEOWNERS)).
 
-## Security baseline
+## Deployment
 
-Every workflow declares least-privilege `permissions:` (default `contents: read`,
-write granted only on the job that needs it), pins all third-party actions to a
-full commit SHA, sets a `concurrency:` group, and passes untrusted
-`github.event.*` values through `env:` (never interpolated directly into `run:`).
+The production site (`it-journey.dev`) is served by **GitHub Pages**. There is
+no `deploy.yml` in this repo — publishing is handled by the built-in Pages
+build, configured in repo **Settings → Pages**. If you migrate to
+"Deploy from GitHub Actions", add the deploy workflow here and update this
+section.
 
 ## Contributing
 
-To contribute improvements to these workflows:
-1. Test changes in a fork first
-2. Document any new configuration options
-3. Update relevant documentation in `docs/workflows/`
-4. Submit pull requests with clear descriptions
-5. Follow the [Developer Contributing Guide](../../docs/CONTRIBUTING_DEVELOPER.md)
-
----
-
-*This documentation is maintained as part of the IT-Journey project. For complete workflow documentation, see the [GitHub Actions Guide](../../docs/workflows/GITHUB_ACTIONS.md).*
+1. Test workflow changes in a fork or via `workflow_dispatch` first.
+2. Keep the least-privilege / SHA-pin / concurrency conventions above.
+3. Update this README's inventory in the same PR.

--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -59,6 +59,53 @@ env:
   NODE_VERSION: '20'
 
 jobs:
+  # Cheap gate so the expensive jobs (Docker build, 3-OS cross-platform matrix)
+  # only run when their inputs actually changed. A content-only push to main no
+  # longer spins up Windows + macOS runners or a ~6-minute Docker build just to
+  # re-confirm dependency compatibility that didn't change.
+  detect-changes:
+    name: 🔎 Detect Changed Inputs
+    runs-on: ubuntu-latest
+    outputs:
+      deps: ${{ steps.filter.outputs.deps }}
+      docker: ${{ steps.filter.outputs.docker }}
+    steps:
+      - name: 🏰 Checkout Repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Compute changed file groups
+        id: filter
+        run: |
+          # Manual runs always exercise everything.
+          if [ "${{ github.event_name }}" != "push" ]; then
+            echo "deps=true" >> "$GITHUB_OUTPUT"
+            echo "docker=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BASE="${{ github.event.before }}"
+          HEAD="${{ github.sha }}"
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ] \
+             || ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
+            CHANGED=$(git diff --name-only "${HEAD}~1" "${HEAD}" 2>/dev/null || echo "")
+          else
+            CHANGED=$(git diff --name-only "$BASE" "$HEAD" 2>/dev/null || echo "")
+          fi
+          echo "Changed files:"; echo "$CHANGED"
+
+          if echo "$CHANGED" | grep -qE '^(Gemfile|Gemfile\.lock)$'; then
+            echo "deps=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "deps=false" >> "$GITHUB_OUTPUT"
+          fi
+          if echo "$CHANGED" | grep -qE '^(Dockerfile|docker-compose\.yml|Gemfile|Gemfile\.lock)$'; then
+            echo "docker=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docker=false" >> "$GITHUB_OUTPUT"
+          fi
+
   jekyll-build-test:
     name: 🏗️ Jekyll Build Test
     runs-on: ubuntu-latest
@@ -168,9 +215,12 @@ jobs:
   docker-build-test:
     name: 🐳 Docker Build Test
     runs-on: ubuntu-latest
+    needs: detect-changes
+    # Only build the image on manual runs or when Docker/dependency inputs change.
     if: |
       github.event.inputs.test_docker != 'false' &&
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+      (github.event_name == 'workflow_dispatch' ||
+       (github.event_name == 'push' && needs.detect-changes.outputs.docker == 'true'))
 
     steps:
     - name: 🏰 Checkout Repository
@@ -237,7 +287,12 @@ jobs:
 
   cross-platform-validation:
     name: 🌐 Cross-Platform Validation
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: detect-changes
+    # Windows + macOS runners are costly; only verify cross-platform Ruby/Jekyll
+    # compatibility when the Gemfile changes or on a manual run.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && needs.detect-changes.outputs.deps == 'true')
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/dependency-checker.yml
+++ b/.github/workflows/dependency-checker.yml
@@ -1,4 +1,4 @@
-name: 🔍 Dependency Security & Build Checker
+name: 🔍 Dependency Security Checker
 
 on:
   # Run only when the dependency definitions actually change. (Previously this
@@ -13,7 +13,7 @@ on:
   # Weekly scheduled dependency check
   schedule:
     - cron: '0 7 * * 1'  # Every Monday at 7 AM UTC (staggered from link-checker)
-  
+
   # Manual trigger (run the checks on demand)
   workflow_dispatch:
 
@@ -26,11 +26,16 @@ concurrency:
 
 env:
   RUBY_VERSION: '3.2'
-  NODE_VERSION: '20'
 
 jobs:
+  # Scope is intentionally security + dependency hygiene ONLY. Jekyll and Docker
+  # build compatibility used to live here too, but that duplicated
+  # build-validation.yml (which builds both on every push to main and on PRs
+  # that touch build inputs) — so on a Gemfile change BOTH workflows ran a full
+  # ~10-minute Jekyll+Docker build. Build coverage now lives solely in
+  # build-validation.yml; this workflow is the lean security/audit gate.
   dependency-security-check:
-    name: 🛡️ Security & Compatibility Analysis
+    name: 🛡️ Security & Dependency Hygiene
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -42,31 +47,26 @@ jobs:
       with:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
-    
+
     - name: 🔧 Setup Ruby Environment
       uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
       with:
         ruby-version: ${{ env.RUBY_VERSION }}
         bundler-cache: false  # We'll handle caching manually to detect issues
-    
-    - name: 🔧 Setup Node.js Environment
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-      with:
-        node-version: ${{ env.NODE_VERSION }}
-    
+
     - name: 📊 Create Results Directory
       run: |
         mkdir -p dependency-check-results
         echo "Check started at: $(date -u +"%Y-%m-%d %H:%M:%S UTC")" > dependency-check-results/summary.md
-    
+
     - name: 🔍 Check Ruby Dependencies
       id: ruby_check
       run: |
         echo "## 💎 Ruby Dependency Analysis" >> dependency-check-results/summary.md
         echo "" >> dependency-check-results/summary.md
-        
+
         echo "### Dependency Status:" >> dependency-check-results/summary.md
-        
+
         # Install dependencies first so Gemfile.lock exists for security audit
         if bundle install 2>&1 | tee dependency-check-results/bundle-install.log; then
           echo "✅ Bundle install successful" >> dependency-check-results/summary.md
@@ -78,16 +78,16 @@ jobs:
           tail -20 dependency-check-results/bundle-install.log >> dependency-check-results/summary.md
           echo "```" >> dependency-check-results/summary.md
         fi
-        
+
         # Install bundler-audit for security checking
         gem install bundler-audit
-        
+
         # Update vulnerability database
         bundle-audit update
-        
+
         echo "" >> dependency-check-results/summary.md
         echo "### Security Vulnerabilities:" >> dependency-check-results/summary.md
-        
+
         # Check for security vulnerabilities (Gemfile.lock now exists from bundle
         # install above). Keep stdout (JSON) and stderr (DB-update / parse
         # warnings) SEPARATE — mixing them with 2>&1 corrupts the JSON, and
@@ -114,7 +114,7 @@ jobs:
           echo "✅ No security vulnerabilities found" >> dependency-check-results/summary.md
           echo "security_issues=false" >> $GITHUB_OUTPUT
         fi
-        
+
         # Check for outdated gems
         echo "" >> dependency-check-results/summary.md
         echo "### Outdated Dependencies:" >> dependency-check-results/summary.md
@@ -128,97 +128,17 @@ jobs:
           cat dependency-check-results/outdated-gems.txt >> dependency-check-results/summary.md
           echo "```" >> dependency-check-results/summary.md
         fi
-    
-    - name: 🔍 Check Jekyll Build Compatibility
-      id: jekyll_check
-      if: steps.ruby_check.outputs.bundle_install == 'success'
-      run: |
-        echo "" >> dependency-check-results/summary.md
-        echo "## 🏗️ Jekyll Build Compatibility" >> dependency-check-results/summary.md
-        echo "" >> dependency-check-results/summary.md
-        
-        # Test Jekyll build process
-        echo "### Build Test Results:" >> dependency-check-results/summary.md
-        
-        if timeout 300 bundle exec jekyll build --verbose --trace 2>&1 | tee dependency-check-results/jekyll-build.log; then
-          echo "✅ Jekyll build successful" >> dependency-check-results/summary.md
-          echo "jekyll_build=success" >> $GITHUB_OUTPUT
-          
-          # Check for warnings
-          if grep -i "warning\|error" dependency-check-results/jekyll-build.log; then
-            echo "⚠️ Build completed with warnings:" >> dependency-check-results/summary.md
-            echo "```" >> dependency-check-results/summary.md
-            grep -i "warning\|error" dependency-check-results/jekyll-build.log >> dependency-check-results/summary.md
-            echo "```" >> dependency-check-results/summary.md
-          fi
-        else
-          echo "❌ Jekyll build failed!" >> dependency-check-results/summary.md
-          echo "jekyll_build=failed" >> $GITHUB_OUTPUT
-          echo "```" >> dependency-check-results/summary.md
-          tail -50 dependency-check-results/jekyll-build.log >> dependency-check-results/summary.md
-          echo "```" >> dependency-check-results/summary.md
-        fi
-        
-        # Test configuration validation
-        echo "" >> dependency-check-results/summary.md
-        echo "### Configuration Validation:" >> dependency-check-results/summary.md
-        
-        if bundle exec jekyll doctor 2>&1 | tee dependency-check-results/jekyll-doctor.log; then
-          echo "✅ Configuration validation passed" >> dependency-check-results/summary.md
-        else
-          echo "⚠️ Configuration issues detected:" >> dependency-check-results/summary.md
-          echo "```" >> dependency-check-results/summary.md
-          cat dependency-check-results/jekyll-doctor.log >> dependency-check-results/summary.md
-          echo "```" >> dependency-check-results/summary.md
-        fi
-    
-    - name: 🔍 Check Docker Build Compatibility
-      id: docker_check
-      run: |
-        echo "" >> dependency-check-results/summary.md
-        echo "## 🐳 Docker Build Compatibility" >> dependency-check-results/summary.md
-        echo "" >> dependency-check-results/summary.md
-        
-        # Test Docker build
-        echo "### Docker Build Test:" >> dependency-check-results/summary.md
-        
-        if timeout 600 docker build -t it-journey-test . 2>&1 | tee dependency-check-results/docker-build.log; then
-          echo "✅ Docker build successful" >> dependency-check-results/summary.md
-          echo "docker_build=success" >> $GITHUB_OUTPUT
-          
-          # Clean up test image
-          docker rmi it-journey-test || true
-        else
-          echo "❌ Docker build failed!" >> dependency-check-results/summary.md
-          echo "docker_build=failed" >> $GITHUB_OUTPUT
-          echo "```" >> dependency-check-results/summary.md
-          tail -50 dependency-check-results/docker-build.log >> dependency-check-results/summary.md
-          echo "```" >> dependency-check-results/summary.md
-        fi
-    
-    - name: 🔍 Check GitHub Actions Compatibility
+
+    - name: 🔍 Check GitHub Actions Workflow Validity
       id: actions_check
       run: |
         echo "" >> dependency-check-results/summary.md
         echo "## ⚙️ GitHub Actions Compatibility" >> dependency-check-results/summary.md
         echo "" >> dependency-check-results/summary.md
-        
-        # Check for outdated actions
-        echo "### Action Version Analysis:" >> dependency-check-results/summary.md
-        
-        # Find all action versions
-        action_versions=$(grep -r "uses:" .github/workflows/ | grep -E "@v[0-9]" | sort | uniq)
-        
-        # Check for potential updates needed
-        echo "**Current Action Versions:**" >> dependency-check-results/summary.md
-        echo "```" >> dependency-check-results/summary.md
-        echo "$action_versions" >> dependency-check-results/summary.md
-        echo "```" >> dependency-check-results/summary.md
-        
-        # Basic validation of workflow files
-        echo "" >> dependency-check-results/summary.md
+
+        # Basic YAML validation of every workflow file
         echo "### Workflow Validation:" >> dependency-check-results/summary.md
-        
+
         workflow_errors=0
         for workflow in .github/workflows/*.yml; do
           if python3 -c "import yaml; yaml.safe_load(open('$workflow'))" 2>/dev/null; then
@@ -228,13 +148,13 @@ jobs:
             workflow_errors=$((workflow_errors + 1))
           fi
         done
-        
+
         if [ $workflow_errors -eq 0 ]; then
           echo "actions_valid=true" >> $GITHUB_OUTPUT
         else
           echo "actions_valid=false" >> $GITHUB_OUTPUT
         fi
-    
+
     - name: 📊 Generate Comprehensive Report
       run: |
         echo "" >> dependency-check-results/summary.md
@@ -244,85 +164,66 @@ jobs:
         echo "|-----------|--------|--------|" >> dependency-check-results/summary.md
         echo "| Security | ${{ steps.ruby_check.outputs.security_issues == 'false' && '✅ Clean' || '❌ Vulnerabilities' }} | ${{ steps.ruby_check.outputs.security_issues == 'true' && 'Security audit required' || 'None detected' }} |" >> dependency-check-results/summary.md
         echo "| Ruby Dependencies | ${{ steps.ruby_check.outputs.bundle_install == 'success' && '✅ Working' || '❌ Failed' }} | ${{ steps.ruby_check.outputs.outdated_gems == 'found' && 'Updates available' || 'Up to date' }} |" >> dependency-check-results/summary.md
-        echo "| Jekyll Build | ${{ steps.jekyll_check.outputs.jekyll_build == 'success' && '✅ Working' || '❌ Failed' }} | Build compatibility verified |" >> dependency-check-results/summary.md
-        echo "| Docker Build | ${{ steps.docker_check.outputs.docker_build == 'success' && '✅ Working' || '❌ Failed' }} | Container compatibility verified |" >> dependency-check-results/summary.md
         echo "| GitHub Actions | ${{ steps.actions_check.outputs.actions_valid == 'true' && '✅ Valid' || '❌ Issues' }} | Workflow syntax validated |" >> dependency-check-results/summary.md
         echo "" >> dependency-check-results/summary.md
-        
+        echo "> Build/Docker compatibility is validated by build-validation.yml." >> dependency-check-results/summary.md
+        echo "" >> dependency-check-results/summary.md
+
         # Generate recommendations
         echo "## 🚀 Recommendations" >> dependency-check-results/summary.md
         echo "" >> dependency-check-results/summary.md
-        
+
         if [ "${{ steps.ruby_check.outputs.security_issues }}" == "true" ]; then
           echo "🔴 **High Priority**: Security vulnerabilities detected - update dependencies immediately" >> dependency-check-results/summary.md
         fi
-        
+
         if [ "${{ steps.ruby_check.outputs.outdated_gems }}" == "found" ]; then
-          echo "🟡 **Medium Priority**: Outdated gems available - consider updating for latest features and bug fixes" >> dependency-check-results/summary.md
+          echo "🟡 **Medium Priority**: Outdated gems available - Dependabot will usually open these bumps automatically" >> dependency-check-results/summary.md
         fi
-        
-        if [ "${{ steps.jekyll_check.outputs.jekyll_build }}" == "failed" ]; then
-          echo "🔴 **High Priority**: Jekyll build failing - site deployment may be affected" >> dependency-check-results/summary.md
-        fi
-        
-        if [ "${{ steps.docker_check.outputs.docker_build }}" == "failed" ]; then
-          echo "🟡 **Medium Priority**: Docker build failing - containerized deployment unavailable" >> dependency-check-results/summary.md
-        fi
-        
+
         echo "" >> dependency-check-results/summary.md
         echo "---" >> dependency-check-results/summary.md
         echo "*Report generated on $(date -u +"%Y-%m-%d %H:%M:%S UTC") by IT-Journey Dependency Checker*" >> dependency-check-results/summary.md
-    
-    - name: 🚨 Create Issue for Critical Issues
-      if: steps.ruby_check.outputs.security_issues == 'true' || steps.jekyll_check.outputs.jekyll_build == 'failed'
+
+    - name: 🚨 Create Issue for Security Vulnerabilities
+      if: steps.ruby_check.outputs.security_issues == 'true'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        # Create issue for critical problems
+        # Create issue for security problems
         cat > issue_body.md << 'EOF'
-        # 🚨 Critical Dependency/Build Issues Detected
-        
+        # 🚨 Security Vulnerability Detected in Dependencies
+
         This issue was automatically generated by the dependency checker workflow.
-        
-        ## 🔍 Issues Found
-        
+
+        ## 🛡️ Security Vulnerabilities
+
+        Security vulnerabilities have been detected in Ruby dependencies. This requires immediate attention.
+
         EOF
-        
-        if [ "${{ steps.ruby_check.outputs.security_issues }}" == "true" ]; then
-          echo "### 🛡️ Security Vulnerabilities" >> issue_body.md
-          echo "" >> issue_body.md
-          echo "Security vulnerabilities have been detected in Ruby dependencies. This requires immediate attention." >> issue_body.md
-          echo "" >> issue_body.md
-          if [ -f dependency-check-results/security-audit.json ]; then
-            echo "**Details:**" >> issue_body.md
-            echo "```json" >> issue_body.md
-            cat dependency-check-results/security-audit.json >> issue_body.md
-            echo "```" >> issue_body.md
-          fi
+
+        if [ -f dependency-check-results/security-audit.json ]; then
+          echo "**Details:**" >> issue_body.md
+          echo "```json" >> issue_body.md
+          cat dependency-check-results/security-audit.json >> issue_body.md
+          echo "```" >> issue_body.md
           echo "" >> issue_body.md
         fi
-        
-        if [ "${{ steps.jekyll_check.outputs.jekyll_build }}" == "failed" ]; then
-          echo "### 🏗️ Build Failure" >> issue_body.md
-          echo "" >> issue_body.md
-          echo "Jekyll build is currently failing, which may prevent site deployment." >> issue_body.md
-          echo "" >> issue_body.md
-        fi
-        
+
         cat >> issue_body.md << 'EOF'
         ## 📋 Full Report
-        
+
         EOF
-        
+
         cat dependency-check-results/summary.md >> issue_body.md
 
         # Dedup: maintain ONE open issue instead of filing a new one each run.
         # Stable title; reuse any existing open automated dependency issue
         # (matches the old date-stamped ones too) by updating it in place.
-        ISSUE_TITLE="🚨 Dependency/Build Issues (automated)"
+        ISSUE_TITLE="🚨 Dependency Security Issues (automated)"
         EXISTING=$(gh issue list --state open --label automated --label critical \
           --json number,title \
-          --jq '[.[] | select(.title | test("Dependency/Build Issues"))] | .[0].number // empty')
+          --jq '[.[] | select(.title | test("Dependency.*Issues"))] | .[0].number // empty')
 
         if [ -n "$EXISTING" ]; then
           gh issue edit "$EXISTING" --body-file issue_body.md
@@ -338,18 +239,18 @@ jobs:
         fi
 
     - name: ✅ Auto-Close Resolved Issue
-      # When the latest check is fully green, close any open automated
-      # dependency issue so the tracker stays clean without manual triage.
-      if: steps.ruby_check.outputs.security_issues != 'true' && steps.jekyll_check.outputs.jekyll_build != 'failed'
+      # When the latest check is clean, close any open automated dependency
+      # issue so the tracker stays clean without manual triage.
+      if: steps.ruby_check.outputs.security_issues != 'true'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         EXISTING=$(gh issue list --state open --label automated --label critical \
           --json number,title \
-          --jq '[.[] | select(.title | test("Dependency/Build Issues"))] | .[0].number // empty')
+          --jq '[.[] | select(.title | test("Dependency.*Issues"))] | .[0].number // empty')
         if [ -n "$EXISTING" ]; then
           gh issue close "$EXISTING" \
-            --comment "✅ Resolved automatically — the latest dependency/build check is green (run ${{ github.run_id }})."
+            --comment "✅ Resolved automatically — the latest dependency security check is clean (run ${{ github.run_id }})."
           echo "Closed resolved issue #$EXISTING"
         else
           echo "No open automated dependency issue to close."
@@ -361,10 +262,10 @@ jobs:
         name: dependency-check-results-${{ github.run_number }}
         path: dependency-check-results/
         retention-days: 30
-    
+
     - name: 📊 Summary
       run: |
-        echo "## 🔍 Dependency & Build Check Summary" >> $GITHUB_STEP_SUMMARY
+        echo "## 🔍 Dependency Security Check Summary" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         cat dependency-check-results/summary.md >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/frontmatter-validation.yml
+++ b/.github/workflows/frontmatter-validation.yml
@@ -1,467 +1,159 @@
-name: Frontmatter Validation and Auto-Fix
+name: Frontmatter Validation
+
+# Validation-only gate. This used to inline a ~400-line frontmatter validator
+# that drifted from the canonical one the repo ships at
+# scripts/validation/frontmatter-validator.py (the same code `make
+# content-validate` runs). It now calls that single source of truth so CI and
+# local stay in lockstep. Mechanical AUTO-FIXING is intentionally NOT here —
+# that is owned by `make content-normalize-apply`, run daily by
+# cms-daily-loop.yml (Lane A). Quest frontmatter is validated by
+# quest-validation.yml, so it is excluded here to avoid double coverage.
 
 on:
   pull_request:
     paths:
       - 'pages/**/*.md'
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
-    inputs:
-      apply_fixes:
-        description: 'Apply automatic fixes to frontmatter'
-        required: true
-        default: 'false'
-        type: choice
-        options:
-        - 'true'
-        - 'false'
 
 permissions:
   contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   validate-frontmatter:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        fetch-depth: 0
-        token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
 
-    - name: Set up Python
-      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-      with:
-        python-version: '3.x'
-    
-    - name: Install dependencies
-      run: |
-        pip install pyyaml
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
 
-    - name: Check Mermaid render flags
-      # Fails if any page contains a Mermaid diagram but omits `mermaid: true`
-      # (the theme only loads Mermaid when that flag is set). Stdlib-only.
-      run: |
-        python3 scripts/validation/check_mermaid_flags.py
+      - name: Install dependencies
+        run: pip install pyyaml
 
-    - name: Get changed markdown files
-      id: changed-files
-      run: |
-        if [ "${{ github.event_name }}" = "pull_request" ]; then
-          changed_files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep -E '^pages/.*\.md$' || true)
-        else
-          # For workflow_dispatch, check all files
-          changed_files=$(find pages -name "*.md" -type f)
-        fi
-        
-        echo "Changed markdown files:"
-        echo "$changed_files"
-        
-        echo "files<<EOF" >> $GITHUB_OUTPUT
-        echo "$changed_files" >> $GITHUB_OUTPUT
-        echo "EOF" >> $GITHUB_OUTPUT
-    
-    - name: Analyze frontmatter
-      env:
-        CHANGED_FILES_INPUT: ${{ steps.changed-files.outputs.files }}
-        APPLY_FIXES_INPUT: ${{ github.event.inputs.apply_fixes || 'false' }}
-      run: |
-        cat > frontmatter_validator.py << 'EOF'
-        import os
-        import yaml
-        import re
-        import json
-        from pathlib import Path
-        from datetime import datetime
-        from typing import Dict, List, Any, Optional
+      - name: Check Mermaid render flags
+        # Fails if any page contains a Mermaid diagram but omits `mermaid: true`
+        # (the theme only loads Mermaid when that flag is set). Stdlib-only.
+        run: python3 scripts/validation/check_mermaid_flags.py
 
-        class FrontmatterValidator:
-            def __init__(self):
-                self.required_fields = {'title', 'description', 'date', 'categories', 'tags', 'author'}
-                self.recommended_fields = {'excerpt', 'lastmod', 'draft'}
-                self.default_author = "bamr87"
-                
-            def extract_frontmatter_and_content(self, file_path: Path) -> tuple:
-                """Extract YAML frontmatter and content from markdown file."""
-                try:
-                    with open(file_path, 'r', encoding='utf-8') as f:
-                        content = f.read()
-                    
-                    if content.startswith('---\n'):
-                        parts = content.split('\n---\n', 1)
-                        if len(parts) == 2:
-                            try:
-                                frontmatter = yaml.safe_load(parts[0][4:])
-                                body_content = parts[1]
-                                return frontmatter if frontmatter else {}, body_content
-                            except yaml.YAMLError:
-                                return {}, content
-                    return {}, content
-                except Exception as e:
-                    print(f"Error reading {file_path}: {e}")
-                    return {}, ""
-            
-            def validate_file(self, file_path: Path) -> Dict[str, Any]:
-                """Validate frontmatter of a single file."""
-                frontmatter, content = self.extract_frontmatter_and_content(file_path)
-                
-                issues = []
-                warnings = []
-                suggestions = []
-                
-                # Check required fields
-                missing_required = self.required_fields - set(frontmatter.keys())
-                for field in missing_required:
-                    issues.append(f"Missing required field: {field}")
-                
-                # Check for empty values
-                empty_fields = [k for k, v in frontmatter.items() if v == "" or v is None]
-                for field in empty_fields:
-                    if field in self.required_fields:
-                        issues.append(f"Required field '{field}' is empty")
-                    else:
-                        warnings.append(f"Optional field '{field}' is empty")
-                
-                # Check recommended fields
-                missing_recommended = self.recommended_fields - set(frontmatter.keys())
-                for field in missing_recommended:
-                    suggestions.append(f"Consider adding recommended field: {field}")
-                
-                # Validate specific fields
-                if frontmatter.get('date'):
-                    try:
-                        # Validate date format
-                        date_str = str(frontmatter['date'])
-                        if not re.match(r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}', date_str):
-                            warnings.append("Date format should be ISO 8601 (YYYY-MM-DDTHH:MM:SS.sssZ)")
-                    except:
-                        issues.append("Invalid date format")
-                
-                if frontmatter.get('tags') and not isinstance(frontmatter['tags'], list):
-                    issues.append("Tags should be a list")
-                
-                if frontmatter.get('categories') and not isinstance(frontmatter['categories'], list):
-                    issues.append("Categories should be a list")
-                
-                # Content quality checks
-                if len(content.strip()) < 100:
-                    warnings.append("Content is very short (less than 100 characters)")
-                
-                if not re.search(r'^#{1,6}\s+', content, re.MULTILINE):
-                    suggestions.append("Consider adding headers to improve content structure")
-                
-                return {
-                    'file_path': str(file_path),
-                    'has_issues': bool(issues),
-                    'issues': issues,
-                    'warnings': warnings,
-                    'suggestions': suggestions,
-                    'frontmatter': frontmatter
-                }
-            
-            def generate_fixes(self, file_path: Path, validation_result: Dict) -> Dict[str, Any]:
-                """Generate automatic fixes for frontmatter issues."""
-                frontmatter, content = self.extract_frontmatter_and_content(file_path)
-                fixes_applied = []
-                
-                # Fix missing title
-                if not frontmatter.get('title'):
-                    title = file_path.stem.replace('-', ' ').replace('_', ' ').title()
-                    title = re.sub(r'^\d{4}-\d{2}-\d{2}\s*', '', title)
-                    frontmatter['title'] = title
-                    fixes_applied.append(f"Added title: {title}")
-                
-                # Fix missing description
-                if not frontmatter.get('description'):
-                    lines = content.split('\n')
-                    content_lines = [line.strip() for line in lines if line.strip() and not line.startswith('#')]
-                    if content_lines:
-                        description = content_lines[0][:150]
-                        if len(content_lines[0]) > 150:
-                            description += "..."
-                    else:
-                        description = f"Learn about {frontmatter.get('title', 'this topic').lower()}."
-                    frontmatter['description'] = description
-                    fixes_applied.append("Added description")
-                
-                # Fix missing date
-                if not frontmatter.get('date'):
-                    date_match = re.search(r'(\d{4}-\d{2}-\d{2})', file_path.name)
-                    if date_match:
-                        date_str = date_match.group(1)
-                        frontmatter['date'] = f"{date_str}T00:00:00.000Z"
-                    else:
-                        file_stat = file_path.stat()
-                        creation_time = datetime.fromtimestamp(file_stat.st_mtime)
-                        frontmatter['date'] = creation_time.strftime('%Y-%m-%dT%H:%M:%S.%fZ')[:-3] + 'Z'
-                    fixes_applied.append("Added date")
-                
-                # Fix missing author
-                if not frontmatter.get('author'):
-                    frontmatter['author'] = self.default_author
-                    fixes_applied.append(f"Added author: {self.default_author}")
-                
-                # Fix missing categories
-                if not frontmatter.get('categories'):
-                    relative_path = file_path.relative_to(Path('pages'))
-                    if len(relative_path.parts) > 1:
-                        category = relative_path.parts[0]
-                        if category.startswith('_'):
-                            category = category[1:]
-                        frontmatter['categories'] = [category]
-                        fixes_applied.append(f"Added categories: [{category}]")
-                
-                # Fix missing tags
-                if not frontmatter.get('tags'):
-                    # Basic tag inference from content
-                    content_lower = content.lower()
-                    tags = []
-                    tag_keywords = {
-                        'tutorial': ['tutorial', 'guide', 'how-to'],
-                        'jekyll': ['jekyll', 'liquid'],
-                        'git': ['git', 'github'],
-                        'ai': ['ai', 'artificial intelligence', 'gpt'],
-                        'python': ['python', 'pip'],
-                        'javascript': ['javascript', 'js', 'node']
-                    }
-                    
-                    for tag, keywords in tag_keywords.items():
-                        if any(keyword in content_lower for keyword in keywords):
-                            tags.append(tag)
-                    
-                    if tags:
-                        frontmatter['tags'] = tags
-                        fixes_applied.append(f"Added tags: {tags}")
-                
-                # Add lastmod
-                if not frontmatter.get('lastmod'):
-                    frontmatter['lastmod'] = datetime.now().strftime('%Y-%m-%dT%H:%M:%S.%fZ')[:-3] + 'Z'
-                    fixes_applied.append("Added lastmod")
-                
-                # Set draft status
-                if 'draft' not in frontmatter:
-                    frontmatter['draft'] = False
-                    fixes_applied.append("Set draft: false")
-                
-                return {
-                    'file_path': str(file_path),
-                    'fixes_applied': fixes_applied,
-                    'new_frontmatter': frontmatter,
-                    'content': content
-                }
-            
-            def write_file_with_frontmatter(self, file_path: Path, frontmatter: Dict, content: str):
-                """Write file with updated frontmatter."""
-                try:
-                    yaml_content = yaml.dump(frontmatter, default_flow_style=False, allow_unicode=True)
-                    full_content = f"---\n{yaml_content}---\n{content}"
-                    
-                    with open(file_path, 'w', encoding='utf-8') as f:
-                        f.write(full_content)
-                    
-                    return True
-                except Exception as e:
-                    print(f"Error writing {file_path}: {e}")
-                    return False
-
-        def main():
-            validator = FrontmatterValidator()
-            
-            # Get list of files to validate
-            changed_files_str = os.getenv('CHANGED_FILES', '')
-            files_to_check = [f.strip() for f in changed_files_str.split('\n') if f.strip()]
-            
-            if not files_to_check:
-                print("No markdown files to validate")
-                return
-            
-            validation_results = []
-            fix_results = []
-            
-            apply_fixes = os.getenv('APPLY_FIXES', 'false').lower() == 'true'
-            
-            for file_path_str in files_to_check:
-                file_path = Path(file_path_str)
-                if not file_path.exists():
-                    continue
-                
-                print(f"Validating: {file_path}")
-                validation_result = validator.validate_file(file_path)
-                validation_results.append(validation_result)
-                
-                if apply_fixes and (validation_result['has_issues'] or validation_result['warnings']):
-                    print(f"Applying fixes to: {file_path}")
-                    fix_result = validator.generate_fixes(file_path, validation_result)
-                    
-                    if fix_result['fixes_applied']:
-                        success = validator.write_file_with_frontmatter(
-                            file_path, 
-                            fix_result['new_frontmatter'], 
-                            fix_result['content']
-                        )
-                        if success:
-                            fix_results.append(fix_result)
-            
-            # Save results (use default=str to handle datetime objects from YAML parsing)
-            with open('/tmp/validation_results.json', 'w') as f:
-                json.dump({
-                    'validation_results': validation_results,
-                    'fix_results': fix_results,
-                    'apply_fixes': apply_fixes
-                }, f, indent=2, default=str)
-            
-            # Print summary
-            total_files = len(validation_results)
-            files_with_issues = len([r for r in validation_results if r['has_issues']])
-            files_with_warnings = len([r for r in validation_results if r['warnings']])
-            
-            print(f"\n=== FRONTMATTER VALIDATION SUMMARY ===")
-            print(f"Files validated: {total_files}")
-            print(f"Files with issues: {files_with_issues}")
-            print(f"Files with warnings: {files_with_warnings}")
-            
-            if apply_fixes:
-                files_fixed = len(fix_results)
-                print(f"Files automatically fixed: {files_fixed}")
-
-        if __name__ == "__main__":
-            main()
-        EOF
-        
-        export CHANGED_FILES="$CHANGED_FILES_INPUT"
-        export APPLY_FIXES="$APPLY_FIXES_INPUT"
-        python frontmatter_validator.py
-    
-    - name: Create validation report
-      run: |
-        cat > create_validation_report.py << 'EOF'
-        import json
-        import os
-        
-        try:
-            with open('/tmp/validation_results.json', 'r') as f:
-                results = json.load(f)
-        except:
-            results = {'validation_results': [], 'fix_results': [], 'apply_fixes': False}
-        
-        validation_results = results['validation_results']
-        fix_results = results['fix_results']
-        apply_fixes = results['apply_fixes']
-        
-        if not validation_results:
-            print("No validation results to report")
-            exit(0)
-        
-        # Create markdown report
-        report = "## 📋 Frontmatter Validation Report\n\n"
-        
-        total_files = len(validation_results)
-        files_with_issues = len([r for r in validation_results if r['has_issues']])
-        files_with_warnings = len([r for r in validation_results if r['warnings']])
-        
-        report += f"**Files validated:** {total_files}  \n"
-        report += f"**Files with issues:** {files_with_issues}  \n"
-        report += f"**Files with warnings:** {files_with_warnings}  \n"
-        
-        if apply_fixes:
-            files_fixed = len(fix_results)
-            report += f"**Files automatically fixed:** {files_fixed}  \n"
-        
-        report += "\n"
-        
-        # Show validation results
-        for result in validation_results:
-            if result['has_issues'] or result['warnings'] or result['suggestions']:
-                report += f"### 📄 `{result['file_path']}`\n\n"
-                
-                if result['issues']:
-                    report += "**❌ Issues (must fix):**\n"
-                    for issue in result['issues']:
-                        report += f"- {issue}\n"
-                    report += "\n"
-                
-                if result['warnings']:
-                    report += "**⚠️ Warnings:**\n"
-                    for warning in result['warnings']:
-                        report += f"- {warning}\n"
-                    report += "\n"
-                
-                if result['suggestions']:
-                    report += "**💡 Suggestions:**\n"
-                    for suggestion in result['suggestions'][:3]:  # Limit to top 3
-                        report += f"- {suggestion}\n"
-                    report += "\n"
-                
-                report += "---\n\n"
-        
-        # Show fix results if any
-        if fix_results:
-            report += "## 🔧 Automatic Fixes Applied\n\n"
-            for fix_result in fix_results:
-                report += f"### 📄 `{fix_result['file_path']}`\n\n"
-                report += "**Fixes applied:**\n"
-                for fix in fix_result['fixes_applied']:
-                    report += f"- ✅ {fix}\n"
-                report += "\n"
-        
-        # Save report
-        with open('/tmp/validation_report.md', 'w') as f:
-            f.write(report)
-        
-        print("Validation report created!")
-        EOF
-        
-        python create_validation_report.py
-    
-    - name: Commit fixes (if applied)
-      if: github.event.inputs.apply_fixes == 'true'
-      run: |
-        if [ -f "/tmp/validation_results.json" ]; then
-          # Check if there are any changes
-          if ! git diff --quiet; then
-            git config --global user.name 'github-actions[bot]'
-            git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-            git add pages/
-            git commit -m "🤖 Auto-fix frontmatter issues [skip ci]
-
-            - Added missing required fields
-            - Fixed formatting issues
-            - Standardized metadata structure
-
-            Generated by frontmatter validation workflow"
-            git push
+      - name: Determine target files
+        id: targets
+        run: |
+          mkdir -p /tmp/fm
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Only changed, non-quest markdown under pages/.
+            git diff --name-only --diff-filter=ACMR \
+              "${{ github.event.pull_request.base.sha }}" \
+              "${{ github.event.pull_request.head.sha }}" \
+              -- 'pages/**/*.md' \
+              | grep -v '^pages/_quests/' > /tmp/fm/targets.txt || true
+          else
+            # Manual run: every non-quest markdown page.
+            find pages -name '*.md' -type f \
+              | grep -v '^pages/_quests/' > /tmp/fm/targets.txt || true
           fi
-        fi
-    
-    - name: Comment on PR
-      if: github.event_name == 'pull_request'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        REPO: ${{ github.repository }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
-      run: |
-        if [ -f "/tmp/validation_report.md" ]; then
-          jq -n --rawfile body /tmp/validation_report.md '{"body": $body}' | \
-          curl -s -X POST \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d @- \
-            "https://api.github.com/repos/$REPO/issues/$PR_NUMBER/comments"
-        fi
+          COUNT=$(grep -c . /tmp/fm/targets.txt || echo 0)
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "Targeting $COUNT file(s):"
+          cat /tmp/fm/targets.txt || true
 
-    - name: Upload validation artifacts
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      with:
-        name: frontmatter-validation-results
-        path: |
-          /tmp/validation_results.json
-          /tmp/validation_report.md
-        retention-days: 30
+      - name: Validate frontmatter (canonical validator)
+        id: validate
+        if: steps.targets.outputs.count != '0'
+        run: |
+          # Run the canonical validator per file so content-type detection (which
+          # keys off the directory name) stays correct, writing one JSON each.
+          i=0
+          while IFS= read -r f; do
+            [ -f "$f" ] || continue
+            i=$((i + 1))
+            python3 scripts/validation/frontmatter-validator.py "$f" \
+              -o "/tmp/fm/result-${i}.json" > /dev/null 2>&1 || true
+          done < /tmp/fm/targets.txt
+
+          # Aggregate the per-file JSON reports into a comment + error total.
+          python3 - <<'PY'
+          import glob, json, os
+          files = []
+          for path in glob.glob('/tmp/fm/result-*.json'):
+              with open(path) as fh:
+                  files.extend(json.load(fh).get('files', []))
+
+          errors = sum(f['error_count'] for f in files)
+          warnings = sum(f['warning_count'] for f in files)
+          invalid = [f for f in files if f['error_count'] > 0]
+
+          lines = ['## 📋 Frontmatter Validation', '',
+                   f'**Files checked:** {len(files)}  ',
+                   f'**Errors:** {errors}  ',
+                   f'**Warnings:** {warnings}  ', '']
+          if invalid:
+              lines.append('### ❌ Files with errors')
+              for f in sorted(invalid, key=lambda x: -x['error_count'])[:25]:
+                  lines.append(f"- `{f['file_path']}` — {f['error_count']} error(s)")
+                  for issue in [i for i in f['issues'] if i['severity'] == 'error'][:5]:
+                      sug = f" — _{issue['suggestion']}_" if issue.get('suggestion') else ''
+                      lines.append(f"  - **{issue['field']}**: {issue['message']}{sug}")
+          else:
+              lines.append('✅ No frontmatter errors in the changed pages.')
+          lines += ['', '<sub>Validated by `scripts/validation/frontmatter-validator.py`'
+                    ' — run locally with `make content-validate`.</sub>']
+
+          with open('/tmp/fm/comment.md', 'w') as fh:
+              fh.write('\n'.join(lines))
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+              fh.write(f'errors={errors}\n')
+          PY
+
+      - name: Comment on PR
+        if: github.event_name == 'pull_request' && steps.targets.outputs.count != '0'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            let body;
+            try { body = fs.readFileSync('/tmp/fm/comment.md', 'utf8'); } catch { return; }
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('Frontmatter Validation'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: context.issue.number, body,
+              });
+            }
+
+      - name: Upload validation report
+        if: steps.targets.outputs.count != '0'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: frontmatter-validation-results
+          path: /tmp/fm/
+          retention-days: 14
+
+      - name: Fail on frontmatter errors
+        if: steps.validate.outputs.errors != '' && steps.validate.outputs.errors != '0'
+        run: |
+          echo "::error::${{ steps.validate.outputs.errors }} frontmatter error(s) in changed pages. See the PR comment / artifact; fix and push."
+          exit 1

--- a/.github/workflows/new-feature-request.yml
+++ b/.github/workflows/new-feature-request.yml
@@ -34,7 +34,7 @@ jobs:
           REPO_URL: https://github.com/${{ github.repository }}/issues/
           GITHUB_WORKSPACE: ${{ github.workspace }}
         run: |
-          python script/append_feature.py
+          python scripts/development/content/append_feature.py
 
       - name: Build commit message
         id: commit_msg

--- a/.github/workflows/update-contributor-profiles.yml
+++ b/.github/workflows/update-contributor-profiles.yml
@@ -1,8 +1,11 @@
 name: Update Contributor Profiles
 
 on:
-  push:
-    branches: [main]
+  # Contributor stats are derived from the GitHub API and barely move between
+  # individual commits, so a per-push run was almost pure waste (one API sweep
+  # per merge to main). Refresh weekly instead, with on-demand dispatch.
+  schedule:
+    - cron: '0 5 * * 1'  # Every Monday at 5 AM UTC
   workflow_dispatch:
     inputs:
       username:

--- a/.github/workflows/update-settings.yml
+++ b/.github/workflows/update-settings.yml
@@ -47,13 +47,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y tree
 
       - name: Make update script executable
-        run: chmod +x scripts/update-settings.sh
+        run: chmod +x scripts/deployment/update-settings.sh
 
       - name: Run update settings script
         run: |
           export SETTINGS_DIR="${{ env.SETTINGS_DIR }}"
           export CONFIG_FILE="${{ env.CONFIG_FILE }}"
-          ./scripts/update-settings.sh
+          ./scripts/deployment/update-settings.sh
 
       - name: Check for changes
         id: changes
@@ -88,7 +88,7 @@ jobs:
           echo "## Settings Update Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Update Method:" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ **Using modular script**: \`scripts/update-settings.sh\`" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ **Using modular script**: \`scripts/deployment/update-settings.sh\`" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ **DRY Principle**: Single source of truth for update logic" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ **Maintainable**: Logic centralized in reusable script" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

A full review of the 20 workflows in `.github/workflows/`, focused on **reducing unnecessary CI workload** while fixing outright bugs and removing obsolete content. Net: **+344 / −881 lines** across 7 files, with measurably less compute per push.

## Bug fixes (workflows pointed at script paths that don't exist)

- **`new-feature-request.yml`** — `script/append_feature.py` → `scripts/development/content/append_feature.py` (was failing at runtime).
- **`update-settings.yml`** — `scripts/update-settings.sh` → `scripts/deployment/update-settings.sh` (chmod, run, and summary text).

## Workload reductions

- **`build-validation.yml`** — added a cheap `detect-changes` job. The **Docker build** and the **3-OS (ubuntu/windows/macOS) cross-platform matrix** now run only when `Gemfile`/`Gemfile.lock`/`Dockerfile`/`docker-compose.yml` change or on manual dispatch — not on every content push to `main`. The Jekyll CI-parity build (the required check) still runs on every relevant change.
- **`dependency-checker.yml`** — removed the redundant Jekyll **and** Docker build steps (already covered by `build-validation.yml`, which means a `Gemfile` push previously triggered two full ~10-min builds) plus the unused Node setup. Now a lean security/dependency-hygiene gate: `bundler-audit` + outdated report + workflow-YAML lint, with security-only issue creation.
- **`update-contributor-profiles.yml`** — was running on **every** push to `main` (one GitHub-API sweep per merge). Moved to **weekly** schedule + dispatch; the derived stats barely move per commit.
- **`frontmatter-validation.yml`** — replaced the ~400-line **inline** validator (which had drifted from the tool the repo actually ships) with the canonical `scripts/validation/frontmatter-validator.py` — the same code `make content-validate` runs, so CI and local stay in lockstep. Validates only changed **non-quest** pages (quests are covered by `quest-validation.yml`); the `apply_fixes` path was removed because mechanical normalization is owned by `cms-daily-loop.yml` Lane A (`make content-normalize-apply`).

## Docs

- Rewrote `.github/workflows/README.md` into an accurate inventory of the real workflows. The old README documented three workflows that **don't exist** (`ai-content-review.yml`, `deploy.yml`, `posts-markdown-lint.yml`) and an OpenAI/GPT-4 review pipeline that was removed; the required-vs-advisory table and deployment notes are now correct.

## Behavior change to flag for review

`frontmatter-validation.yml` now **fails** a PR when a changed non-quest page has frontmatter **errors** (per the canonical validator). The previous inline script only printed a report and never failed — so the check matched its documented intent ("the PR will fail frontmatter-validation otherwise") in name only. This aligns it with `make content-validate`. Scope is limited to *changed* files, so it won't retroactively block PRs for untouched pages. The required-check **job name** (`validate-frontmatter`) and other required-check job names are unchanged, so branch protection contexts are preserved.

## Validation done

- All 20 workflow YAML files parse (`yaml.safe_load`).
- The embedded Python in the new frontmatter workflow compiles after YAML block-scalar dedent.
- Smoke-tested the validator + JSON aggregation end-to-end on real `pages/` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLpb65PRqUikrHiVV1VfAU)_