### PR TITLE
fix(ci): repair invalid quest-perfection workflow + guard workflow validity

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,69 @@
+# =============================================================================
+# lint-workflows.yml — keep GitHub Actions workflow files valid at PR time.
+# -----------------------------------------------------------------------------
+# Guards the class of bug that a plain YAML lint misses: a workflow file that
+# PARSES as YAML but is invalid to GitHub Actions — a bad context reference, an
+# undefined `needs.<job>`, a `matrix` read in a job-level `if`, and so on. GitHub
+# only surfaces those AT RUN TIME as a 0-job "This run likely failed because of a
+# workflow file issue" failure — and because every push re-validates *all*
+# workflows, a single broken file spews red runs on unrelated branches until it's
+# fixed. `actionlint` catches the same errors statically, so they're caught in
+# review instead of after merge. (This is exactly what would have flagged the
+# `matrix.open_new_fix_prs` bug in quest-perfection.yml at PR time.)
+#
+# Scope = the workflow files a PR CHANGES, not the whole directory: pre-existing
+# style noise in untouched files never blocks an unrelated PR, but anything you
+# add or edit must be clean. shellcheck integration is OFF (`-shellcheck=`) — this
+# gates workflow VALIDITY, not shell style.
+# =============================================================================
+name: 🧹 Lint workflows
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-workflows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      # Only the workflow YAML this PR added/modified/renamed (not deleted),
+      # diffed from the merge-base so a moving base branch doesn't pull in files
+      # the PR never touched.
+      - name: Collect changed workflow files
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          merge_base="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
+          git diff --name-only --diff-filter=ACMR "$merge_base" "$HEAD_SHA" -- \
+            '.github/workflows/**.yml' '.github/workflows/**.yaml' > changed.txt || true
+          count="$(wc -l < changed.txt | tr -d ' ')"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "changed workflow files ($count):"
+          cat changed.txt || true
+
+      - name: actionlint (changed workflows only)
+        if: steps.changed.outputs.count != '0'
+        run: |
+          set -euo pipefail
+          mapfile -t files < changed.txt
+          echo "Running actionlint 1.7.12 on ${#files[@]} file(s)…"
+          # Official actionlint image, digest-pinned. `-shellcheck=` disables the
+          # bundled shellcheck so this gates workflow VALIDITY, not shell style.
+          docker run --rm -v "${PWD}:/repo" --workdir /repo \
+            rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 \
+            -shellcheck= -color "${files[@]}"

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -64,6 +64,8 @@ jobs:
           echo "Running actionlint 1.7.12 on ${#files[@]} file(s)…"
           # Official actionlint image, digest-pinned. `-shellcheck=` disables the
           # bundled shellcheck so this gates workflow VALIDITY, not shell style.
+          # `--` terminates option parsing so a workflow filename that begins with
+          # `-` (possible from a fork PR) is treated as a path, never a flag.
           docker run --rm -v "${PWD}:/repo" --workdir /repo \
             rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 \
-            -shellcheck= -color "${files[@]}"
+            -shellcheck= -color -- "${files[@]}"

--- a/.github/workflows/quest-perfection.yml
+++ b/.github/workflows/quest-perfection.yml
@@ -316,7 +316,9 @@ jobs:
           print(f"fix_count={len(fix_include)}")
           PY
           echo "--- planned matrix ---"
-          tail -n2 "$GITHUB_OUTPUT" || true
+          # Show every output this step emitted (matrix/count + fix_matrix/fix_count),
+          # not a fixed tail — so the debug view can't silently drop outputs again.
+          grep -E '^(matrix|count|fix_matrix|fix_count)=' "$GITHUB_OUTPUT" || true
 
   # ---------------------------------------------------------------------------
   # slice — one (character, level) slice per matrix entry, IN SERIES

