### PR TITLE
content(quests): implement PR #391 walkthrough findings (developer/0000)

### DIFF
--- a/pages/_quests/0000/begin-your-it-journey.md
+++ b/pages/_quests/0000/begin-your-it-journey.md
@@ -118,6 +118,8 @@ Remember, every great wizard started as an apprentice. Mistakes are part of the 
 
 # Choose your path
 
+Every path in the realm has its own apprenticeship, but they all follow the same approach: learn the fundamentals, pick your tools, then practice on real projects. To show you what that looks like, let's walk one path end-to-end as a **worked example** — the *systems builder*. As you read it, notice the pattern; a developer, a security guardian, or a cloud wizard would chart a nearly identical course with their own tools swapped in. (Use the [Developer Roadmaps](https://roadmap.sh/) to trace your chosen path the same way.)
+
 Ah, a systems builder! Crafting robust and efficient systems is akin to constructing magical fortresses and intricate contraptions in our fantastical IT realm. Here's how you can start your journey as a system architect:
 
 1. **Understand the Fundamentals**: Before you start building, you need to understand the basics of computer systems. This includes hardware components, operating systems, and networking. It's like learning the foundation of castle-building before creating your own fortress.
@@ -139,6 +141,69 @@ Ah, a systems builder! Crafting robust and efficient systems is akin to construc
 9. **Security Mindset**: Always consider security in your designs. Protecting your systems from intruders is as essential as a fortress's walls and moats.
 
 10. **Stay Curious and Updated**: The field of system building is constantly evolving. Keep learning about new technologies and best practices. Your quest for knowledge is never-ending.
+
+## 🗺️ Forge Your IT Career Map
+
+Before you can chart a learning plan, you need a map of the realm. The table below shows how each path leads to real-world roles and the first skills worth gathering. Find the row that excites you most — that's your direction.
+
+| Path | Sample Roles | First Skills to Gather |
+|---|---|---|
+| **Development** | Web Developer, Software Engineer, Mobile Dev | Python or JavaScript, Git, HTML/CSS |
+| **Systems / Sysadmin** | System Administrator, DevOps Engineer | Linux, Bash scripting, networking basics |
+| **Security** | Security Analyst, Penetration Tester | Networking, Linux, the security mindset |
+| **Cloud** | Cloud Engineer, Solutions Architect | One cloud platform (AWS/Azure/GCP), Linux, automation |
+| **Networking** | Network Engineer, Network Admin | TCP/IP, DNS, routing & switching concepts |
+
+## 📝 Create Your Learning Plan
+
+This is the heart of your quest. Copy the template below into a note, a document, or a `learning-plan.md` file, then fill in each blank. A plan you can actually read back to yourself is worth more than a hundred good intentions.
+
+```markdown
+# My IT Learning Plan
+
+- **My goal (why I'm here):** _______________________________________
+- **My chosen path:** ___________ (Development / Systems / Security / Cloud / Networking)
+- **3 skills I'll learn first:**
+  1. _______________________________________
+  2. _______________________________________
+  3. _______________________________________
+- **First quest I'll tackle next:** _______________________________________
+- **Target date for my first skill:** ______ / ______ / ______
+```
+
+Keep this file somewhere you'll see it. You'll revisit and grow it as you progress through the realm.
+
+## 🪄 Cast Your First Script
+
+Every wizard remembers their first spell. Yours automates a tiny, real task — greeting the world and stamping it with the current date. Pick the version that matches your tools.
+
+**Bash** (macOS / Linux / WSL) — save as `hello.sh`:
+
+```bash
+#!/usr/bin/env bash
+echo "Hello, IT realm! My journey begins on $(date)."
+```
+
+Run it with:
+
+```bash
+bash hello.sh
+```
+
+**Python** (any OS with Python installed) — save as `hello.py`:
+
+```python
+from datetime import date
+print(f"Hello, IT realm! My journey begins on {date.today()}.")
+```
+
+Run it with:
+
+```bash
+python3 hello.py
+```
+
+That's it — you just made the computer do your bidding. Trivial today, but it's the same idea behind every automation spell you'll ever cast. 🪄
 
 ## 🏆 Quest Completion Validation
 

--- a/pages/_quests/0000/begin-your-it-journey.md
+++ b/pages/_quests/0000/begin-your-it-journey.md
@@ -118,7 +118,23 @@ Remember, every great wizard started as an apprentice. Mistakes are part of the 
 
 # Choose your path
 
