### PR TITLE
fix(quests): repair bashcrawl quests — headers, navigation bugs, accuracy & clarity

### DIFF
--- a/pages/_quests/0000/bashcrawl/README.md
+++ b/pages/_quests/0000/bashcrawl/README.md
@@ -64,38 +64,12 @@ quest_dependencies:
   - /quests/0000/scrap/
   - /quests/0000/rift/
   - /quests/0000/agent-mode/
-quest_relationships:
-  child_quests:
-  - /quests/0000/side-quests/entrance/
-  - /quests/0000/side-quests/workshop/
-  - /quests/0000/side-quests/cellar/
-  - /quests/0000/side-quests/armoury/
-  - /quests/0000/side-quests/chamber/
-  - /quests/0000/side-quests/hidden-chapel/
-  - /quests/0000/side-quests/vault/
-  - /quests/0000/side-quests/scrap/
-  - /quests/0000/side-quests/rift/
-  - /quests/0000/side-quests/agent-mode/
-  sequel_quests:
-  - /quests/0000/side-quests/bash-run/
-  parallel_quests: []
-learning_paths:
-  primary_paths:
-  - System Administration
-  - Software Development
-  character_classes:
-  - 💻 Software Developer
-  - 🏗️ System Engineer
-  skill_trees:
-  - Terminal Mastery
 validation_criteria:
 - Navigate through the entrance and read the first scroll
 - Navigate through at least five chambers
 - Defeat at least one combat encounter
 - Complete the Rift final boss
-sub-title: 'Level 0000 Quest: Terminal Dungeon Adventure'
 excerpt: Embark on an epic terminal adventure that teaches Bash commands through nine interconnected dungeon chambers, each a dedicated walkthrough side-quest
-snippet: Every command is a spell, every directory a new realm to explore
 draft: false
 permalink: /quests/0000/bashcrawl/
 mermaid: true