--- a/.github/workflows/quest-perfection.yml
+++ b/.github/workflows/quest-perfection.yml
@@ -109,6 +109,12 @@ jobs:
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       count: ${{ steps.matrix.outputs.count }}
+      # A pre-filtered view of `matrix` holding only the entries granted a fix PR
+      # (open_new_fix_prs == "true"). The `fix` job fans out over THIS instead of
+      # gating on matrix.open_new_fix_prs — a job-level `if` can't read the matrix
+      # context, so per-entry gating has to happen by shaping the matrix upstream.
+      fix_matrix: ${{ steps.matrix.outputs.fix_matrix }}
+      fix_count: ${{ steps.matrix.outputs.fix_count }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -302,6 +308,12 @@ jobs:
           matrix = {"include": include}
           print(f"matrix={json.dumps(matrix)}")
           print(f"count={len(include)}")
+          # The fix lane fans out over ONLY the granted entries. A reusable-workflow
+          # job's `if` can't read the matrix context, so the per-entry open_new_fix_prs
+          # gate is applied HERE, by shaping a separate matrix the fix job consumes.
+          fix_include = [e for e in include if e.get("open_new_fix_prs") == "true"]
+          print(f"fix_matrix={json.dumps({'include': fix_include})}")
+          print(f"fix_count={len(fix_include)}")
           PY
           echo "--- planned matrix ---"
           tail -n2 "$GITHUB_OUTPUT" || true
@@ -516,18 +528,18 @@ jobs:
   # ---------------------------------------------------------------------------
   fix:
     needs: [plan, slice]
-    # Only when this entry's queue check said new fix PRs are allowed (the budget
-    # job sets open_new_fix_prs uniformly across the matrix from the OODA count of
-    # open auto:quest-fix PRs). A reusable-workflow `uses` job can't gate a step,
-    # but its job-level `if` can read the matrix context — so the per-entry flag is
-    # the gate here. Per-slice "already perfect" / circuit-breaker short-circuiting
-    # is re-checked INSIDE quest-fix.yml (it reads the ledger before editing), so a
-    # slice that became perfect during the walk still ships no fix PR.
-    if: ${{ needs.plan.outputs.count != '0' && needs.plan.outputs.matrix != '' && matrix.open_new_fix_prs == 'true' }}
+    # Runs only for the slices the budget/OODA step granted a fix PR. A
+    # reusable-workflow `uses` job can't gate a step, AND its job-level `if` can't
+    # read the matrix context — so the per-entry open_new_fix_prs gate is applied
+    # UPSTREAM: the plan job emits `fix_matrix` holding only the granted entries and
+    # this job fans out over that. Per-slice "already perfect" / circuit-breaker
+    # short-circuiting is re-checked INSIDE quest-fix.yml (it reads the ledger before
+    # editing), so a slice that became perfect during the walk still ships no fix PR.
+    if: ${{ needs.plan.outputs.fix_count != '0' && needs.plan.outputs.fix_matrix != '' }}
     strategy:
       max-parallel: 1
       fail-fast: false
-      matrix: ${{ fromJson(needs.plan.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.plan.outputs.fix_matrix) }}
     uses: ./.github/workflows/quest-fix.yml
     with:
       slug: ${{ matrix.slug }}


### PR DESCRIPTION
## What & why

The [`♾️ Quest Perfection Loop`](.github/workflows/quest-perfection.yml) was an **invalid workflow file** and had failed **every run since #394** — e.g. [run 28491277656](https://github.com/bamr87/it-journey/actions/runs/28491277656) (0 jobs, *"This run likely failed because of a workflow file issue"*).

**Root cause:** the `fix` job (a reusable-workflow `uses:` call) referenced `matrix.open_new_fix_prs` in its **job-level `if`**, but `matrix` is not an available context there — only `github`, `inputs`, `needs`, `vars` are. GitHub can't parse the file, so it emitted a red 0-job run on **every push to any branch** (pushes re-validate all workflows). The in-file comment even asserted the opposite (*"its job-level `if` can read the matrix context"*) — that was the mistaken assumption.

## The fix

You can't gate a reusable-workflow job per-matrix-entry via the job `if`, so the per-entry gate moves **upstream**:

- The `plan` job now emits a pre-filtered **`fix_matrix`** / **`fix_count`** containing only the slices granted a fix PR (`open_new_fix_prs == "true"`).
- The `fix` job fans out over `fix_matrix` with a plain `needs`-based `if` — no `matrix` reference.

**Semantics unchanged:** every slice is still walked (the `slice` job iterates the full `matrix`); only the budget/OODA-granted subset gets a fix PR. The empty-grant case sets `fix_count=0`, so the job skips cleanly (no empty-matrix error).

## Guard against recurrence

Adds [`lint-workflows.yml`](.github/workflows/lint-workflows.yml): runs **actionlint** on the workflow files a PR *changes*, so this class of "parses as YAML but invalid to Actions" bug is caught in review instead of after merge.

- Verified it flags the **exact** `matrix` error on #394's pre-fix content.
- **Scoped to changed files** so pre-existing shell-style noise in untouched workflows never blocks an unrelated PR; `-shellcheck=` off (this gates *validity*, not shell style).
- actionlint image pinned by version + digest (`rhysd/actionlint:1.7.12@sha256:b1934ee5…`), `actions/checkout` SHA-pinned — matches repo convention.

## Validation

- `actionlint` on both files → clean (was: 1 error at `quest-perfection.yml:526`).
- YAML parses; simulated the new filter (3 entries → 2 granted → `fix_count=2`; 0 granted → skips).
- Dry-ran the guard's git logic against `3332133a` (#394): correctly selects the 3 changed workflows and fails on the pre-fix file.

## Heads-up (separate issue, not in this PR)

The guard surfaced a **second** actionlint error in [`prd-sync.yml:218`](.github/workflows/prd-sync.yml#L218): the `check-conflicts` job reads `needs.check.outputs.needs_update` but only declares `needs: sync`. GitHub tolerates it (evaluates to null), so that job has been **silently skipped every run** — the conflict-detection + issue-creation step is effectively dead code. Fixing it (`needs: [check, sync]`) would *activate* a job that opens GitHub issues, which is a behavior change I've deliberately left out of this syntax fix. Flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)