-Every path in the realm has its own apprenticeship, but they all follow the same approach: learn the fundamentals, pick your tools, then practice on real projects. To show you what that looks like, let's walk one path end-to-end as a **worked example** — the *systems builder*. As you read it, notice the pattern; a developer, a security guardian, or a cloud wizard would chart a nearly identical course with their own tools swapped in. (Use the [Developer Roadmaps](https://roadmap.sh/) to trace your chosen path the same way.)
+Every path in the realm has its own apprenticeship, but they all follow the same approach: learn the fundamentals, pick your tools, then practice on real projects. Before tracing a single path, study the whole map of the realm below — then watch one path get walked end-to-end as a worked example.
+
+## 🗺️ Forge Your IT Career Map
+
+Before you can chart a learning plan, you need a map of the realm. The table below shows how each path leads to real-world roles and the first skills worth gathering. Find the row that excites you most — that's your direction.
+
+| Path | Sample Roles | First Skills to Gather |
+|---|---|---|
+| **Development** | Web Developer, Software Engineer, Mobile Dev | Python or JavaScript, Git, HTML/CSS |
+| **Systems / Sysadmin** | System Administrator, DevOps Engineer | Linux, Bash scripting, networking basics |
+| **Security** | Security Analyst, Penetration Tester | Networking, Linux, the security mindset |
+| **Cloud** | Cloud Engineer, Solutions Architect | One cloud platform (AWS/Azure/GCP), Linux, automation |
+| **Networking** | Network Engineer, Network Admin | TCP/IP, DNS, routing & switching concepts |
+
+### A worked example: walking the Systems Builder path
+
+To show you what an apprenticeship looks like, let's walk one path end-to-end — the *systems builder*. As you read it, notice the pattern; a developer, a security guardian, or a cloud wizard would chart a nearly identical course with their own tools swapped in. (Use the [Developer Roadmaps](https://roadmap.sh/) to trace your chosen path the same way.)
 
 Ah, a systems builder! Crafting robust and efficient systems is akin to constructing magical fortresses and intricate contraptions in our fantastical IT realm. Here's how you can start your journey as a system architect:
 
@@ -142,17 +158,7 @@ Ah, a systems builder! Crafting robust and efficient systems is akin to construc
 
 10. **Stay Curious and Updated**: The field of system building is constantly evolving. Keep learning about new technologies and best practices. Your quest for knowledge is never-ending.
 
-## 🗺️ Forge Your IT Career Map
-
-Before you can chart a learning plan, you need a map of the realm. The table below shows how each path leads to real-world roles and the first skills worth gathering. Find the row that excites you most — that's your direction.
-
-| Path | Sample Roles | First Skills to Gather |
-|---|---|---|
-| **Development** | Web Developer, Software Engineer, Mobile Dev | Python or JavaScript, Git, HTML/CSS |
-| **Systems / Sysadmin** | System Administrator, DevOps Engineer | Linux, Bash scripting, networking basics |
-| **Security** | Security Analyst, Penetration Tester | Networking, Linux, the security mindset |
-| **Cloud** | Cloud Engineer, Solutions Architect | One cloud platform (AWS/Azure/GCP), Linux, automation |
-| **Networking** | Network Engineer, Network Admin | TCP/IP, DNS, routing & switching concepts |
+That's the pattern: fundamentals first, then tools, then real projects, with security and curiosity woven throughout. If you chose a different path, swap in the tools from the career-map table above and follow the same pattern — the steps map onto every specialization in the realm.
 
 ## 📝 Create Your Learning Plan
 
@@ -177,7 +183,7 @@ Keep this file somewhere you'll see it. You'll revisit and grow it as you progre
 
 Every wizard remembers their first spell. Yours automates a tiny, real task — greeting the world and stamping it with the current date. Pick the version that matches your tools.
 
-**Bash** (macOS / Linux / WSL) — save as `hello.sh`:
+**Bash** (macOS / Linux / WSL) — open any text editor (VS Code, nano, or TextEdit), paste the following, and save it as `hello.sh`:
 
 ```bash
 #!/usr/bin/env bash
@@ -190,7 +196,7 @@ Run it with:
 bash hello.sh
 ```
 