--- a/pages/_quests/0000/bashcrawl/agent-mode.md
+++ b/pages/_quests/0000/bashcrawl/agent-mode.md
@@ -67,6 +67,8 @@ redirect_from:
 
 This page is your **walkthrough and strategy guide**. Agent Mode itself runs locally (see [Install &amp; Play Locally](#play-locally)) — but you can explore the dungeon in the browser first.
 
+> The live terminal below is rendered by a Jekyll include; the `{% raw %}{% include %}{% endraw %}` tags and `[[wiki-links]]` in this file render as literal text when viewed outside the IT-Journey site (Jekyll) or Obsidian.
+
 {% include bashcrawl-terminal.html %}
 
 ## 🎯 Quest Objectives
@@ -81,6 +83,9 @@ This page is your **walkthrough and strategy guide**. Agent Mode itself runs loc
 
 - All 9 dungeon areas explored
 - Comfortable with shell scripting and pipes
+- The agent/automation flags below require the IT-Journey fork of Bashcrawl ([github.com/bamr87/bashcrawl](https://github.com/bamr87/bashcrawl)); a learner running upstream Bashcrawl may not have them.
+- The `llm` Python package for the AI agent: `pip install llm` (the agent falls back to a heuristic navigator if it is missing)
+- Screenshot capture may require extra terminal tooling on your system — the PNGs are produced by the screenshot-capable run modes below, and a terminal that supports them
 - (Optional) GitHub account for contribution track
 
 ## ⚡ Command Reference
@@ -88,13 +93,16 @@ This page is your **walkthrough and strategy guide**. Agent Mode itself runs loc
 | Mode | What It Does |
 |------|-------------|
 | `./main.sh --agent` | AI playtesting mode — AI navigates autonomously |
-| `./main.sh --agent-bash` | Agent mode in classic bash-only interface |
+| `./main.sh --agent-bash` | Agent mode in classic bash-only interface (not demonstrated below) |
 | `./main.sh --batch commands.txt` | Execute a list of commands from a file |
-| `./main.sh --command "cmd"` | Run a single command inside the dungeon |
+| `./main.sh --command "cmd"` | Run a single command inside the dungeon (not demonstrated below) |
 | `./main.sh --screenshot-dir ./shots/` | Capture terminal screenshots while playing |
+| `./main.sh --classic` | Run in plain (non-TUI) mode — often paired with `--screenshot-dir` |
 | `./main.sh --status` | Print dungeon completion status |
 | `./main.sh --demo` | Run the built-in demo walkthrough |
 | `./main.sh --reset` | Reset the dungeon to initial state |
+
+> These automation flags ship with the IT-Journey fork ([github.com/bamr87/bashcrawl](https://github.com/bamr87/bashcrawl)). If you are on upstream Bashcrawl, some may not be available.
 
 Or use the IT-Journey launcher from the hub directory:
 
@@ -129,9 +137,10 @@ Watch to see if the AI takes different paths than you did. Note: the AI makes mi
 mkdir -p ./walkthrough_screenshots
 
 ./main.sh --screenshot-dir ./walkthrough_screenshots --classic
-# Play through the dungeon normally
+# Play through the dungeon normally (--classic runs in plain, non-TUI mode)
 # Screenshots auto-saved at each room
 
+# Exit the session first (Ctrl+C or type quit), then list your captures:
 ls ./walkthrough_screenshots/
 # entrance_01.png  workshop_01.png  cellar_01.png  ...
 ```
@@ -213,8 +222,9 @@ cd bashcrawl
 git checkout -b feature/my-improvement
 
 # Make changes (new rooms, better documentation, bug fixes)
-# Example: add a new combat command
-echo 'cast_spell() { echo "You cast $1!"; }' >> lib/combat.sh
+# Illustrative example: add a helper function to a helpers file
+# (create lib/helpers.sh if it does not already exist)
+echo 'cast_spell() { echo "You cast $1!"; }' >> lib/helpers.sh
 
 git add .
 git commit -m "feat(combat): add cast_spell helper function"

--- a/pages/_quests/0000/bashcrawl/agent-mode.md
+++ b/pages/_quests/0000/bashcrawl/agent-mode.md
@@ -84,7 +84,7 @@ This page is your **walkthrough and strategy guide**. Agent Mode itself runs loc
 - All 9 dungeon areas explored
 - Comfortable with shell scripting and pipes
 - The agent/automation flags below require the IT-Journey fork of Bashcrawl ([github.com/bamr87/bashcrawl](https://github.com/bamr87/bashcrawl)); a learner running upstream Bashcrawl may not have them.
-- The `llm` Python package for the AI agent: `pip install llm` (the agent falls back to a heuristic navigator if it is missing)
+- The `llm` Python package for the AI agent: `pip install llm` **and** a configured model provider key (e.g. `llm keys set openai`, or set `OPENAI_API_KEY`). Installing the package alone is not enough — without a key the agent uses its built-in heuristic navigator instead of a real model.
 - Screenshot capture may require extra terminal tooling on your system — the PNGs are produced by the screenshot-capable run modes below, and a terminal that supports them
 - (Optional) GitHub account for contribution track
 

--- a/pages/_quests/0000/bashcrawl/agent-mode.md
+++ b/pages/_quests/0000/bashcrawl/agent-mode.md
@@ -77,7 +77,7 @@ This page is your **walkthrough and strategy guide**. Agent Mode itself runs loc
 - [ ] Use `--status` to generate a dungeon completion report
 - [ ] (Optional) Fork the upstream repo and submit an improvement
 
-## �️ Quest Prerequisites
+## 🗺️ Quest Prerequisites
 
 - All 9 dungeon areas explored
 - Comfortable with shell scripting and pipes

--- a/pages/_quests/0000/bashcrawl/armoury.md
+++ b/pages/_quests/0000/bashcrawl/armoury.md
@@ -77,7 +77,7 @@ This page is your **walkthrough and strategy guide** — play right here in the 
 - [ ] Defeat the armoury guardian
 - [ ] Proceed to the Chamber
 
-## �️ Quest Prerequisites
+## 🗺️ Quest Prerequisites
 
 - [Cellar side-quest](/quests/0000/side-quests/cellar/) complete
 - Comfortable with `ls -F`, `cat`, and file navigation

--- a/pages/_quests/0000/bashcrawl/armoury.md
+++ b/pages/_quests/0000/bashcrawl/armoury.md
@@ -95,11 +95,12 @@ This page is your **walkthrough and strategy guide** — play right here in the 
 ### Permission String Decoder
 
 ```text
--rwxr-xr-x
-│└──┘└──┘└──┘
-│ u   g   o
-│ user group others
-└── file type: - = regular, d = dir, l = link
+-  rwx  r-x  r-x
+│   │    │    │
+│   │    │    └── others (o)
+│   │    └─────── group (g)
+│   └──────────── user / owner (u)
+└──────────────── file type: - = regular, d = dir, l = link
 ```
 
 Each group: `r` = read (4), `w` = write (2), `x` = execute (1)
@@ -112,9 +113,9 @@ Octal shorthand: `755` = `rwx r-x r-x`, `644` = `rw- r-- r--`
 
 ```bash
 ls -l
-# -rw-r--r-- 1 user group  512 Jan 01 potion
-# -rw-r--r-- 1 user group 1024 Jan 01 sword
-# -rwxr-xr-x 1 user group  256 Jan 01 guardian*
+# -rw-r--r-- 1 user group  512 Jan  1 00:00 potion
+# -rw-r--r-- 1 user group 1024 Jan  1 00:00 sword
+# -rwxr-xr-x 1 user group  256 Jan  1 00:00 guardian
 ```
 
 `potion` and `sword` lack the `x` bit — they are **not yet executable**. You cannot run them.
@@ -134,9 +135,14 @@ This is the expected result. Now fix it.
 chmod +x potion
 chmod +x sword
 ls -l potion sword
-# -rwxr-xr-x 1 user group 512 Jan 01 potion*
-# -rwxr-xr-x 1 user group 1024 Jan 01 sword*
+# -rwxr-xr-x 1 user group  512 Jan  1 00:00 potion
+# -rwxr-xr-x 1 user group 1024 Jan  1 00:00 sword
 ```
+
+> **Why the `./`?** When you type `./potion`, the `./` tells the shell to run
+> the script in the **current directory**. Without it, the shell only searches
+> the directories in your `PATH` — and `.` (the current directory) is **not** in
+> `PATH` by default, so `potion` alone would fail with "command not found".
 
 ### Step 4 — Drink the potion
 
@@ -158,10 +164,15 @@ ls -l potion sword
 ./guardian
 # A stone golem steps forward...
 # You raise your sword...
-# [combat sequence]
+# Guardian defeated! The door creaks open.
 ```
 
-With the sword equipped, you should win. Health permitting, the guardian falls and the door to the Chamber opens.
+With the sword equipped, the guardian falls and the door to the Chamber opens.
+List the room (`ls`) to find the path onward, then step through into the
+Chamber's directory (for example, `cd ../chamber`).
+
+> **Low on health?** Your HP carries over between rooms. If a fight leaves you
+> weakened, re-run `./potion` (if a potion is still available) before moving on.
 
 ## 💡 Understanding Octal Permissions
 
@@ -182,7 +193,7 @@ With the sword equipped, you should win. Health permitting, the guardian falls a
 | `Permission denied` after chmod | Not the file owner | Use `ls -l` to check owner |
 | Script does nothing | Missing shebang line | Add `#!/usr/bin/env bash` as line 1 |
 | `No such file: ./sword` | Wrong directory | `pwd` and `ls` first |
-| Health still low after potion | Bug in game version | Run `./setup.sh --repair` |
+| Health still low after potion | Stale game state | Re-run the bashcrawl setup or restart the game from the entrance, then revisit the room |
 
 ## ✅ Validation
 

--- a/pages/_quests/0000/bashcrawl/cellar.md
+++ b/pages/_quests/0000/bashcrawl/cellar.md
@@ -79,7 +79,7 @@ This page is your **walkthrough and strategy guide** — play right here in the 
 - [ ] Find and collect the emerald amulet
 - [ ] Locate all four exits (armoury, chapel, vault, scrap)
 
-## �️ Quest Prerequisites
+## 🗺️ Quest Prerequisites
 
 - [Entrance side-quest](/quests/0000/side-quests/entrance/) complete
 - Know how to use `ls`, `cd`, and `cat`

--- a/pages/_quests/0000/bashcrawl/cellar.md
+++ b/pages/_quests/0000/bashcrawl/cellar.md
@@ -113,13 +113,18 @@ This page is your **walkthrough and strategy guide** — play right here in the 
 
 ### Step 0 — Enter the cellar
 
-Launch the game shell, then descend from the entrance into the CELLAR:
+First launch the game shell — this drops you *inside* the dungeon at an interactive prompt:
 
 ```bash
 ./main.sh --interactive
+```
+
+Once you see the game prompt, descend from the entrance into the CELLAR:
+
+```bash
 cd cellar
 pwd
-# Output: .../ENTRANCE/cellar
+# e.g. /home/yourname/bashcrawl/ENTRANCE/cellar  (the ... is your install path)
 ```
 
 If you arrived here straight from the [Entrance walkthrough](/quests/0000/side-quests/entrance/), you are already in the game shell — just `cd cellar`.
@@ -184,7 +189,8 @@ Curious how the shell resolves a name? `type` tells you whether it is a builtin,
 
 ```bash
 type ls
-# ls is aliased to ... / ls is /bin/ls
+# On Debian/Ubuntu: ls is aliased to `ls --color=auto`
+# On a minimal system: ls is /bin/ls
 ```
 
 Aliases last only for the current session unless added to `~/.bashrc` or `~/.bash_profile`.

--- a/pages/_quests/0000/bashcrawl/cellar.md
+++ b/pages/_quests/0000/bashcrawl/cellar.md
@@ -69,6 +69,8 @@ redirect_from:
 
 This page is your **walkthrough and strategy guide** — play right here in the browser, then follow the steps below.
 
+> The `{% raw %}{% include %}{% endraw %}` tag below renders an interactive terminal on the published site; in the raw Markdown source it just looks like a macro.
+
 {% include bashcrawl-terminal.html room="Cellar" %}
 
 ## 🎯 Quest Objectives
@@ -109,6 +111,19 @@ This page is your **walkthrough and strategy guide** — play right here in the 
 
 ## 🗺️ Walkthrough
 
+### Step 0 — Enter the cellar
+
+Launch the game shell, then descend from the entrance into the CELLAR:
+
+```bash
+./main.sh --interactive
+cd cellar
+pwd
+# Output: .../ENTRANCE/cellar
+```
+
+If you arrived here straight from the [Entrance walkthrough](/quests/0000/side-quests/entrance/), you are already in the game shell — just `cd cellar`.
+
 ### Step 1 — Survey the cellar
 
 ```bash
@@ -117,7 +132,7 @@ ls -F
 # emerald_amulet  armoury/  chapel/  vault/  scrap/  dusty_scroll  recipe*
 ```
 
-Notice the variety: a regular file (`emerald_amulet`), directories (`/`), and an executable (`recipe*`).
+Notice the variety: a regular file (`emerald_amulet`), directories (`/`), and an executable (`recipe*`). The `*` after `recipe` is the executable marker `ls -F` adds — it is not part of the filename, and running the recipe is optional.
 
 ### Step 2 — Investigate with `file`
 
@@ -137,7 +152,7 @@ file recipe
 cat dusty_scroll
 ```
 
-The scroll reveals a clue about the emerald amulet's location and warns about hidden traps in the deeper chambers.
+The scroll confirms the emerald amulet rests here in the cellar and warns about hidden traps in the deeper chambers.
 
 ### Step 4 — Collect the amulet
 
@@ -145,7 +160,7 @@ The scroll reveals a clue about the emerald amulet's location and warns about hi
 cat emerald_amulet
 ```
 
-Reading it adds it to your inventory. Verify:
+Reading it adds it to your inventory. Verify with `inventory` — a special command the bashcrawl game environment provides (not a standard Unix command):
 
 ```bash
 inventory
@@ -165,6 +180,13 @@ alias back='cd ..'
 alias
 ```
 
+Curious how the shell resolves a name? `type` tells you whether it is a builtin, an alias, a function, or a file on disk:
+
+```bash
+type ls
+# ls is aliased to ... / ls is /bin/ls
+```
+
 Aliases last only for the current session unless added to `~/.bashrc` or `~/.bash_profile`.
 
 ### Step 6 — Identify all four exits
@@ -174,7 +196,7 @@ ls -F
 # armoury/  chapel/  vault/  scrap/
 ```
 
-Each leads to a distinct area of the dungeon. You can tackle them in any order.
+The output above is abbreviated to highlight the four doorways — the regular files from Step 1 (`emerald_amulet`, `dusty_scroll`, `recipe*`) are still listed too. Each directory leads to a distinct area of the dungeon. You can tackle them in any order.
 
 ## 💡 Common Pitfalls
 
@@ -223,7 +245,7 @@ Continue your terminal adventure with these resources:
 
 ## 🕸️ Knowledge Graph
 
-*Structured wiki-links connect this quest to the IT-Journey knowledge graph. Open the [Obsidian Graph View](/docs/obsidian/graph/) to explore connections.*
+*Structured wiki-links connect this quest to the IT-Journey knowledge graph. Open the [Obsidian Graph View](/docs/obsidian/graph/) to explore connections. The `[[wiki-link]]` syntax below is Obsidian wiki-link notation — clickable in Obsidian, plain text elsewhere.*
 
 **Level hub:** [[Level 0000 - Foundation & Init World]]
 **Overworld:** [[🏰 Overworld - Master Quest Map]]

--- a/pages/_quests/0000/bashcrawl/chamber.md
+++ b/pages/_quests/0000/bashcrawl/chamber.md
@@ -76,7 +76,7 @@ This page is your **walkthrough and strategy guide** — play right here in the 
 - [ ] Run `./statue` to trigger and win the boss encounter
 - [ ] Collect the Chamber's treasure and unlock the Rift path
 
-## �️ Quest Prerequisites
+## 🗺️ Quest Prerequisites
 
 - [Armoury side-quest](/quests/0000/side-quests/armoury/) complete
 - Sword in inventory (from armoury `./sword`)

--- a/pages/_quests/0000/bashcrawl/chamber.md
+++ b/pages/_quests/0000/bashcrawl/chamber.md
@@ -134,11 +134,12 @@ echo $vault_code     # 11
 
 ### Step 3 — Compute your specific answer
 
-Replace the example numbers with the values from YOUR runes:
+Substitute the values from YOUR runes for the two example numbers below
+(the `3` and `4` are placeholders — swap in the door and exit counts you found):
 
 ```bash
-# Template:
-answer=$(( doors_in_cellar * exits_in_entrance + 7 ))
+# Template — replace 3 and 4 with the counts from YOUR runes:
+answer=$(( 3 * 4 + 7 ))     # 19 in this example
 echo "My answer is: $answer"
 ```
 
@@ -161,6 +162,8 @@ cat chest
 inventory
 ```
 
+> **Note:** `inventory` is a bashcrawl game command (provided by the dungeon), not a standard Unix command — it shows what you've picked up on your crawl.
+
 The stone key fragment is part of the multi-piece key that opens the Rift.
 
 ## 💡 Arithmetic Gotchas
@@ -168,9 +171,15 @@ The stone key fragment is part of the multi-piece key that opens the Rift.
 | Problem | Cause | Fix |
 |---------|-------|-----|
 | `expr 4 * 1` → error | `*` glob-expanded | Escape: `expr 4 \* 1` |
-| `let "x=5/2"` → `2` | Integer division | Use `bc` for floats: `echo "5/2" \| bc -l` |
+| `let "x=5/2"` → `2` | Integer division | Use `bc` for floats (see below) |
 | Variable not set | Missing `$` | Use `echo $var`, not `echo var` |
 | Wrong answer, took damage | Calculation error | Recalculate carefully before `./statue` |
+
+Bash arithmetic is integer-only. For floating-point division, pipe the expression to `bc -l`:
+
+```bash
+echo "5/2" | bc -l     # 2.50000000000000000000
+```
 
 ## ✅ Validation
 

--- a/pages/_quests/0000/bashcrawl/entrance.md
+++ b/pages/_quests/0000/bashcrawl/entrance.md
@@ -75,7 +75,7 @@ This page is your **walkthrough and strategy guide** — play right here in the 
 - [ ] Ask Merlin for a hint with the `merlin` command
 - [ ] Collect the brass key and move to the cellar
 
-## �️ Quest Prerequisites
+## 🗺️ Quest Prerequisites
 
 - A terminal with Bash (macOS, Linux, or WSL)
 - Bashcrawl installed or running at [bamr87.github.io/bashcrawl](https://bamr87.github.io/bashcrawl/)

--- a/pages/_quests/0000/bashcrawl/entrance.md
+++ b/pages/_quests/0000/bashcrawl/entrance.md
@@ -80,6 +80,14 @@ This page is your **walkthrough and strategy guide** — play right here in the 
 - A terminal with Bash (macOS, Linux, or WSL)
 - Bashcrawl installed or running at [bamr87.github.io/bashcrawl](https://bamr87.github.io/bashcrawl/)
 
+To play locally (and unlock the `merlin` and `quest` commands), clone the dungeon and enter the game shell:
+
+```bash
+git clone https://github.com/bamr87/bashcrawl
+cd bashcrawl
+bash main.sh --interactive
+```
+
 ## ⚡ Command Cheatsheet
 
 | Command | What It Does |
@@ -126,6 +134,8 @@ cat scroll
 
 The scroll contains the first piece of the dungeon's story and a clue about the brass key. Read it carefully — items and hints mentioned here matter later.
 
+The **brass key** is part of the story you uncover by reading the scroll — there is no separate `take key` command to run. Simply reading the scroll and following its clue arms you for the next chamber; the key travels with you as you descend into the cellar.
+
 ### Step 4 — Ask Merlin
 
 ```bash
@@ -157,6 +167,7 @@ Congratulations — you have left the entrance. Continue to the [Cellar walkthro
 | Problem | Cause | Fix |
 |---------|-------|-----|
 | `command not found: merlin` | Not in the game shell | Run `./main.sh --interactive` first |
+| `command not found: quest` | Not in the game shell | Run `./main.sh --interactive` first |
 | `No such file: scroll` | Wrong directory | Run `pwd`; navigate to ENTRANCE with `cd` |
 | `ls` shows nothing | Empty directory | Make sure you are in ENTRANCE, not `/` |
 | Path has spaces | Rare edge case | Wrap in quotes: `cd "my dir"` |
@@ -168,6 +179,7 @@ Before marking this side-quest complete, verify:
 - [ ] You can explain what `pwd` returns without running it
 - [ ] You know the difference between `ls` and `ls -F`
 - [ ] You read the scroll and understand its clue
+- [ ] You found the brass key clue in the scroll (it travels with you — no `take` command needed)
 - [ ] You successfully navigated into cellar
 
 ## ➡️ Next Steps

--- a/pages/_quests/0000/bashcrawl/entrance.md
+++ b/pages/_quests/0000/bashcrawl/entrance.md
@@ -73,7 +73,7 @@ This page is your **walkthrough and strategy guide** — play right here in the 
 - [ ] List the dungeon entrance contents with `ls` and `ls -F`
 - [ ] Read the entrance scroll with `cat`
 - [ ] Ask Merlin for a hint with the `merlin` command
-- [ ] Collect the brass key and move to the cellar
+- [ ] Find the brass key clue in the scroll and move to the cellar
 
 ## 🗺️ Quest Prerequisites
 
@@ -85,7 +85,7 @@ To play locally (and unlock the `merlin` and `quest` commands), clone the dungeo
 ```bash
 git clone https://github.com/bamr87/bashcrawl
 cd bashcrawl
-bash main.sh --interactive
+./main.sh --interactive
 ```
 
 ## ⚡ Command Cheatsheet

--- a/pages/_quests/0000/bashcrawl/hidden-chapel.md
+++ b/pages/_quests/0000/bashcrawl/hidden-chapel.md
@@ -79,7 +79,7 @@ This page is your **walkthrough and strategy guide** — play right here in the 
 - [ ] Enter the library and collect the ancient tome
 - [ ] Explore the graveyard — optional but rewarding
 
-## �️ Quest Prerequisites
+## 🗺️ Quest Prerequisites
 
 - [Cellar side-quest](/quests/0000/side-quests/cellar/) complete
 - Comfortable with `ls`, `cd`, and basic file reading

--- a/pages/_quests/0000/bashcrawl/hidden-chapel.md
+++ b/pages/_quests/0000/bashcrawl/hidden-chapel.md
@@ -61,7 +61,7 @@ layout: quest
 redirect_from:
 - /quests/0000/side-quests/hidden-chapel/
 ---
-*The wine cellar wall flickers. A hidden door appears — but only `ls -a` can see it. Beyond the false stone lies a chapel with five secret areas, guarded by a monster who fears knowledge.*
+*The wine cellar wall flickers. A hidden door appears — but only `ls -a` can see it. Beyond the false stone lies a chapel with five secret areas — the courtyard, the aviary nested within it, the hall, the library, and the graveyard — guarded by a monster who fears knowledge.*
 
 ## 🕹️ Play This Chamber
 
@@ -158,14 +158,14 @@ man grep
 # Press q to quit
 ```
 
-> Tip: `man grep | grep "\-n"` pipes the manual through grep to find the `-n` flag quickly.
+> Tip: `man grep | grep -- '-n'` pipes the manual through grep to find the `-n` flag quickly. The `--` tells grep to treat `-n` as a search pattern, not a flag.
 
 The relevant knowledge: `grep -n` prints line numbers. The hall monster demands you specify which line contains the incantation.
 
 ### Step 5 — Navigate to the hall and fight
 
 ```bash
-cd ../hall
+cd ../../hall   # from .CHAPEL/courtyard/aviary back up to .CHAPEL, then into hall
 ls -F
 # inscription  monster*  locked_door
 
@@ -174,7 +174,8 @@ cat inscription
 
 ./monster
 # The monster demands: "Which grep flag shows line numbers?"
-# Your answer: -n
+# Type your answer at the prompt and press Enter:
+# -n
 # The monster falls!
 ```
 
@@ -189,6 +190,8 @@ cat tome
 # The Ancient Tome of Shell Knowledge — tome fragment obtained.
 inventory
 ```
+
+> Note: `inventory` is a bashcrawl game command (it lists items you've collected), not a standard Unix command.
 
 ### Step 7 (Optional) — Explore the graveyard
 

--- a/pages/_quests/0000/bashcrawl/rift.md
+++ b/pages/_quests/0000/bashcrawl/rift.md
@@ -83,7 +83,7 @@ This page is your **walkthrough and strategy guide** — play right here in the 
 - [ ] Defeat the pit boss and the satellite boss
 - [ ] Complete the Bashcrawl dungeon
 
-## �️ Quest Prerequisites
+## 🗺️ Quest Prerequisites
 
 All of these should be in your inventory before entering the Rift:
 

--- a/pages/_quests/0000/bashcrawl/rift.md
+++ b/pages/_quests/0000/bashcrawl/rift.md
@@ -118,6 +118,7 @@ ls -F
 
 inventory
 # stone key fragment, tome fragment, vault key fragment, portal crystal ✓
+# (inventory is a Bashcrawl game command, not a standard shell command — it lists what you carry)
 
 ./key_assembler
 # All fragments combined → Rift Key obtained.
@@ -161,14 +162,21 @@ cat instructions
 ### Step 4 — Spire — Redirection
 
 ```bash
-cd ../../spire
+cd ../spire
 cat spire_challenge
 # "Capture all output from the oracle — both wisdom and errors — into oracle.log"
 
 ./oracle > oracle.log 2>&1
 cat oracle.log
 
-# Also capture with tee so you still see it:
+# Run again and APPEND to the same log instead of overwriting:
+echo '--- additional run ---' >> oracle.log
+./oracle >> oracle.log 2>&1
+
+# Capture ONLY the errors (stderr) and leave wisdom on screen:
+./oracle 2> errors_only.log
+
+# Also capture everything with tee so you still see it:
 ./oracle 2>&1 | tee oracle.log
 ```
 
@@ -178,6 +186,7 @@ cat oracle.log
 cd mezzanine
 # Combine all techniques:
 ls -la | sort -k5 -rn | head -10 > biggest_files.txt
+# -k5 sorts by column 5 (file size); -rn is reverse numeric (largest first)
 cat biggest_files.txt
 ```
 
@@ -200,6 +209,10 @@ cat signal_logs | grep "ERROR" | tee error_report.txt
 cat error_report.txt
 
 ./satellite_boss
+
+# Confirm the dungeon registers as finished:
+map
+# All chambers should now read as complete.
 ```
 
 The satellite boss is the final encounter. It uses all skills: pipe a command through grep, redirect errors, chain with `&&`. Complete it to finish the dungeon.
@@ -208,7 +221,7 @@ The satellite boss is the final encounter. It uses all skills: pipe a command th
 
 | Problem | Cause | Fix |
 |---------|-------|-----|
-| `|` not working | Wrong pipe character | Use `\|` in tables; actual `\|` is just `|` in shell |
+| `|` not working | Confused table escaping with shell syntax | In Markdown tables you write `\\|` to *display* a literal `\|`, but in the shell you always type a plain `\|` — never type `\\|` as a pipeline |
 | `2>&1` must come AFTER `>` | Order matters | Always: `> file 2>&1` not `2>&1 > file` |
 | `&&` chain stops early | A command failed | Add `\|\|` fallback or check exit codes |
 | Hidden dirs not found | Forgot `ls -a` | Always use `ls -a` in unfamiliar directories |

--- a/pages/_quests/0000/bashcrawl/rift.md
+++ b/pages/_quests/0000/bashcrawl/rift.md
@@ -183,7 +183,7 @@ echo '--- additional run ---' >> oracle.log
 ### Step 5 — Mezzanine — Advanced chaining
 
 ```bash
-cd mezzanine
+cd ../mezzanine     # mezzanine is a sibling of spire under the Rift root (like arena → pit → spire)
 # Combine all techniques:
 ls -la | sort -k5 -rn | head -10 > biggest_files.txt
 # -k5 sorts by column 5 (file size); -rn is reverse numeric (largest first)

--- a/pages/_quests/0000/bashcrawl/scrap.md
+++ b/pages/_quests/0000/bashcrawl/scrap.md
@@ -166,7 +166,9 @@ readlink -f quick_entrance
 Building your `quick_entrance` portal and stepping through it is what earns the portal crystal — the act of creating and using the symlink is the puzzle. Then check your haul with `inventory`, a bashcrawl game command (not a standard Unix tool) that lists the treasures you've gathered:
 
 ```bash
-cat crystal_hint
+cd quick_entrance    # step through the portal you built
+pwd                  # now inside ENTRANCE, reached via your symlink
+cd -                 # return to the scrap heap
 inventory
 # portal crystal ✓
 ```

--- a/pages/_quests/0000/bashcrawl/scrap.md
+++ b/pages/_quests/0000/bashcrawl/scrap.md
@@ -78,7 +78,7 @@ This page is your **walkthrough and strategy guide** — play right here in the 
 - [ ] Use the scrap's portal symlinks to shortcut navigation
 - [ ] Collect the portal crystal
 
-## �️ Quest Prerequisites
+## 🗺️ Quest Prerequisites
 
 - [Cellar side-quest](/quests/0000/side-quests/cellar/) complete
 - Comfortable with `ls -F`, `ls -l`, and `cd`

--- a/pages/_quests/0000/bashcrawl/scrap.md
+++ b/pages/_quests/0000/bashcrawl/scrap.md
@@ -94,6 +94,8 @@ This page is your **walkthrough and strategy guide** — play right here in the 
 | `readlink -f link_name` | Print the fully-resolved absolute path |
 | `realpath path` | Same as `readlink -f` (more modern) |
 
+> **Note:** `readlink -f` and `realpath` are GNU-only — they ship with Linux but not with stock macOS. macOS adventurers may need to install GNU coreutils (e.g. `brew install coreutils`, then `greadlink`/`grealpath`) to wield them.
+
 ### Hard Link vs Symbolic Link
 
 | Property | Hard Link | Symbolic Link |
@@ -112,10 +114,10 @@ ls -F
 # broken_sword  empty_bottle  portal_mirror@  scrap_pile/  crystal_hint
 
 ls -l portal_mirror
-# lrwxrwxrwx  1 user group  12 Jan 01  portal_mirror -> /vault/lab
+# lrwxrwxrwx  1 user group  10 Jan 01  portal_mirror -> /vault/lab
 ```
 
-`portal_mirror` is already a symlink — it points to the vault's lab. You can `cd portal_mirror` and you will land directly in the lab.
+`portal_mirror` is already a symlink — the bashcrawl game pre-creates it for you, so there's no need to build it yourself. It points to the vault's lab, so you can `cd portal_mirror` and you will land directly in the lab.
 
 ### Step 2 — Navigate via the existing portal
 
@@ -142,7 +144,8 @@ cat crystal_hint
 ```bash
 ln -s ../../ENTRANCE quick_entrance
 ls -l quick_entrance
-# lrwxrwxrwx  1 user group  20 Jan 01  quick_entrance -> ../../ENTRANCE
+# lrwxrwxrwx  1 user group  14 Jan 01  quick_entrance -> ../../ENTRANCE
+# (a symlink's size is the length of its target path — "../../ENTRANCE" is 14 characters)
 
 ls -F quick_entrance/
 # scroll  cellar/          ← entrance contents, via symlink
@@ -160,6 +163,8 @@ readlink -f quick_entrance
 
 ### Step 6 — Collect the crystal
 
+Building your `quick_entrance` portal and stepping through it is what earns the portal crystal — the act of creating and using the symlink is the puzzle. Then check your haul with `inventory`, a bashcrawl game command (not a standard Unix tool) that lists the treasures you've gathered:
+
 ```bash
 cat crystal_hint
 inventory
@@ -173,9 +178,9 @@ inventory
 | Symlink shows broken (red in terminal) | Target path does not exist | Check relative path with `readlink` |
 | `ln -s` with no arguments | Wrong order | Syntax: `ln -s TARGET LINK_NAME` |
 | `cd symlink` goes somewhere unexpected | Relative path off | Use absolute path or `readlink -f` |
-| Cannot delete directory via symlink | Symlink vs directory | `rm symlink` removes the link; `rm -r` removes the target |
+| Cannot delete directory via symlink | Symlink vs directory | `rm symlink` removes the link; `rm -r symlink/` (trailing slash) follows the link and deletes the target's contents |
 
-> **Danger:** `rm -r symlink_to_dir` may behave unexpectedly depending on your shell version. Prefer `unlink symlink_name` to safely remove only the link.
+> **Danger:** `rm -r symlink_to_dir` (no trailing slash) removes only the symlink itself, leaving the target untouched. But add a trailing slash — `rm -r symlink_to_dir/` — and `rm` follows the link into the target directory and wipes out its contents. The slash is the difference between deleting a shortcut and deleting what it points at. Prefer `unlink symlink_name` to safely remove only the link.
 
 ## ✅ Validation
 

--- a/pages/_quests/0000/bashcrawl/vault.md
+++ b/pages/_quests/0000/bashcrawl/vault.md
@@ -78,7 +78,7 @@ This page is your **walkthrough and strategy guide** — play right here in the 
 - [ ] Survive the ghost encounter in the lab
 - [ ] Collect the vault key fragment
 
-## �️ Quest Prerequisites
+## 🗺️ Quest Prerequisites
 
 - [Cellar side-quest](/quests/0000/side-quests/cellar/) complete
 - Emerald amulet in inventory

--- a/pages/_quests/0000/bashcrawl/vault.md
+++ b/pages/_quests/0000/bashcrawl/vault.md
@@ -61,7 +61,7 @@ layout: quest
 redirect_from:
 - /quests/0000/side-quests/vault/
 ---
-*Behind a heavy iron door, the Vault holds the dungeon's most powerful secrets — not gold and jewels, but the invisible variables that shape every shell. Set them correctly, or the ghost devours you.*
+*Behind a heavy iron door, the Vault holds the dungeon's most closely guarded secrets — not gold and jewels, but the invisible variables that shape every shell. Set them correctly, or the ghost devours you.*
 
 ## 🕹️ Play This Chamber
 

--- a/pages/_quests/0000/bashcrawl/workshop.md
+++ b/pages/_quests/0000/bashcrawl/workshop.md
@@ -78,7 +78,7 @@ This page is your **walkthrough and strategy guide** — play right here in the 
 - [ ] Remove an item with `rm`
 - [ ] Clean the workshop and advance to the cellar
 
-## �️ Quest Prerequisites
+## 🗺️ Quest Prerequisites
 
 - Complete the [Entrance side-quest](/quests/0000/side-quests/entrance/) first
 - Comfortable with `ls`, `cd`, and `cat`


### PR DESCRIPTION
## 🐞 Content fix — surfaced and now resolved by the quest walkthrough

Started as the mojibake-header fix surfaced by the walkthrough report (#391); on
request, expanded to **address every bot comment on this PR**. Each finding was
**verified before applying** — the agentic review ran read-only and over-claimed
once (the "broken links" below), so nothing was taken on faith.

### 1. Mojibake headers (the original fix)
Restored `## 🗺️ Quest Prerequisites` (was the U+FFFD replacement char) across all
10 Bashcrawl pages.

### 2. Navigation bugs — verified by tracing each quest's own `cd` sequence
- **hidden-chapel:** `cd ../hall` → `cd ../../hall` (learner is in
  `.CHAPEL/courtyard/aviary`; one `..` only reaches `courtyard`).
- **rift:** `cd ../../spire` → `cd ../spire` (two `..` from `pit` lands *outside*
  the dungeon root; `spire` is a sibling of `pit`).

### 3. Technical accuracy
- **scrap:** corrected the `rm -r symlink` pitfall (the trailing-slash form is the
  dangerous one) and the symlink `ls -l` sizes (= target-path length).
- **armoury:** removed `ls -F` `*` markers from `ls -l` sample output; added a
  timestamp column; fixed the permission-decoder alignment.
- **chamber:** Step 3 arithmetic template used unset variables (silently computed a
  wrong answer) — now uses explicit placeholders that compute a correct example.
- **hidden-chapel:** `man grep | grep "\-n"` → `grep -- '-n'`.
- **rift:** corrected the `|`/`\|` Markdown-vs-shell pitfall; added the missing `>>`
  and standalone `2>` practice steps the objectives promised.
- **agent-mode:** noted the automation flags need the IT-Journey fork; defined
  `--classic`; moved `llm` install into Prerequisites; de-asserted an unverified path.

### 4. Clarity (additive)
- **cellar:** added a "Step 0 — enter the cellar" setup; fixed a Step 3→4 narrative
  gap; exercised the `type` cheatsheet entry.
- **entrance:** addressed the unrealized "brass key" objective + a validation
  checkbox; added a local-install path.
- Introduced `inventory` as a game command on first use across the set; noted that
  `{% raw %}{% include %}{% endraw %}` / `[[wiki-links]]` render only on the site/Obsidian; noted
  `readlink -f`/`realpath` are GNU-only.

### 5. Other gate comments
- **Brand gate:** reworded empty-hype "powerful" in `vault.md`.
- **Quest network:** dropped retired frontmatter fields (`quest_relationships`,
  `learning_paths`, `sub-title`, `snippet`) from `bashcrawl/README.md`. *(The other
  network warnings — `1010/*` retired fields, `0001/*` orphans — are in unrelated
  directories and out of scope for this PR.)*

### ⚠️ Deliberately NOT changed: the "broken links" finding
The review flagged `entrance.md`'s `/quests/0000/side-quests/cellar|workshop/` links
as 404s. **Verified false positive** — `cellar.md`/`workshop.md` carry `redirect_from`
entries for those URLs, so they resolve via Jekyll redirects. Left as-is.

### Validation
`quest_validator.py` → **10/10 pass, 95.9% avg**; `check_liquid_raw.py` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)