-**Python** (any OS with Python installed) — save as `hello.py`:
+**Python** (any OS with Python installed) — open any text editor (VS Code, nano, or Notepad), paste the following, and save it as `hello.py`:
 
 ```python
 from datetime import date
@@ -205,6 +211,10 @@ python3 hello.py
 
 That's it — you just made the computer do your bidding. Trivial today, but it's the same idea behind every automation spell you'll ever cast. 🪄
 
+## 🤝 Join Your First Guild
+
+No wizard learns alone. Claim your place in a community so you have somewhere to ask questions and share your spells. The simplest first move: create a free **GitHub** account at [github.com/signup](https://github.com/signup) — it's where you'll store your projects and join the wider IT realm. (Prefer somewhere else? A free [Stack Overflow](https://stackoverflow.com/) account or a tech community forum works just as well.) Sign up now, before you move on — that account is one of your quest artifacts.
+
 ## 🏆 Quest Completion Validation
 
 ### Portfolio Artifacts Created
@@ -217,9 +227,13 @@ That's it — you just made the computer do your bidding. Trivial today, but it'
 - [ ] **Research Skills** — Ability to explore and compare IT career paths
 - [ ] **Goal Setting** — Creating actionable, time-bound learning objectives
 
+### 🎖️ Rewards
+
+> 🏆 Completing this quest awards **50 progression points**, the **Journey Initiate Badge**, and the **⚡ IT Awareness Achievement** — and unlocks the next quest: [Character Building: Forge Your IT Identity](/quests/0000/character-building/).
+
 ## 📚 References & Resources
 
-- [CompTIA IT Fundamentals Certification](https://www.comptia.org/certifications/it-fundamentals)
+- [CompTIA ITF+ (IT Fundamentals+)](https://www.comptia.org/certifications/it-fundamentals)
 - [freeCodeCamp — Learn to Code for Free](https://www.freecodecamp.org/)
 - [roadmap.sh — Developer Roadmaps](https://roadmap.sh/)
 - [The Odin Project — Full Stack Curriculum](https://www.theodinproject.com/)

--- a/pages/_quests/0000/begin-your-it-journey.md
+++ b/pages/_quests/0000/begin-your-it-journey.md
@@ -140,7 +140,7 @@ Ah, a systems builder! Crafting robust and efficient systems is akin to construc
 
 1. **Understand the Fundamentals**: Before you start building, you need to understand the basics of computer systems. This includes hardware components, operating systems, and networking. It's like learning the foundation of castle-building before creating your own fortress.
 
-2. **Learn About Operating Systems**: Get comfortable with different operating systems, especially Linux, as it's widely used in server environments. Think of Linux as an arcane language that, once mastered, can control the most powerful of systems.
+2. **Learn About Operating Systems**: Get comfortable with different operating systems, especially Linux, as it's widely used in server environments. Think of Linux as an arcane language that, once mastered, can control the systems that run the world's servers.
 
 3. **Dive into Networking**: Systems don't exist in isolation; they communicate with each other. Learn about network protocols, IP addresses, DNS, and firewalls. It's like understanding the ley lines and teleportation spells that connect different locations in a magical world.
 

--- a/pages/_quests/0000/begin-your-it-journey.md
+++ b/pages/_quests/0000/begin-your-it-journey.md
@@ -183,7 +183,7 @@ Keep this file somewhere you'll see it. You'll revisit and grow it as you progre
 
 Every wizard remembers their first spell. Yours automates a tiny, real task — greeting the world and stamping it with the current date. Pick the version that matches your tools.
 
-**Bash** (macOS / Linux / WSL) — open any text editor (VS Code, nano, or TextEdit), paste the following, and save it as `hello.sh`:
+**Bash** (macOS / Linux / WSL) — open a plain-text editor (VS Code or nano; if you use macOS TextEdit, first choose **Format → Make Plain Text**, or it saves unusable rich text), paste the following, and save it as `hello.sh`:
 
 ```bash
 #!/usr/bin/env bash
@@ -208,6 +208,8 @@ Run it with:
 ```bash
 python3 hello.py
 ```
+
+> On Windows, use `python hello.py` or `py hello.py` if `python3` isn't recognized.
 
 That's it — you just made the computer do your bidding. Trivial today, but it's the same idea behind every automation spell you'll ever cast. 🪄
 

--- a/pages/_quests/0000/hello-noob.md
+++ b/pages/_quests/0000/hello-noob.md
@@ -145,9 +145,9 @@ By completing this foundational quest, you will achieve:
 
 ### Primary Objectives (Required for Quest Completion)
 - [ ] **Create Your GitHub Account** - Establish your identity in the developer universe
-- [ ] **Fork the IT-Journey Repository** - Make your first contribution to open source
+- [ ] **Fork the IT-Journey Repository** - Create your own copy to learn and experiment in
 - [ ] **Navigate GitHub Interface** - Understand the basic layout and features
-- [ ] **Join the Community** - Connect with fellow adventurers on their learning journeys
+- [ ] **Find the Community** - Locate the IT-Journey Discussions tab where adventurers gather
 
 ### Secondary Objectives (Bonus Achievements)
 - [ ] **Customize Your Profile** - Add a bio, avatar, and personal information
@@ -245,7 +245,7 @@ Check your email for a verification message from GitHub and click the confirmati
 
 ## 🎮 Chapter 3: Your First Fork - Join the IT Journey
 
-*Now for the exciting part - making your first contribution to an open source project!*
+*Now for the exciting part - claiming your very own copy of an open source project so you can explore and experiment freely!*
 
 ### 🏗️ Step 1: Navigate to IT-Journey Repository
 
@@ -268,8 +268,20 @@ Or manually navigate:
 
 Congratulations! You've just:
 - ✅ Created a GitHub account
-- ✅ Made your first open source contribution
-- ✅ Joined the IT-Journey community
+- ✅ Forked an open source project, giving you your own copy to learn in
+- ✅ Taken your first step into the IT-Journey community
+
+> 💡 **A quick clarification:** Forking gives you your *own* copy of the project to experiment with. It is *not* yet a contribution back to the original — that happens when you send a **pull request** to propose your changes. You'll learn how to do exactly that in a later quest. For now, having your own fork is the perfect place to start.
+
+### 🤝 Step 4: Find the Community
+
+You're not adventuring alone! IT-Journey has a gathering place where learners ask questions, share progress, and help one another.
+
+1. Visit the **[IT-Journey Discussions](https://github.com/bamr87/it-journey/discussions)** tab
+2. Browse the categories to see what fellow adventurers are talking about
+3. Notice the **Issues** tab too — that's where bugs and improvement ideas are reported
+
+No need to post anything yet. Just knowing where the community lives is your goal for now.
 
 ## 🧭 Chapter 4: Exploring Your New Environment
 
@@ -295,6 +307,19 @@ Familiarize yourself with these important buttons and sections:
 - **Settings**: Configure your repository options
 - **Star**: Show appreciation for projects you like
 - **Watch**: Get notifications about project updates
+
+### ✨ Bonus: Customize Your Profile
+
+*Make your corner of GitHub feel like yours. This is a secondary objective — optional, but a great touch for your developer identity.*
+
+1. Click your **avatar** in the top-right corner, then choose **Settings**
+2. Under the **Public profile** section, add:
+   - **Name**: How you'd like to be known
+   - **Bio**: A short line about yourself (e.g. "Aspiring developer on the IT-Journey")
+   - **Profile picture (avatar)**: Upload an image so you're not just the default icon
+3. Click **Update profile** to save
+
+That's it — your profile now tells the world a little about the adventurer behind the account.
 
 ## 🏆 Quest Completion Validation
 
@@ -335,8 +360,8 @@ Familiarize yourself with these important buttons and sections:
 
 ### 🌟 What You've Accomplished
 
-- **Joined the Developer Community**: You're now part of the massive global community of developers
-- **Made Your First Open Source Contribution**: By forking IT-Journey, you've participated in open source
+- **Joined the Developer Community**: You're now part of the massive global community of developers, and you know where IT-Journey's Discussions live
+- **Forked Your First Open Source Project**: By forking IT-Journey, you've claimed your own copy to learn in — contributing changes back via a pull request is an adventure for a later quest
 - **Established Your Online Presence**: Your GitHub profile is the beginning of your developer portfolio
 - **Overcome the First Hurdle**: The hardest part of any journey is taking the first step - and you've done it!
 

--- a/pages/_quests/0000/hello-noob.md
+++ b/pages/_quests/0000/hello-noob.md
@@ -227,7 +227,7 @@ Fill out the registration form with:
 1. **Username**: Choose wisely! This becomes part of your developer identity
    - Make it professional (you might use this for job applications someday)
    - Keep it memorable and relatively short
-   - Examples: `sarah_codes`, `mike_developer`, `alex_learns_tech`
+   - Examples: `sarah-codes`, `mike-developer`, `alex-learns-tech` (GitHub usernames allow only letters, numbers, and single hyphens — no underscores or spaces)
 
 2. **Email**: Use an email you check regularly
    - GitHub will send you important notifications

--- a/pages/_quests/0000/hello-noob.md
+++ b/pages/_quests/0000/hello-noob.md
@@ -87,7 +87,7 @@ mermaid: true
 
 *This quest is specifically designed for absolute beginners - those who might not even know what GitHub is yet. That's perfectly okay! Every expert started exactly where you are now.*
 
-### 🗺️ Quest Network Position
+### 🗺️ Quest Network Map
 
 ```mermaid
 graph TB

--- a/pages/_quests/0000/it-fundamentals.md
+++ b/pages/_quests/0000/it-fundamentals.md
@@ -71,7 +71,7 @@ draft: false
 slug: fundamentals
 layout: quest
 ---
-*Welcome, aspiring IT adventurer! Before you can cast powerful spells or build grand digital fortresses, you must understand the fundamental building blocks of the IT realm. This quest covers the essential skills every technology professional needs — from organizing files to understanding networks and cloud computing.*
+*Welcome, aspiring IT adventurer! Before you can cast your first spells or build grand digital fortresses, you must understand the fundamental building blocks of the IT realm. This quest covers the essential skills every technology professional needs — from organizing files to understanding networks and cloud computing.*
 
 ## 🎯 Quest Objectives
 

--- a/pages/_quests/0000/it-fundamentals.md
+++ b/pages/_quests/0000/it-fundamentals.md
@@ -275,11 +275,13 @@ Absolutely! Hands-on exercises are like spells and incantations – they're best
   - Explore the settings and schedule regular scans.
 - **Exercise**: Check your system for pending updates. Outdated software is one of the most common ways attackers break in — patching closes known holes before someone walks through them. See what's waiting to be updated on your realm:
 
-  **Windows** (PowerShell) — lists available upgrades; drop `--all` to preview without installing:
+  **Windows** (PowerShell) — list what's upgradable first (review before installing):
 
   ```powershell
-  winget upgrade --all
+  winget upgrade
   ```
+
+  > ⚠️ `winget upgrade --all` **installs every available upgrade immediately** — it is not a preview. Run plain `winget upgrade` to review the list, then add `--all` only when you're ready to apply them all.
 
   **Linux** (Debian/Ubuntu) — refresh the package list, then see what can be upgraded:
 
@@ -301,6 +303,8 @@ Absolutely! Hands-on exercises are like spells and incantations – they're best
   - Create your first repository and make your first commit. Run these one at a time:
 
     ```bash
+    git config --global user.name "Your Name"
+    git config --global user.email "you@example.com"
     git init my-repo
     cd my-repo
     echo "# My first repo" > README.md
@@ -308,7 +312,7 @@ Absolutely! Hands-on exercises are like spells and incantations – they're best
     git commit -m "first commit"
     ```
 
-    `git init` creates the repo, `git add .` stages your new file, and `git commit` records a snapshot. Run `git log` to see your commit in the project's history. 🎉
+    The two `git config` lines set your identity — Git refuses to commit without them on a fresh install. `git init` creates the repo, `git add .` stages your new file, and `git commit` records a snapshot. Run `git log` to see your commit in the project's history. 🎉
   - Clone an existing repository from GitHub and explore its contents:
 
     ```bash

--- a/pages/_quests/0000/it-fundamentals.md
+++ b/pages/_quests/0000/it-fundamentals.md
@@ -113,6 +113,13 @@ Absolutely! Hands-on exercises are like spells and incantations – they're best
 - **Exercise**: Organize your files and folders.
   - Create a new folder structure on your computer.
   - Organize your documents, images, and other files into these folders.
+  - **Prefer the terminal?** On macOS or Linux, conjure the whole structure in one command:
+
+    ```bash
+    mkdir -p ~/projects/my-quest/{docs,scripts,images}
+    ```
+
+    This creates `my-quest` with three sub-folders in one stroke (`-p` makes parent folders as needed; the `{...}` brace expansion creates all three at once). Verify it with `ls ~/projects/my-quest`.
 
 ### 2. **Operating Systems (OS) Basics**
 
@@ -129,8 +136,30 @@ Absolutely! Hands-on exercises are like spells and incantations – they're best
 ### 3. **Networking Fundamentals**
 
 - **Exercise**: Explore your home network.
-  - Find out your computer’s IP address and default gateway.
-  - Log into your router’s admin page (usually through the default gateway IP).
+  - Find out your computer’s IP address and default gateway. Open your terminal and run the command for your realm:
+
+    **Windows** (Command Prompt or PowerShell) — your IPv4 address is the `IPv4 Address` line; the gateway is `Default Gateway`:
+
+    ```powershell
+    ipconfig
+    ```
+
+    **Linux** — the first command lists your addresses; the second shows the gateway (the IP after `default via`):
+
+    ```bash
+    ip addr show
+    ip route show
+    ```
+
+    **macOS** — `ifconfig` lists everything; the shortcut prints just your Wi‑Fi IP, and `route` reveals the gateway:
+
+    ```bash
+    ipconfig getifaddr en0
+    ifconfig
+    netstat -nr | grep default
+    ```
+
+  - Log into your router’s admin page by typing the default gateway IP (for example `192.168.1.1`) into your browser’s address bar.
   - Explore settings and understand terms like DHCP, DNS, and NAT.
 
 ### 4. **Basic Programming with Python**
@@ -151,6 +180,13 @@ Absolutely! Hands-on exercises are like spells and incantations – they're best
 
   ```bash
   pip install requests
+  ```
+
+  On macOS or Linux, use `pip3` (or invoke pip through the interpreter to be sure you're installing into the right Python):
+
+  ```bash
+  pip3 install requests
+  python3 -m pip install requests
   ```
 
   Then save this as `weather.py` and run it with `python weather.py`:
@@ -181,6 +217,13 @@ Absolutely! Hands-on exercises are like spells and incantations – they're best
     ```
 
 - **Exercise for Linux** (also works on macOS): Write a Bash script.
+  - First, give your scripts a home and move into it (keeping with the file-organization habit from Exercise 1):
+
+    ```bash
+    mkdir -p ~/scripts
+    cd ~/scripts
+    ```
+
   - Save the script below as `list_by_size.sh`. Make it runnable with `chmod +x list_by_size.sh`, then run it with `./list_by_size.sh`.
 
     ```bash
@@ -195,7 +238,11 @@ Absolutely! Hands-on exercises are like spells and incantations – they're best
 
 - **Exercise**: Create a free account on a cloud platform like Google Cloud Platform (GCP) or AWS.
   - Explore the dashboard and familiarize yourself with the interface.
-  - Follow a tutorial to deploy a simple 'Hello World' application.
+  - Follow a guided "Hello World" quickstart so the cloud stops being abstract. Pick one:
+    - **Google Cloud Run** — deploy a sample container with the [Cloud Run quickstart](https://cloud.google.com/run/docs/quickstarts/deploy-container). On your own machine you can start the CLI with `gcloud init` after installing the [gcloud CLI](https://cloud.google.com/sdk/docs/install).
+    - **AWS CloudShell** — open a free browser terminal already signed in to your account from the [CloudShell guide](https://docs.aws.amazon.com/cloudshell/latest/userguide/getting-started.html); run `aws --version` to confirm you're talking to AWS.
+
+    > 💡 Both platforms have a free tier, but always check what counts as free before deploying — spinning down resources when you're done keeps your bill at zero.
 
 ### 7. **Virtualization and Containers**
 
@@ -226,13 +273,49 @@ Absolutely! Hands-on exercises are like spells and incantations – they're best
 - **Exercise**: Install and use an antivirus software.
   - Perform a full system scan.
   - Explore the settings and schedule regular scans.
+- **Exercise**: Check your system for pending updates. Outdated software is one of the most common ways attackers break in — patching closes known holes before someone walks through them. See what's waiting to be updated on your realm:
+
+  **Windows** (PowerShell) — lists available upgrades; drop `--all` to preview without installing:
+
+  ```powershell
+  winget upgrade --all
+  ```
+
+  **Linux** (Debian/Ubuntu) — refresh the package list, then see what can be upgraded:
+
+  ```bash
+  sudo apt update
+  apt list --upgradable
+  ```
+
+  **macOS** — list available system updates:
+
+  ```bash
+  softwareupdate -l
+  ```
 
 ### 9. **Version Control with Git**
 
 - **Exercise**: Set up Git and practice basic commands.
-  - Install Git.
-  - Create a new repository and practice `git add`, `git commit`, `git push`.
-  - Clone an existing repository from GitHub and explore its contents.
+  - Install Git from [git-scm.com/downloads](https://git-scm.com/downloads), then confirm it's ready with `git --version`.
+  - Create your first repository and make your first commit. Run these one at a time:
+
+    ```bash
+    git init my-repo
+    cd my-repo
+    echo "# My first repo" > README.md
+    git add .
+    git commit -m "first commit"
+    ```
+
+    `git init` creates the repo, `git add .` stages your new file, and `git commit` records a snapshot. Run `git log` to see your commit in the project's history. 🎉
+  - Clone an existing repository from GitHub and explore its contents:
+
+    ```bash
+    git clone https://github.com/bamr87/it-journey.git
+    ```
+
+  - **Want to go deeper?** This is just the spark — the dedicated [Git Basics quest](/quests/0000/git-basics/) walks you through version control end-to-end.
 
 These exercises are your first steps. As you complete each one, you'll build a strong foundation in IT. Remember, the key is to practice regularly and keep challenging yourself with more complex tasks as you grow. Happy learning! 🌟💻🔧
 

--- a/pages/_quests/0000/it-fundamentals.md
+++ b/pages/_quests/0000/it-fundamentals.md
@@ -93,6 +93,17 @@ layout: quest
 - [ ] Can write a basic script to automate a simple task
 - [ ] Understands the basics of virtualization and containers
 
+## 🗺️ Quest Prerequisites
+
+*Every adventurer must pack the right supplies before setting out. Gather these before you begin so no exercise leaves you stranded:*
+
+- **A modern operating system** — Windows 10/11, macOS, or a Linux distribution. Any of them works for this quest.
+- **Internet access** — for downloading tools, reaching cloud platforms, and a couple of online exercises.
+- **Administrator / install rights** — you'll install Python, Git, VirtualBox, and Docker, which require permission to install software on your machine.
+- **~20 GB free disk space** — the Linux virtual machine and container images need room to live (the VM alone can take 10+ GB).
+
+> 🧭 **No admin rights?** If you're on a locked-down school or work computer, you can still complete the file-management, networking-exploration, and Python exercises. Save the VM and Docker secondary objectives for a machine you fully control.
+
 ---
 
 Absolutely! Hands-on exercises are like spells and incantations – they're best learned by doing. Let's start with some foundational IT skills and practical exercises to get you going:
@@ -113,6 +124,8 @@ Absolutely! Hands-on exercises are like spells and incantations – they're best
   - Download the Ubuntu ISO and install it on your virtual machine.
   - Practice basic Linux commands: `pwd`, `ls`, `cd`, `mkdir`, `rm`.
 
+  > ⚠️ **Handle `rm` with care.** Unlike dragging a file to the trash, `rm` permanently deletes files — there is **no recycle bin** and no undo. Practice on throwaway files you created (like a test folder), and use `rm -i` to make the shell ask for confirmation before each deletion. Never run `rm -rf` on a path you don't fully understand.
+
 ### 3. **Networking Fundamentals**
 
 - **Exercise**: Explore your home network.
@@ -123,16 +136,60 @@ Absolutely! Hands-on exercises are like spells and incantations – they're best
 ### 4. **Basic Programming with Python**
 
 - **Exercise**: Write a simple Python script.
-  - Install Python on your computer.
-  - Write a script that takes user input and prints a personalized greeting.
-  - Explore Python libraries by writing a script that fetches and displays the current weather from an online API.
+  - Install Python on your computer (download from [python.org](https://www.python.org/downloads/) and check the box to add Python to your PATH on Windows).
+  - Verify the install by running `python --version` (or `python3 --version` on macOS/Linux) in your terminal.
+  - Write a script that takes user input and prints a personalized greeting. Save this as `greet.py`:
+
+    ```python
+    name = input("What is your name, adventurer? ")
+    print(f"Welcome to the IT realm, {name}! 🧙")
+    ```
+
+    Run it with `python greet.py` (or `python3 greet.py`).
+
+- **Bonus — explore a library**: Fetch the current weather using a public endpoint that needs **no API key or sign-up**. First install the `requests` library:
+
+  ```bash
+  pip install requests
+  ```
+
+  Then save this as `weather.py` and run it with `python weather.py`:
+
+  ```python
+  import requests
+
+  # wttr.in is a free weather service — no API key required.
+  # "?format=3" returns one short line, e.g. "London: ⛅️ +15°C"
+  response = requests.get("https://wttr.in/?format=3")
+  print(response.text)
+  ```
+
+  Try changing the URL to `https://wttr.in/Tokyo?format=3` to check another city. You've just made your first program talk to the internet! 🌦️
 
 ### 5. **Scripting and Automation**
 
 - **Exercise for Windows**: Write a basic Batch script.
-  - Create a script that cleans up temporary files from your computer.
-- **Exercise for Linux**: Write a Bash script.
-  - Create a script that lists all files in a directory and sorts them by size.
+  - Open Notepad, paste the script below, and save it as `hello.bat` (choose "All Files" as the file type so it doesn't become `hello.bat.txt`). Double-click the file, or run it from Command Prompt with `hello.bat`.
+
+    ```batch
+    @echo off
+    echo Hello from your first Batch script!
+    echo The current date and time is: %date% %time%
+    echo Files in this folder:
+    dir /b
+    pause
+    ```
+
+- **Exercise for Linux** (also works on macOS): Write a Bash script.
+  - Save the script below as `list_by_size.sh`. Make it runnable with `chmod +x list_by_size.sh`, then run it with `./list_by_size.sh`.
+
+    ```bash
+    #!/bin/bash
+    echo "Hello from your first Bash script!"
+    echo "Files in this directory, largest first:"
+    # -l = long listing, -S = sort by size, -h = human-readable sizes
+    ls -lSh
+    ```
 
 ### 6. **Introduction to Cloud Computing**
 
@@ -143,9 +200,26 @@ Absolutely! Hands-on exercises are like spells and incantations – they're best
 ### 7. **Virtualization and Containers**
 
 - **Exercise**: Create a Docker container.
-  - Install Docker on your machine.
-  - Pull a simple image like `nginx` or `hello-world` from Docker Hub.
-  - Run the container and access it via your web browser.
+  - Install Docker on your machine ([Docker Desktop](https://www.docker.com/products/docker-desktop/) is the easiest way on Windows and macOS). Confirm it works with `docker --version`. For a deeper dive later, see the [Frontend Docker quest](/quests/0100/frontend-docker/).
+  - **Run your very first container** — this pulls the image and prints a welcome message, then exits:
+
+    ```bash
+    docker run hello-world
+    ```
+
+  - **Run a real web server** you can visit in your browser. This starts the `nginx` web server and maps it to port 8080 on your computer:
+
+    ```bash
+    docker run -d -p 8080:80 --name my-web nginx
+    ```
+
+    Now open **<http://localhost:8080>** in your browser — you'll see the nginx welcome page being served from inside the container. 🎉
+  - **Stop and clean up** when you're done:
+
+    ```bash
+    docker stop my-web
+    docker rm my-web
+    ```
 
 ### 8. **Basic System Security**
 

--- a/scripts/ci/brand_lint.py
+++ b/scripts/ci/brand_lint.py
@@ -44,6 +44,11 @@ CONTENT_GLOBS = ("pages/**/*.md", "pages/**/*.markdown")
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?\n)---\s*\n", re.DOTALL)
 FENCE_RE = re.compile(r"^([`~]{3,})")
 INLINE_CODE_RE = re.compile(r"`[^`]*`")
+# Markdown link/image destinations `](url)`, bare URLs, and `<url>` autolinks are
+# NOT prose — a real asset filename like `/assets/images/github-login.png` can't be
+# re-cased, so spelling/hype must not be policed inside them (false positives that
+# would otherwise block the brand gate on any quest referencing such a file).
+LINK_TARGET_RE = re.compile(r"\]\([^)]*\)|<https?://[^>]*>|\bhttps?://\S+")
 VENDORED_KEYS = ("source_repo:", "source_url:")
 
 
@@ -101,7 +106,12 @@ def strip_code(body: str) -> List[str]:
                 in_fence = False
             out.append("")          # the fence line itself is not prose
             continue
-        out.append("" if in_fence else INLINE_CODE_RE.sub(" ", raw))
+        if in_fence:
+            out.append("")
+        else:
+            # Blank inline code, then markdown link/image URL targets + bare URLs,
+            # so only PROSE is scanned (link text stays; only the destination goes).
+            out.append(LINK_TARGET_RE.sub("](url)", INLINE_CODE_RE.sub(" ", raw)))
     return out
 
 


### PR DESCRIPTION
## 🐞 Fixes from the developer/0000 walkthrough (#391)

Implements the **verified** learner-experience findings from the #391 walkthrough report, focused on the three **orientation quests** (the bashcrawl-Entrance items were already fixed in #392; the report's "broken side-quests links" finding was a **verified false positive** — `redirect_from` covers those URLs — and is intentionally left).

Each finding was re-verified against current content before editing; every edit **adds** learner value (no deleting objectives to game a score), and tier-1 scores **held or rose**.

### `hello-noob.md` (96.1% held)
- **Accuracy:** forking is now "your own copy to learn in," not "your first open-source contribution" — with a note that contributing back via a PR is a later quest.
- **Unclearable objectives:** "Join the Community" now links the real **Discussions** tab (a real step, not an empty checkbox); added concrete "Customize Your Profile" steps.

### `begin-your-it-journey.md` (91.3% → 91.9%)
- **Unframed pivot:** the systems-builder section is now framed as **one worked example** of a shared approach (other paths follow the same pattern).
- **Delivered the unscaffolded objectives:** a fill-in **Learning Plan** template, a copy-pasteable **first script** (Bash + Python), and an **IT Career Map** table.

### `it-fundamentals.md` (91.3% → 95.9%)
- **Runnable exercises:** explicit Python steps + a no-API-key `wttr.in` skeleton (Ex 4); concrete `docker run` commands + URL/cleanup (Ex 7); Batch + Bash starter skeletons (Ex 5).
- **Safety + completeness:** an ⚠️ `rm` callout (no recycle bin; use `rm -i`) and a **Quest Prerequisites** section (OS, internet, admin rights, ~20 GB disk).

### `brand_lint.py` (enabling fix — why this isn't a content-only PR)
The content gate scans whole changed files and failed on **pre-existing** lowercase `github` inside an **image path** (`/assets/images/github-login.png`) — a real filename that can't be re-cased. Fixed brand-lint to **not police spelling/hype inside markdown link/image URL targets or bare URLs** (link *text* and prose are still scanned). This is a fleet-wide false-positive fix the autonomous loop's fix lane would also have hit. *(Because this touches `scripts/`, the PR isn't content-only and isn't labeled `auto:content` — it's for your review/merge.)*

### Validation
tier-1: hello-noob 96.1% · begin 91.9% · it-fundamentals 95.9% (all pass) · brand spelling drift **0** · Liquid guards clean · body-only quest edits (no frontmatter/`_data` changes) · `brand_lint` regression-checked (real prose `github` still flagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DN6Y4iZKQKKsaWMBVvAZYP)_