### PR TITLE
content(quests): expand GH-600 epic with hands-on labs and repair the capstone

### DIFF
--- a/pages/_notes/gh-600/exam-overview.md
+++ b/pages/_notes/gh-600/exam-overview.md
@@ -40,8 +40,8 @@ Official study guide: [Microsoft Learn — GH-600 Study Guide](https://learn.mic
 
 ## Key Preparation Milestones
 
-- [ ] Review all 19 sub-skills in the [Skills Measured](/docs/certifications/gh-600/skills-measured/) page
-- [ ] Complete all 20 quests in the [Agentic Codex arc](/docs/certifications/gh-600/)
+- [ ] Review all 19 sub-skills in the [Skills Measured](/notes/gh-600/skills-measured/) page
+- [ ] Complete all 20 quests in the [Agentic Codex arc](/notes/gh-600/)
 - [ ] Score ≥ 70% on each domain in the Capstone rubric
 - [ ] Review the [Glossary](/notes/gh-600/glossary/) before exam day
 

--- a/pages/_notes/gh-600/learning-path.md
+++ b/pages/_notes/gh-600/learning-path.md
@@ -60,7 +60,7 @@ keywords:
 | Tue | Complete **Q1: Initiation Rites** — SDLC Integration | 90 min |
 | Wed | Complete **Q2: The Three Sigils** — Plan vs. Action Boundaries | 90 min |
 | Thu | Complete **Q3: The All-Seeing Eye** — Observability & Control | 90 min |
-| Fri | Write a 1-page reflection: anti-patterns you've seen in your own AI usage; review [Domain 1 chronicle post](/quests/0111/agentic-codex-01-agents-in-the-sdlc/) | 30 min |
+| Fri | Write a 1-page reflection: anti-patterns you've seen in your own AI usage; review [Chapter I — Agents in the SDLC](/quests/0111/agentic-codex-01-agents-in-the-sdlc/) | 30 min |
 
 ---
 
@@ -88,7 +88,7 @@ keywords:
 | Tue | Complete **Q8: Vaults of Recollection** — Memory Strategies | 90 min |
 | Wed | Complete **Q9: Anchoring the Drifting Agent** — State Persistence & Drift | 90 min |
 | Thu | Complete **Q10: Crossing the Tool Planes** — State Continuity Cross-Tools | 90 min |
-| Fri | Review [Taming Agent Memory post](/quests/1001/agentic-codex-03-memory-state-and-execution/) | 30 min |
+| Fri | Review [Chapter III — Vaults of Recollection: Memory & State](/quests/1001/agentic-codex-03-memory-state-and-execution/) | 30 min |
 
 ---
 
@@ -102,7 +102,7 @@ keywords:
 | Tue | Complete **Q11: The Oracle's Rubric** — Success Criteria & Signals | 90 min |
 | Wed | Complete **Q12: The Necromancer's Inquest** — Failure Root Cause Analysis | 90 min |
 | Thu | Complete **Q13: Reforging the Agent's Mind** — Behavior Tuning | 2 hrs |
-| Fri | Review [Evaluation post](/quests/1010/agentic-codex-04-evaluation-and-tuning/) | 30 min |
+| Fri | Review [Chapter IV — The Oracle Rubric: Evaluation & Tuning](/quests/1010/agentic-codex-04-evaluation-and-tuning/) | 30 min |
 
 ---
 
@@ -160,7 +160,7 @@ keywords:
 | 3 | Domain 2 deep dive | Q6 + Q7 | 3 hrs |
 | 4 | Domain 3 memory | Q8 + Q9 + Q10 | 3 hrs |
 | 5 | Domain 4 eval | Q11 + Q12 | 2 hrs |
-| 6 | Domain 4 tuning | Q13 + review D4 chronicle post | 2 hrs |
+| 6 | Domain 4 tuning | Q13 + review Chapter IV | 2 hrs |
 | 7 | **Rest day** — light review of [Glossary](/notes/gh-600/glossary/) | 30 min |
 | 8 | Domain 5 part 1 | Q14 + Q15 | 3 hrs |
 | 9 | Domain 5 part 2 | Q16 + Q17 | 3 hrs |
@@ -191,7 +191,7 @@ keywords:
 | 7 | Finish **Q2** |
 | 8 | Start **Q3** |
 | 9 | Finish **Q3** |
-| 10 | Read [Domain 1 chronicle post](/quests/0111/agentic-codex-01-agents-in-the-sdlc/) |
+| 10 | Read [Chapter I — Agents in the SDLC](/quests/0111/agentic-codex-01-agents-in-the-sdlc/) |
 
 ### Phase 2 — Tools & Environment (Days 11–30)
 

--- a/pages/_notes/gh-600/learning-path.md
+++ b/pages/_notes/gh-600/learning-path.md
@@ -60,7 +60,7 @@ keywords:
 | Tue | Complete **Q1: Initiation Rites** — SDLC Integration | 90 min |
 | Wed | Complete **Q2: The Three Sigils** — Plan vs. Action Boundaries | 90 min |
 | Thu | Complete **Q3: The All-Seeing Eye** — Observability & Control | 90 min |
-| Fri | Write a 1-page reflection: anti-patterns you've seen in your own AI usage; review [Domain 1 chronicle post](/docs/agentic-codex/embedding-agents-in-the-sdlc/) | 30 min |
+| Fri | Write a 1-page reflection: anti-patterns you've seen in your own AI usage; review [Domain 1 chronicle post](/quests/0111/agentic-codex-01-agents-in-the-sdlc/) | 30 min |
 
 ---
 
@@ -88,7 +88,7 @@ keywords:
 | Tue | Complete **Q8: Vaults of Recollection** — Memory Strategies | 90 min |
 | Wed | Complete **Q9: Anchoring the Drifting Agent** — State Persistence & Drift | 90 min |
 | Thu | Complete **Q10: Crossing the Tool Planes** — State Continuity Cross-Tools | 90 min |
-| Fri | Review [Taming Agent Memory post](/docs/agentic-codex/taming-agent-memory-and-context-drift/) | 30 min |
+| Fri | Review [Taming Agent Memory post](/quests/1001/agentic-codex-03-memory-state-and-execution/) | 30 min |
 
 ---
 
@@ -102,7 +102,7 @@ keywords:
 | Tue | Complete **Q11: The Oracle's Rubric** — Success Criteria & Signals | 90 min |
 | Wed | Complete **Q12: The Necromancer's Inquest** — Failure Root Cause Analysis | 90 min |
 | Thu | Complete **Q13: Reforging the Agent's Mind** — Behavior Tuning | 2 hrs |
-| Fri | Review [Evaluation post](/docs/agentic-codex/evaluating-and-tuning-agents-with-github-signals/) | 30 min |
+| Fri | Review [Evaluation post](/quests/1010/agentic-codex-04-evaluation-and-tuning/) | 30 min |
 
 ---
 
@@ -182,7 +182,7 @@ keywords:
 
 | Day | Session |
 |---|---|
-| 1 | Read [Exam at a Glance](/docs/certifications/gh-600/) (the hub table) |
+| 1 | Read [Exam at a Glance](/notes/gh-600/) (the hub table) |
 | 2 | Read [Domain 1 Skills Measured](../skills-measured/#domain-1) |
 | 3 | Skim [Copilot coding agent docs](https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/about-copilot-coding-agent) |
 | 4 | Start **Q1** (first half — read through "Quest Setup") |
@@ -191,7 +191,7 @@ keywords:
 | 7 | Finish **Q2** |
 | 8 | Start **Q3** |
 | 9 | Finish **Q3** |
-| 10 | Read [Domain 1 chronicle post](/docs/agentic-codex/embedding-agents-in-the-sdlc/) |
+| 10 | Read [Domain 1 chronicle post](/quests/0111/agentic-codex-01-agents-in-the-sdlc/) |
 
 ### Phase 2 — Tools & Environment (Days 11–30)
 

--- a/pages/_quests/0111/agentic-codex-01-agents-in-the-sdlc.md
+++ b/pages/_quests/0111/agentic-codex-01-agents-in-the-sdlc.md
@@ -2,7 +2,7 @@
 title: 'Initiation Rites: Agents in the SDLC'
 description: 'Embed GitHub Copilot agents into the software lifecycle with bounded roles, plan-then-act gates, and observable traces — GH-600 Domain 1 of The Agentic Codex.'
 date: '2026-06-30T00:00:00.000Z'
-lastmod: '2026-06-30T00:00:00.000Z'
+lastmod: '2026-07-01T00:00:00.000Z'
 level: '0111'
 difficulty: '🟡 Medium'
 estimated_time: 2-4 hours
@@ -310,6 +310,109 @@ Now the **degree of autonomy** is a dial you control: the JSONL trail is the evi
 - [ ] Why is a JSONL trace more useful to an auditor than free-text log lines?
 - [ ] What two artifacts let a reviewer understand an agent run *without re-running* the workflow?
 - [ ] How does good observability let you *shrink* the set of actions that need a human approval gate?
+
+## 🧪 Hands-On Lab: Raise the Gate in Fifteen Minutes
+
+*Rites are learned by performing them, not reading them.* This lab stands up a real plan-then-act pipeline — plan job, human gate, observable trace — in a scratch repository, using nothing but the `gh` CLI. No Copilot subscription required: the "agent" is a stub you can later replace with the real coding agent.
+
+### Step 1 — Forge the scratch repo
+
+```bash
+gh auth login                                  # skip if already authenticated
+gh repo create codex-rites-lab --private --clone
+cd codex-rites-lab
+mkdir -p .github/workflows scripts
+```
+
+### Step 2 — Lay down the workflow
+
+One file gives you all three rites: a `plan` job that only plans, an `execute` job behind the gate, and a trace both jobs write. (Drop the `raw` escapes when copying from this page.)
+
+{% raw %}
+```yaml
+# .github/workflows/plan-then-act.yml
+name: Plan-then-Act Lab
+on: workflow_dispatch
+permissions:
+  contents: read
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Produce the plan (no changes, only intent)
+        run: |
+          mkdir -p .agent
+          cat > .agent/plan.json <<'PLAN'
+          {"task":"demo","edits":["README.md"],"success":"README gains a lab badge"}
+          PLAN
+          echo '{"ts":"'"$(date -u +%FT%TZ)"'","action":"plan","result":"ok"}' >> .agent/trace.jsonl
+          echo "### 🗺️ Plan produced — awaiting the gate" >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: agent-plan
+          path: .agent/
+  execute:
+    needs: plan
+    runs-on: ubuntu-latest
+    environment: agent-approval        # the gate — configured in Step 3
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: agent-plan
+          path: .agent
+      - name: Act on the approved plan (observed)
+        run: |
+          echo "Executing: $(jq -r .task .agent/plan.json)"
+          echo '{"ts":"'"$(date -u +%FT%TZ)"'","action":"execute","result":"ok"}' >> .agent/trace.jsonl
+          echo "### ✅ Executed after human approval" >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: agent-trace
+          path: .agent/trace.jsonl
+```
+{% endraw %}
+
+### Step 3 — Bind the gate with yourself as Warden
+
+The `agent-approval` environment must exist and name a required reviewer, or the `execute` job will run ungated:
+
+```bash
+me=$(gh api user -q .id)
+cat > /tmp/env.json <<EOF
+{ "reviewers": [ { "type": "User", "id": $me } ] }
+EOF
+gh api -X PUT "repos/{owner}/{repo}/environments/agent-approval" --input /tmp/env.json
+```
+
+### Step 4 — Trigger the rite and watch it wait
+
+```bash
+git add . && git commit -m "lab: plan-then-act pipeline" && git push -u origin main
+gh workflow run plan-then-act.yml
+sleep 5 && gh run watch
+```
+
+Expected: the `plan` job completes, then the run **pauses** — `gh run list` shows it `waiting`, and the run page says *"Review pending deployments: agent-approval"*. The agent planned; it cannot act. That pause **is** Rite Two working.
+
+### Step 5 — Approve, then audit without re-running
+
+Approve the pending deployment on the run page (`gh run view --web`), then pull the evidence:
+
+```bash
+run_id=$(gh run list --workflow=plan-then-act.yml -L1 --json databaseId -q '.[0].databaseId')
+gh run download "$run_id" --name agent-trace --dir /tmp/lab-trace
+cat /tmp/lab-trace/trace.jsonl
+```
+
+Expected — one JSONL line per action, plan before execute:
+
+```text
+{"ts":"2026-07-01T20:14:02Z","action":"plan","result":"ok"}
+{"ts":"2026-07-01T20:16:41Z","action":"execute","result":"ok"}
+```
+
+You reconstructed the run from its trace and step summaries alone — Rite Three. Clean up with `gh repo delete codex-rites-lab --yes` when you are done, and note what you proved: a **bounded entry point** (`workflow_dispatch`), a **plan that cannot act**, a **human gate that actually held**, and a **trace an auditor can read cold**.
 
 ## ⚔️ The Quests of This Domain
 

--- a/pages/_quests/0111/agentic-plan-vs-action-boundaries.md
+++ b/pages/_quests/0111/agentic-plan-vs-action-boundaries.md
@@ -363,7 +363,7 @@ python3 scripts/validate_quest.py --quest q2
 
 - **Next quest:** [Q3: The All-Seeing Eye — Observability & Control](/quests/1000/agentic-observability-and-control/)
 - **Prerequisite for:** All Domain 2+ quests
-- **Chronicle post:** [Embedding Agents in the SDLC](/docs/agentic-codex/embedding-agents-in-the-sdlc/)
+- **Codex chapter:** [Initiation Rites: Agents in the SDLC](/quests/0111/agentic-codex-01-agents-in-the-sdlc/)
 
 ## 🕸️ Knowledge Graph
 

--- a/pages/_quests/0111/agentic-sdlc-integration.md
+++ b/pages/_quests/0111/agentic-sdlc-integration.md
@@ -368,8 +368,8 @@ python3 scripts/validate_quest.py --quest q1
 ## 🔗 Continue Your Journey
 
 - **Next quest:** [Q2: The Three Sigils — Plan, Reason, Act](/quests/0111/agentic-plan-vs-action-boundaries/)
-- **Domain hub:** [Domain 1 in the GH-600 Skills Measured breakdown](/docs/certifications/gh-600/skills-measured/#domain-1)
-- **Chronicle post:** [Embedding Agents in the SDLC](/docs/agentic-codex/embedding-agents-in-the-sdlc/)
+- **Domain hub:** [Domain 1 in the GH-600 Skills Measured breakdown](/notes/gh-600/skills-measured/#domain-1)
+- **Codex chapter:** [Initiation Rites: Agents in the SDLC](/quests/0111/agentic-codex-01-agents-in-the-sdlc/)
 - **Official docs:** [GitHub Copilot coding agent](https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-for-pull-requests/about-copilot-coding-agent)
 
 ## 🕸️ Knowledge Graph

--- a/pages/_quests/1000/agentic-codex-02-tool-use-and-environment.md
+++ b/pages/_quests/1000/agentic-codex-02-tool-use-and-environment.md
@@ -2,7 +2,7 @@
 title: 'Forging the Arsenal: Tool Use & Environment'
 description: 'Equip GitHub Copilot agents with the right tools, wire MCP servers, scope least-privilege permissions, and bind agents to a CI environment — GH-600 Domain 2.'
 date: '2026-06-30T00:00:00.000Z'
-lastmod: '2026-06-30T00:00:00.000Z'
+lastmod: '2026-07-01T00:00:00.000Z'
 level: '1000'
 difficulty: '🔴 Hard'
 estimated_time: 2-4 hours
@@ -58,9 +58,9 @@ prerequisites:
 quest_dependencies:
   required_quests: []
   recommended_quests:
-  - /quests/0111/agentic-codex-01-agents-in-the-sdlc/ # planned quest
+  - /quests/0111/agentic-codex-01-agents-in-the-sdlc/
   unlocks_quests:
-  - /quests/1001/agentic-codex-03-memory-state-and-execution/ # planned quest
+  - /quests/1001/agentic-codex-03-memory-state-and-execution/
 rewards:
   badges:
   - 🗡️ Arsenal Smith — equipped an agent with scoped tools and a remote MCP server
@@ -330,6 +330,86 @@ Three safety properties make this safe: **bounded retries** (transient blips rec
 - [ ] What does an agent learn from `AGENTS.md` that it cannot infer from the code alone?
 - [ ] Why must the script `exit 1` on final failure instead of logging and returning 0?
 - [ ] How does `timeout-minutes` bound an agent's blast radius differently than `permissions:` does?
+
+## 🧪 Hands-On Lab: Slay the Silent Failure on Your Own Bench
+
+*You do not need a CI runner to fight this dragon — you need a flaky tool and a script that refuses to lie about it.* This lab runs entirely on your machine with zero credentials: a stub tool fails deterministically, the safe-execution wrapper retries and escalates, and you verify every exit code yourself.
+
+### Step 1 — Build the flaky tool and a stubbed `gh`
+
+```bash
+mkdir -p ~/codex-arsenal-lab && cd ~/codex-arsenal-lab
+
+# The tool: fails twice, succeeds on the third call — a classic transient fault
+cat > agent-step.sh <<'EOF'
+#!/usr/bin/env bash
+n=$(cat .attempts 2>/dev/null || echo 0)
+echo $((n + 1)) > .attempts
+if [ "$n" -lt 2 ]; then
+  echo "tool error: transient failure (call $((n + 1)))" >&2
+  exit 1
+fi
+echo "tool ok on call $((n + 1))"
+EOF
+chmod +x agent-step.sh
+
+# A stub gh so the escalation path is observable without touching GitHub
+cat > gh <<'EOF'
+#!/usr/bin/env bash
+echo "[stub gh] would run: $*"
+EOF
+chmod +x gh
+export PATH="$PWD:$PATH"
+```
+
+### Step 2 — Copy in the safe-execution wrapper
+
+Save the `run-agent.sh` script from Chapter 3 above as `run-agent.sh` in this directory (replace `./agent-step.sh` paths as-is — they match), then `chmod +x run-agent.sh`.
+
+### Step 3 — Watch bounded retries absorb a transient fault
+
+```bash
+rm -f .attempts && ./run-agent.sh; echo "exit=$?"
+```
+
+Expected — two failures absorbed, success on the third, exit code 0:
+
+```text
+tool error: transient failure (call 1)
+Attempt 1 failed; retrying after backoff…
+tool error: transient failure (call 2)
+Attempt 2 failed; retrying after backoff…
+tool ok on call 3
+Agent step succeeded on attempt 3.
+exit=0
+```
+
+### Step 4 — Make the fault permanent and watch it escalate loudly
+
+```bash
+rm -f .attempts
+sed -i.bak 's/-lt 2/-lt 99/' agent-step.sh    # now it always fails
+./run-agent.sh; echo "exit=$?"
+```
+
+Expected — the retries exhaust, a `needs-human` issue is filed (by the stub), and the run ends **red**:
+
+```text
+tool error: transient failure (call 1)
+Attempt 1 failed; retrying after backoff…
+tool error: transient failure (call 2)
+Attempt 2 failed; retrying after backoff…
+tool error: transient failure (call 3)
+::error::Agent failed after 3 attempts — escalating to a human.
+[stub gh] would run: issue create --title Agent run failed: … --label needs-human …
+exit=1
+```
+
+That `exit=1` is the whole lesson: the dragon only lives where a failed run can report green. Now break the wrapper on purpose — delete the `exit 1` line and re-run — and watch the run end `exit=0` while the tool never succeeded. You have reproduced the Silent CI Failure and can name the one line that kills it.
+
+### Step 5 — Take it to the real forge (optional)
+
+Swap the stub for reality: commit `run-agent.sh` and `agent-step.sh` to a scratch repo, wrap them in the CI workflow from Chapter 3, and confirm the Actions run goes red with a real `needs-human` issue filed by the real `gh`. The scripts do not change — only the bench does.
 
 ## ⚔️ The Quests of This Domain
 

--- a/pages/_quests/1000/agentic-mcp-server-mastery.md
+++ b/pages/_quests/1000/agentic-mcp-server-mastery.md
@@ -321,7 +321,7 @@ python3 scripts/validate_quest.py --quest q5
 
 - **Next:** [Q6: Bind the Agent to the Realm](/quests/1001/agentic-dev-environment-integration/)
 - **Reference note:** [MCP Quick Reference](/notes/gh-600/mcp-quickref/)
-- **Chronicle post:** [MCP Servers and Agent Tooling in Practice](/docs/agentic-codex/mcp-servers-and-agent-tooling-in-practice/)
+- **Codex chapter:** [Forging the Arsenal: Tool Use & Environment](/quests/1000/agentic-codex-02-tool-use-and-environment/)
 
 ## 🕸️ Knowledge Graph
 

--- a/pages/_quests/1000/agentic-observability-and-control.md
+++ b/pages/_quests/1000/agentic-observability-and-control.md
@@ -329,7 +329,7 @@ python3 scripts/validate_quest.py --quest q3
 ## 🔗 Continue Your Journey
 
 - **Next quest:** [Q4: Forging the Agent's Arsenal](/quests/1000/agentic-tool-selection-and-permissions/) — Domain 2 begins
-- **Chronicle post:** [Embedding Agents in the SDLC](/docs/agentic-codex/embedding-agents-in-the-sdlc/)
+- **Codex chapter:** [Initiation Rites: Agents in the SDLC](/quests/0111/agentic-codex-01-agents-in-the-sdlc/)
 - **Related note:** [Evaluation Signals Table](/notes/gh-600/evaluation-signals-table/)
 
 ## 🕸️ Knowledge Graph

--- a/pages/_quests/1001/agentic-codex-03-memory-state-and-execution.md
+++ b/pages/_quests/1001/agentic-codex-03-memory-state-and-execution.md
@@ -2,7 +2,7 @@
 title: 'Vaults of Recollection: Memory & State'
 description: 'Master the three tiers of agent memory, persist state across GitHub Actions runs, and detect context drift before it corrupts an agent. GH-600 Domain 3.'
 date: '2026-06-30T00:00:00.000Z'
-lastmod: '2026-06-30T00:00:00.000Z'
+lastmod: '2026-07-01T00:00:00.000Z'
 level: '1001'
 difficulty: '🔴 Hard'
 estimated_time: 2-4 hours
@@ -340,6 +340,86 @@ This single document prevents the two failure modes named in the sub-skill. It p
 - [ ] Why does the handoff carry a `handoff_at` timestamp?
 - [ ] Why can't you assume the Copilot agent and the PR's Actions run already share memory?
 
+## 🧪 Hands-On Lab: Carve All Three Vaults on Your Own Machine
+
+*The vaults do not require a cloud — they require discipline you can practice at a terminal.* This lab builds every memory tier and the drift guard locally, in ten minutes, with `git`, `jq`, and `sha256sum`.
+
+### Step 1 — Raise the lab realm
+
+```bash
+mkdir -p ~/codex-vaults-lab && cd ~/codex-vaults-lab
+git init -q && echo "# The Realm" > README.md
+mkdir -p .agent/memory scripts
+git add . && git commit -qm "lab: the realm stands"
+```
+
+### Step 2 — Tier 2: hand a plan across a job boundary
+
+Simulate the `plan` job and the `act` job as two separate shells that share **only** the artifact directory:
+
+```bash
+# --- the "plan job": writes the plan, touches nothing else
+jq -n '{goal:"update changelog",steps:["read","edit","verify"]}' > .agent/plan.json
+
+# --- the "act job": knows nothing except what the artifact tells it
+jq -r '.steps[]' .agent/plan.json
+```
+
+Expected:
+
+```text
+read
+edit
+verify
+```
+
+The act shell recovered the plan's full intent from the artifact alone. That is Tier 2: state that survives the job boundary because you made it a **file**, not a memory.
+
+### Step 3 — Tier 3: commit memory the next run can read
+
+```bash
+jq -n --arg ts "$(date -u +%FT%TZ)" '{run:"local-1", at:$ts, status:"completed"}' \
+  >> .agent/memory/task-register.jsonl
+git add .agent/memory && git commit -qm "chore(memory): record run local-1"
+
+# A "next run", hours later, asks: what already happened?
+jq -r '.run + " → " + .status' .agent/memory/task-register.jsonl
+```
+
+Expected: `local-1 → completed` — the next run resumes instead of repeating. Delete your shell history if you like; the memory is in Git now, which is the point.
+
+### Step 4 — The drift guard catches a moved world
+
+Save the `drift-guard.sh` script from Chapter 3 above into `scripts/drift-guard.sh` (`chmod +x` it), then:
+
+```bash
+# Snapshot right after "planning"
+bash scripts/drift-guard.sh snapshot
+
+# Verify immediately — the world has not moved
+bash scripts/drift-guard.sh verify; echo "exit=$?"
+
+# Now the world moves out from under the agent…
+echo "a rival scribe edits the scroll" >> README.md
+bash scripts/drift-guard.sh verify; echo "exit=$?"
+```
+
+Expected:
+
+```text
+Snapshot taken.
+No drift — safe to act.
+exit=0
+::warning::Context drift detected — key files changed since snapshot.
+exit=78
+```
+
+*(Adjust the `WATCH` array in the script to `("README.md" ".agent/plan.json")` for this lab — the realm has no `_config.yml`.)* The `exit=78` is your abort-before-acting signal: the plan was drawn against a world that no longer exists, and the guard refused to let the agent pretend otherwise.
+
+### Step 5 — Prove you can place state in its tier
+
+Close the lab with the placement drill from the Mastery Indicators. For each item, say the tier aloud before checking: a retry counter inside one job (*Tier 1 — ephemeral*), the plan crossing plan→act (*Tier 2 — artifact*), the task register (*Tier 3 — committed file*), a cached dependency graph (*Tier 3 — cache, non-authoritative*). If any answer surprised you, re-read Chapter 1's table — the exam will hand you exactly this drill.
+
 ## ⚔️ The Quests of This Domain
 
 This chapter is the map of the Vaults; these three quests are the chambers you descend into. Each carries complete workflows, drift-detection scripts, and the handoff schema — finish all three to seal Domain 3.
@@ -397,7 +477,7 @@ The vaults are carved and the world can no longer drift out from under your agen
 - [Caching dependencies with `actions/cache`](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows) — non-authoritative persistent state
 - [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) — stateless tool surfaces that need explicit shared state
 - [GitHub Models](https://docs.github.com/en/github-models) — the reasoning engine behind cheap re-planning
-- [Agentic Codex: Taming Agent Memory and Context Drift](/docs/agentic-codex/taming-agent-memory-and-context-drift/) — the reference article this chapter teaches from
+- [GH-600 Study Hub](/notes/gh-600/) — the campaign map: domains, weights, and the full quest line
 
 ## 🕸️ Knowledge Graph
 

--- a/pages/_quests/1001/agentic-memory-strategies.md
+++ b/pages/_quests/1001/agentic-memory-strategies.md
@@ -296,7 +296,7 @@ python3 scripts/validate_quest.py --quest q8
 ## 🔗 Continue Your Journey
 
 - **Next:** [Q9: Anchoring the Drifting Agent](/quests/1010/agentic-state-persistence-and-drift/)
-- **Chronicle post:** [Taming Agent Memory and Context Drift](/docs/agentic-codex/taming-agent-memory-and-context-drift/)
+- **Codex chapter:** [Vaults of Recollection: Memory & State](/quests/1001/agentic-codex-03-memory-state-and-execution/)
 - **Related note:** [Evaluation Signals Table](/notes/gh-600/evaluation-signals-table/)
 
 ## 🕸️ Knowledge Graph

--- a/pages/_quests/1010/agentic-codex-04-evaluation-and-tuning.md
+++ b/pages/_quests/1010/agentic-codex-04-evaluation-and-tuning.md
@@ -2,7 +2,7 @@
 title: 'The Oracle Rubric: Evaluation & Tuning'
 description: 'Define machine-verifiable success criteria, read GitHub signals to grade agent runs, run root-cause analysis on failures, and tune behaviour by instruction.'
 date: '2026-06-30T00:00:00.000Z'
-lastmod: '2026-06-30T00:00:00.000Z'
+lastmod: '2026-07-01T00:00:00.000Z'
 level: '1010'
 difficulty: '🔴 Hard'
 estimated_time: 2-4 hours
@@ -382,6 +382,96 @@ This closes the loop the legend opened: rubric → signal → trace → tuned in
 - [ ] An agent keeps re-reading the same file every run — is the right lever an instruction, a constraint, a memory rule, or a tool change? Why?
 - [ ] What does an instruction changelog give you that a raw `git log` of `AGENTS.md` does not?
 
+## 🧪 Hands-On Lab: Build the Oracle on Your Own Bench
+
+*A rubric you have never watched fail is a rubric you do not understand.* This lab builds a working completion detector locally — deterministic signals in a JSON file, a grader that reads them — then points it at a real pull request with `gh`. Ten minutes, no Copilot required.
+
+### Step 1 — Fabricate a run's signals
+
+```bash
+mkdir -p ~/codex-oracle-lab && cd ~/codex-oracle-lab
+cat > signals.json <<'EOF'
+{
+  "checks":        { "test": "success", "lint": "success" },
+  "pr":            { "draft": false, "body": "Fix parser crash. Closes #42", "approvals": 1 },
+  "new_alerts":    0,
+  "changed_files": ["src/parser.js", "test/parser.test.js"]
+}
+EOF
+```
+
+### Step 2 — Write the grader
+
+Every line of the Chapter 1 rubric becomes one `jq` assertion — the machine-verifiable criteria, executed:
+
+```bash
+cat > grade.sh <<'EOF'
+#!/usr/bin/env bash
+# grade.sh — the Oracle's rubric as a function: signals in, verdict out
+set -euo pipefail
+S="${1:-signals.json}"
+fails=0
+grade() {  # name, jq-expression that must be true
+  if [ "$(jq -r "$2" "$S")" = "true" ]; then echo "✅ $1"
+  else echo "❌ $1"; fails=$((fails + 1)); fi
+}
+grade "Tests pass"          '.checks.test  == "success"'
+grade "Lint passes"         '.checks.lint  == "success"'
+grade "No new alerts"       '.new_alerts   == 0'
+grade "References issue"    '.pr.body | test("Closes #[0-9]+")'
+grade "Ready for review"    '.pr.draft     == false'
+grade "Human approved"      '.pr.approvals >= 1'
+grade "In scope"            '[.changed_files[] | test("^(src|test)/")] | all'
+[ "$fails" -eq 0 ] && echo "🔮 Rubric satisfied — task complete" \
+                   || { echo "⏳ Rubric not satisfied — $fails signal(s) failing"; exit 1; }
+EOF
+chmod +x grade.sh && ./grade.sh
+```
+
+Expected: seven ✅ lines and `🔮 Rubric satisfied — task complete`, exit code 0.
+
+### Step 3 — Watch it fail for the right reason
+
+```bash
+jq '.pr.draft = true | .changed_files += [".github/workflows/deploy.yml"]' \
+  signals.json > drifted.json
+./grade.sh drifted.json; echo "exit=$?"
+```
+
+Expected — the two poisoned signals fail, everything else still passes, and the exit code goes red:
+
+```text
+✅ Tests pass
+✅ Lint passes
+✅ No new alerts
+✅ References issue
+❌ Ready for review
+✅ Human approved
+❌ In scope
+⏳ Rubric not satisfied — 2 signal(s) failing
+exit=1
+```
+
+Notice what the second ❌ caught: a workflow file crept into the diff — exactly the "out of scope" failure a tests-only rubric would have waved through.
+
+### Step 4 — Point the Oracle at reality
+
+Now build `signals.json` from a **real** PR instead of a fixture — any PR in a repo you can read:
+
+```bash
+repo="<owner>/<repo>"; pr=<number>
+jq -n \
+  --argjson pr    "$(gh pr view "$pr" --repo "$repo" --json isDraft,body,reviews)" \
+  --argjson files "$(gh pr view "$pr" --repo "$repo" --json files -q '[.files[].path]')" \
+  '{ checks: {test:"success", lint:"success"},
+     pr: { draft: $pr.isDraft, body: $pr.body,
+           approvals: ([$pr.reviews[] | select(.state=="APPROVED")] | length) },
+     new_alerts: 0, changed_files: $files }' > signals.json
+./grade.sh
+```
+
+The fabricated `checks`/`new_alerts` fields are the two signals that need a workflow context to read — in CI they come from `checks.listForRef` and `code-scanning.listAlertsForRef`, exactly as in the `check-task-completion.yml` above. The lab's lesson survives the swap: **the rubric is a pure function of signals**, and anything that can produce the signals can be graded — a fixture, a live PR, or the agent run you ship next week.
+
 ## ⚔️ The Quests of This Domain
 
 This chapter is the campaign hub for Domain 4. Each linked quest takes one craft deep with hands-on exercises — play them in order:
@@ -442,7 +532,7 @@ You can now grade an agent, diagnose its failures, and reforge its mind. The nex
 - [GitHub CLI: `gh run`](https://cli.github.com/manual/gh_run) — downloading run logs and artifacts for forensics
 - [GitHub Models](https://docs.github.com/en/github-models) — adding an LLM-as-judge signal for qualitative criteria
 - [Code scanning REST API](https://docs.github.com/en/rest/code-scanning) — reading the "no new alerts" signal
-- [Agentic Codex: Evaluating & Tuning Agents with GitHub Signals](/docs/agentic-codex/evaluating-and-tuning-agents-with-github-signals/) — the Domain 4 reference article
+- [Evaluation Signals Table (GH-600 notes)](/notes/gh-600/evaluation-signals-table/) — every Domain 4 signal and the API call that reads it
 
 ## 🕸️ Knowledge Graph
 

--- a/pages/_quests/1011/agentic-codex-05-multi-agent-coordination.md
+++ b/pages/_quests/1011/agentic-codex-05-multi-agent-coordination.md
@@ -2,7 +2,7 @@
 title: 'The Council of Many: Multi-Agent Coordination'
 description: 'Orchestrate a council of agents on GitHub Actions: fan-out and chain patterns, correlation-ID tracing, failure recovery, and lifecycle. GH-600 Domain 5.'
 date: '2026-06-30T00:00:00.000Z'
-lastmod: '2026-06-30T00:00:00.000Z'
+lastmod: '2026-07-01T00:00:00.000Z'
 level: '1011'
 difficulty: '🔴 Hard'
 estimated_time: 2-4 hours
@@ -310,6 +310,71 @@ Adding an agent to an existing workflow is a new roster row plus a new job; *rep
 - [ ] Which recovery strategy fits a *transient* network failure, and which fits a *logic* error — and why are they different?
 - [ ] What signal distinguishes a stalled sub-agent from a conflicting one, and why is a blind retry wrong for the conflicting case?
 - [ ] What three lifecycle operations does `_data/agents.yml` govern, and what does flipping a `status` to `deprecated` communicate?
+
+## 🧪 Hands-On Lab: Convene a Council at Your Own Table
+
+*The exam's hardest Domain 5 question hands you a trace and asks which agent caused the fault. Answer it once with your own hands and you will never miss it.* This lab runs a three-agent council locally — one of them sabotaged — then stitches the unified trace and finds the culprit. Pure shell and `jq`, five minutes.
+
+### Step 1 — Mint the correlation ID and the trace writer
+
+```bash
+mkdir -p ~/codex-council-lab && cd ~/codex-council-lab
+export CID="council-$(date +%s)"
+
+trace() {  # seq, agent, event, detail — one JSONL line, stamped with the shared CID
+  printf '{"cid":"%s","seq":%s,"agent":"%s","event":"%s","detail":"%s"}\n' \
+    "$CID" "$1" "$2" "$3" "$4" >> "trace-$2-$CID.jsonl"
+}
+```
+
+### Step 2 — Run the council (one member is subtly broken)
+
+The planner hands off cleanly; the frontend agent finishes its slice but hands the backend an **empty payload** — the seeded fault; the backend then crashes on it:
+
+```bash
+# planner: draws the plan, hands off to both agents
+trace 1 planner start   "drawing the plan"
+trace 2 planner handoff "frontend:build-ui backend:build-api"
+trace 3 planner done    "plan issued"
+
+# frontend agent: succeeds, but its handoff payload is empty — the real fault
+trace 4 frontend start   "building ui slice"
+trace 5 frontend handoff ""
+trace 6 frontend done    "ui slice green"
+
+# backend agent: crashes on the empty handoff — the visible failure
+trace 7 backend start "building api slice"
+trace 8 backend error "empty payload received from upstream handoff"
+```
+
+### Step 3 — The collect job: stitch one narrative from three logs
+
+```bash
+cat trace-*-"$CID".jsonl \
+  | jq -s 'sort_by(.seq) | .[] | "\(.seq)  \(.agent)\t\(.event)\t\(.detail)"' -r \
+  | tee "council-trace-$CID.txt"
+```
+
+Expected — the whole council's work in one ordered record:
+
+```text
+1  planner   start    drawing the plan
+2  planner   handoff  frontend:build-ui backend:build-api
+3  planner   done     plan issued
+4  frontend  start    building ui slice
+5  frontend  handoff
+6  frontend  done     ui slice green
+7  backend   start    building api slice
+8  backend   error    empty payload received from upstream handoff
+```
+
+### Step 4 — Name the culprit
+
+Answer the exam's question from the trace alone: **which agent introduced the fault?** The backend *crashed* (seq 8) — but read upstream: the frontend's handoff at seq 5 is empty while its own status reports `done … green`. The fault was **introduced by the frontend agent** and merely *surfaced* by the backend. Now prove why the correlation ID mattered: imagine the same three log files with no shared key — you could still see the backend crash, but you could never join seq 5 to seq 8 across files with confidence. The shared `cid` is what turns three alibis into one testimony.
+
+### Step 5 — Promote it to the real arena (optional)
+
+Everything above maps one-to-one onto the `council-fanout.yml` workflow from Chapter 1: the `trace` function becomes the traced step in each job, `$CID` becomes `needs.orchestrate.outputs.run_id`, the local files become uploaded artifacts, and Step 3 becomes the `collect` job. Ship it to a scratch repo and confirm the stitched narrative appears as a run artifact — the same forensics, now surviving in CI where your future councils will actually fail.
 
 ## ⚔️ The Quests of This Domain
 

--- a/pages/_quests/1100/agentic-codex-06-guardrails-and-accountability.md
+++ b/pages/_quests/1100/agentic-codex-06-guardrails-and-accountability.md
@@ -2,7 +2,7 @@
 title: 'The Warden Pact: Guardrails & Accountability'
 description: 'GH-600 Domain 6: classify agent actions by risk, set autonomy levels, enforce least-privilege guardrails, gate humans in the loop, and build an audit trail.'
 date: '2026-06-30T00:00:00.000Z'
-lastmod: '2026-06-30T00:00:00.000Z'
+lastmod: '2026-07-01T00:00:00.000Z'
 level: '1100'
 difficulty: '🔴 Hard'
 estimated_time: 2-4 hours
@@ -329,6 +329,107 @@ A final accountability note that the exam loves: the human gate must never be a 
 - [ ] What three things must every audit entry record?
 - [ ] Where do the "instruction" and "outcome" of an agent action live in GitHub's native tooling?
 - [ ] Why is append-only `.jsonl` safer than a single JSON array for parallel agent runs?
+
+## 🧪 Hands-On Lab: Build a Warden That Says No
+
+*A guardrail you have never watched refuse an action is a decoration.* This lab builds a working policy gate on your own machine: an autonomy map, a forbidden-paths list, and a warden script that allows, gates, or refuses each proposed action. Then you attack it and watch it hold. Pure shell, five minutes.
+
+### Step 1 — Write the Pact as data
+
+```bash
+mkdir -p ~/codex-warden-lab && cd ~/codex-warden-lab
+
+# action → autonomy level (the ladder from Chapter 1, as machine-readable policy)
+cat > autonomy-map.txt <<'EOF'
+format-and-lint L4
+bump-patch-dependency L3
+implement-feature L2
+edit-database-migration L0
+EOF
+
+# paths no agent diff may ever touch unattended (the CODEOWNERS boundary, simulated)
+cat > forbidden-paths.txt <<'EOF'
+.github/workflows/
+src/auth/
+database/migrations/
+EOF
+```
+
+### Step 2 — Forge the Warden
+
+```bash
+cat > warden.sh <<'EOF'
+#!/usr/bin/env bash
+# warden.sh <action> <changed-file>... — allow, gate, or refuse
+set -euo pipefail
+action="$1"; shift
+
+level=$(awk -v a="$action" '$1 == a {print $2}' autonomy-map.txt)
+[ -n "$level" ] || { echo "🚫 REFUSED: unknown action '$action' — unmapped actions default to manual"; exit 1; }
+
+for f in "$@"; do
+  while read -r p; do
+    case "$f" in "$p"*) echo "🚫 REFUSED: '$f' is inside forbidden path '$p'"; exit 1;; esac
+  done < forbidden-paths.txt
+done
+
+case "$level" in
+  L0)      echo "🚫 REFUSED: '$action' is $level — never the agent's call"; exit 1 ;;
+  L1|L2)   if [ "${APPROVED:-no}" = "yes" ]; then
+             echo "✅ ALLOWED (gated): '$action' is $level and a human approved"
+           else
+             echo "⏸️  WAITING: '$action' is $level — set APPROVED=yes after human review"; exit 78
+           fi ;;
+  L3|L4)   echo "✅ ALLOWED: '$action' is $level — autonomous, audit-logged" ;;
+esac
+printf '{"ts":"%s","action":"%s","level":"%s","files":"%s","verdict":"allowed"}\n' \
+  "$(date -u +%FT%TZ)" "$action" "$level" "$*" >> ledger.jsonl
+EOF
+chmod +x warden.sh
+```
+
+### Step 3 — Petition the gate
+
+```bash
+./warden.sh format-and-lint src/app.js;                          echo "exit=$?"
+./warden.sh implement-feature src/routes/signup.ts;              echo "exit=$?"
+APPROVED=yes ./warden.sh implement-feature src/routes/signup.ts; echo "exit=$?"
+./warden.sh edit-database-migration database/migrations/001.sql; echo "exit=$?"
+```
+
+Expected — four different verdicts from one policy:
+
+```text
+✅ ALLOWED: 'format-and-lint' is L4 — autonomous, audit-logged
+exit=0
+⏸️  WAITING: 'implement-feature' is L2 — set APPROVED=yes after human review
+exit=78
+✅ ALLOWED (gated): 'implement-feature' is L2 and a human approved
+exit=0
+🚫 REFUSED: 'edit-database-migration' is L0 — never the agent's call
+exit=1
+```
+
+### Step 4 — Attack the Pact
+
+Now play the adversarial prompt. Try to smuggle a forbidden file under an innocent action, and try an action the policy has never heard of:
+
+```bash
+./warden.sh format-and-lint .github/workflows/deploy.yml; echo "exit=$?"
+./warden.sh casually-drop-the-database prod.sql;          echo "exit=$?"
+```
+
+Expected: both **REFUSED**, exit 1 — the forbidden path beats the friendly action name, and an unmapped action falls to manual by default. That is the definition from Chapter 2 made real: *a constraint that holds regardless of instruction.* Finish by reading `cat ledger.jsonl` — every allowed action left a ledger line recording what ran, at which level, against which files. Instruction, action, outcome: the three pillars, on your own bench.
+
+### Step 5 — Map it back to GitHub (where each piece really lives)
+
+| Lab piece | Production control |
+|---|---|
+| `autonomy-map.txt` | `.github/agent-autonomy.yml` read by a gate workflow |
+| `forbidden-paths.txt` | CODEOWNERS + branch protection |
+| `exit 78` waiting state | Environment with required reviewers |
+| `APPROVED=yes` | The reviewer clicking *Approve* on the run |
+| `ledger.jsonl` | The committed audit trail from Chapter 3 |
 
 ## ⚔️ The Quests of This Domain
 

--- a/pages/_quests/1100/agentic-codex-capstone-exam-trial.md
+++ b/pages/_quests/1100/agentic-codex-capstone-exam-trial.md
@@ -461,7 +461,7 @@ seal "S1: plan-then-execute workflow"     grep -ql "environment:" .github/workfl
 seal "S2: least-privilege permissions"    grep -ql "pull-requests: write" .github/workflows/plan-then-execute.yml
 seal "S2: MCP server configured"          test -s .vscode/mcp.json
 # Seal 3 — memory + drift
-seal "S3: persistent memory committed"    git log --oneline -- .agent/memory/ 2>/dev/null | grep -q .
+seal "S3: persistent memory committed"    sh -c 'git log --oneline -- .agent/memory/ | grep -q .'
 seal "S3: drift guard present"            test -x scripts/drift-guard.sh
 # Seal 4 — evaluation
 seal "S4: acceptance criteria schema"     jq -e '.criteria | length >= 3' work/gh-600/capstone/acceptance-criteria.json

--- a/pages/_quests/1100/agentic-codex-capstone-exam-trial.md
+++ b/pages/_quests/1100/agentic-codex-capstone-exam-trial.md
@@ -40,7 +40,7 @@ keywords:
   - GitHub Copilot certification
   - agentic codex master
   - all domains review
-lastmod: '2026-05-17T00:00:00.000Z'
+lastmod: '2026-07-01T00:00:00.000Z'
 permalink: /quests/1100/agentic-codex-capstone-exam-trial/
 quest_dependencies:
   required_quests:
@@ -76,7 +76,7 @@ rewards:
 prerequisites:
   knowledge_requirements:
   - ALL 19 prerequisite quests completed (see required_quests above)
-  - Review the skills-measured page at /docs/certifications/gh-600/skills-measured/
+  - Review the skills-measured page at /notes/gh-600/skills-measured/
   system_requirements:
   - GitHub repository with Copilot, Actions, and Environments fully configured
   - All tools and workflows from prior quests present and operational
@@ -117,7 +117,9 @@ graph TD
     style D6 fill:#4CAF50,stroke:#2E7D32,color:#fff
 ```
 
-## 🎯 Capstone Objectives
+## 🎯 Quest Objectives
+
+*Six seals, six domains — break them all to claim the trial:*
 
 - [ ] **Seal 1 (Domain 1 — 18%)**: Implement agent-in-SDLC and define boundaries
 - [ ] **Seal 2 (Domain 2 — 18%)**: Configure tools, permissions, MCP, environment integration
@@ -150,16 +152,6 @@ The following 6 chapters map directly to the GH-600 exam domains.
 <!-- work/gh-600/capstone/sdlc-diagram.md -->
 # Our Agentic SDLC
 
-## 🎯 Quest Objectives
-
-By the end of this quest, you will be able to:
-
-- [ ] Understand the core concepts introduced in this quest
-- [ ] Complete the hands-on exercises and verify the results
-- [ ] Apply what you learned to a follow-up scenario of your own design
-
-> *Note: objectives auto-seeded during framework alignment — authors should refine these to reflect this quest's specific skills.*
-
 ## Agent Integration Points
 
 | Phase | Agent Role | Trigger | Human Touchpoint |
@@ -176,8 +168,9 @@ By the end of this quest, you will be able to:
 
 ### Challenge 1.2: Demonstrate planning vs. action separation
 
-> **Task:** Show a GitHub Actions workflow that separates the plan step from the execute step with a mandatory break between them.
+> **Task:** Show a GitHub Actions workflow that separates the plan step from the execute step with a mandatory break between them. (The `raw`/`endraw` tags below are this site's Liquid escapes — drop them when you copy the YAML into your own `.github/workflows/`.)
 
+{% raw %}
 ```yaml
 # .github/workflows/plan-then-execute.yml
 name: Plan-Then-Execute (Sealed Capstone)
@@ -191,7 +184,7 @@ jobs:
     if: contains(github.event.label.name, 'agent-implement')
     runs-on: ubuntu-latest
     outputs:
-      plan_approved: ${% raw %}{{ steps.plan.outputs.approved }}{% endraw %}
+      plan_approved: ${{ steps.plan.outputs.approved }}
     steps:
       - name: Generate plan
         id: plan
@@ -219,6 +212,7 @@ jobs:
       - name: Execute approved plan
         run: echo "Executing plan after human approval..."
 ```
+{% endraw %}
 
 ### Challenge 1.3: Configure an observability workflow
 
@@ -446,19 +440,50 @@ After completing all 6 seals, publish your reflection:
 
 ## ✅ Capstone Validation
 
+The trial ends the way every domain taught you to end: with a **machine-verifiable verdict**, not a feeling. Create this script in your capstone repository and make it pass — it checks that every seal left its artifact behind:
+
 ```bash
-# Validate all 20 quests in the arc
-python3 test/quest-validator/quest_validator.py -d pages/_quests/
+cat > validate-capstone.sh <<'EOF'
+#!/usr/bin/env bash
+# validate-capstone.sh — each seal must have left its artifact behind
+set -uo pipefail
+fails=0
+seal() {  # description, test-command...
+  local desc="$1"; shift
+  if "$@" >/dev/null 2>&1; then echo "✅ $desc"
+  else echo "❌ $desc"; fails=$((fails + 1)); fi
+}
 
-# Check all 6 seals are present
-python3 work/gh-600/scripts/validate_capstone.py \
-  --registry _data/agents.yml \
-  --matrix _data/autonomy-matrix.yml \
-  --reflection work/gh-600/capstone/grand-reflection.md
+# Seal 1 — SDLC design + plan/act separation
+seal "S1: SDLC diagram exists"            test -s work/gh-600/capstone/sdlc-diagram.md
+seal "S1: plan-then-execute workflow"     grep -ql "environment:" .github/workflows/plan-then-execute.yml
+# Seal 2 — tools, permissions, MCP
+seal "S2: least-privilege permissions"    grep -ql "pull-requests: write" .github/workflows/plan-then-execute.yml
+seal "S2: MCP server configured"          test -s .vscode/mcp.json
+# Seal 3 — memory + drift
+seal "S3: persistent memory committed"    git log --oneline -- .agent/memory/ 2>/dev/null | grep -q .
+seal "S3: drift guard present"            test -x scripts/drift-guard.sh
+# Seal 4 — evaluation
+seal "S4: acceptance criteria schema"     jq -e '.criteria | length >= 3' work/gh-600/capstone/acceptance-criteria.json
+seal "S4: RCA document written"           grep -qil "5-why" forensics/*.md
+# Seal 5 — multi-agent
+seal "S5: agent registry (>= 3 agents)"   test "$(grep -c '^- name:' _data/agents.yml)" -ge 3
+seal "S5: orchestration workflow"         grep -ql "needs:" .github/workflows/council-fanout.yml
+# Seal 6 — governance
+seal "S6: autonomy matrix"                test -s _data/autonomy-matrix.yml
+seal "S6: CODEOWNERS boundary"            test -s .github/CODEOWNERS
+seal "S6: forbidden actions in AGENTS.md" grep -qi "forbidden" AGENTS.md
+# The reflection
+seal "🪞 Grand reflection published"      test -s work/gh-600/capstone/grand-reflection.md
 
-# Build site
-docker-compose exec jekyll bundle exec jekyll build
+echo
+[ "$fails" -eq 0 ] && echo "🏆 All seals hold — the trial is complete." \
+                   || { echo "⚔️  $fails seal(s) unbroken — return to the domain and finish the work."; exit 1; }
+EOF
+chmod +x validate-capstone.sh && ./validate-capstone.sh
 ```
+
+Adjust paths to match where your trial actually put each artifact — the script encodes the *contract* (every seal leaves evidence), not a sacred directory layout. A capstone whose validator passes on the first try was written after the artifacts; one that fails a few times first was written honestly.
 
 ---
 

--- a/pages/_quests/codex/agentic-codex.md
+++ b/pages/_quests/codex/agentic-codex.md
@@ -3,7 +3,7 @@ title: 'Epic Quest: The Agentic Codex'
 description: 'Earn the GitHub GH-600 — six chapters that build, evaluate, and govern autonomous AI agents on GitHub-native rails, from the SDLC to the Warden Pact.'
 excerpt: A six-chapter GH-600 campaign — build, tool, remember, evaluate, coordinate, and govern AI agents with Copilot, MCP, Actions, and the Models API.
 date: '2026-06-30T00:00:00.000Z'
-lastmod: '2026-06-30T00:00:00.000Z'
+lastmod: '2026-07-01T00:00:00.000Z'
 level: '1100'
 difficulty: '⚔️ Epic'
 estimated_time: 40-60 hours
@@ -144,6 +144,8 @@ The six chapters map one-to-one to the six GH-600 exam domains, with the same we
 | IV | [The Oracle Rubric: Evaluation & Tuning](/quests/1010/agentic-codex-04-evaluation-and-tuning/) | `1010` | D4 · Evaluation & Tuning (19%) | 🔴 Hard |
 | V | [The Council of Many: Multi-Agent Systems](/quests/1011/agentic-codex-05-multi-agent-coordination/) | `1011` | D5 · Multi-Agent Coordination (17%) | 🔴 Hard |
 | VI | [The Warden Pact: Guardrails & Accountability](/quests/1100/agentic-codex-06-guardrails-and-accountability/) | `1100` | D6 · Guardrails & Accountability (9%) | 🔴 Hard |
+
+> 🧪 **Every chapter ends at a workbench.** Each chapter closes with a hands-on lab you can run in minutes — most entirely on your own machine with `bash`, `jq`, and the `gh` CLI, no Copilot subscription required — so every domain's key pattern (the approval gate, the retry harness, the drift guard, the rubric grader, the council trace, the warden policy) is something you have actually watched work *and* watched fail.
 
 > 🏆 **Capstone gate.** The [Grand Capstone](/quests/1100/agentic-codex-capstone-exam-trial/) stands beyond Chapter VI. You cannot face the Trial of the Agentic Codex until all six domain seals are broken — it integrates every domain into a single working multi-agent system with observability, evaluation, and governance in place.
 


### PR DESCRIPTION
## Summary

A run-through of the **GH-600 epic (The Agentic Codex)** — hub, six chapters, and the Grand Capstone — improving the content and expanding every chapter with a hands-on example, per request.

### 1. A runnable 🧪 Hands-On Lab in every chapter

The chapters taught each domain well conceptually, but their code was illustrative and the Mastery Challenges were unguided checklists. Each chapter now closes with a worked lab — copy-paste runnable, with expected output shown, local-first so no Copilot subscription is needed (just `bash`, `jq`, and the `gh` CLI):

| Chapter | Lab |
|---|---|
| I — Agents in the SDLC | Stand up a real plan-then-act pipeline in a scratch repo: environment approval gate created via `gh api`, run pauses in *Waiting*, JSONL trace audited after approval |
| II — Tool Use & Environment | A deterministic retry/escalation harness: a tool that fails twice then succeeds, then a permanent fault — reproduce the Silent CI Failure and kill it with one `exit 1` |
| III — Memory & State | Build all three memory vaults locally (step outputs → artifact file → committed register) and watch the drift guard abort on a moved world with `exit=78` |
| IV — Evaluation & Tuning | A rubric grader as a pure function of signals: seven `jq` assertions, watch it fail for the right reason, then point it at a real PR with `gh pr view` |
| V — Multi-Agent Coordination | A three-agent council with a seeded handoff fault — stitch the correlation-ID trace and name the agent that *caused* the failure, not the one that crashed |
| VI — Guardrails & Accountability | A warden policy gate that allows (L4), gates (L2, `exit 78` until `APPROVED=yes`), and refuses (L0/forbidden paths) — then survives an adversarial petition |

Each lab ends by mapping the local pieces back to their production GitHub controls. The campaign hub now advertises the labs.

### 2. Grand Capstone repairs

- **Removed an auto-seeded "Quest Objectives" block that had been injected into the middle of a code example** (the `sdlc-diagram.md` sample), and instead renamed the real `## 🎯 Capstone Objectives` section to the validator's required heading — satisfying the check legitimately. The capstone's tier-1 score is now real (91.9%) instead of propped up by the injected block.
- Normalized the odd inline `${% raw %}…{% endraw %}` escape to the whole-block raw guard used everywhere else.
- Replaced the **Capstone Validation** section: it invoked `work/gh-600/scripts/validate_capstone.py` (doesn't exist anywhere) plus IT-Journey-maintainer commands. It now has the candidate build a self-contained `validate-capstone.sh` — one machine-verifiable check per seal, which is itself the Domain 4 lesson applied to the trial.

### 3. Stale link cleanup across the GH-600 family

The `_docs` collection no longer exists; its URLs only survive as redirects. Fixed in the epic chapters, five Domain sub-quests, and two GH-600 notes:
- Chronicle-post links (`/docs/agentic-codex/…`) → their canonical chapter quests (labels updated from "Chronicle post" to "Codex chapter")
- `/docs/certifications/gh-600/…` → `/notes/gh-600/…`
- Chapters III and IV no longer cite **their own redirect URL** as "the reference article this chapter teaches from" (circular); they now point at the study hub / evaluation-signals note
- All `redirect_from:` entries kept intact
- Dropped stale `# planned quest` comments in Chapter II frontmatter (those quests exist)

Note: a few unrelated dead `/docs/` links remain outside the GH-600 family (bash cheatsheets, world map, obsidian index) — left for a separate pass.

## Validation

- `make quest-audit` — ✅ passed (content 185/185 avg 94.3%, 0 broken deps, freshness in sync; capstone previously scored via the injected block, now passes on its own at 91.9%)
- `make content-audit` — ✅ passed
- `make liquid-check` — ✅ raw-guards clean across 265 files (all lab YAML with `${{ }}` is raw-guarded)
- `scripts/ci/brand_lint.py` on all edited files — ✅ on-brand, no glossary drift
- Every remapped link verified against a real `permalink:` in the repo

Content-only change; no layout/CSS/JS touched, so no screenshots required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEojXuotoSHa7SL7w9W7JU

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEojXuotoSHa7SL7w9W7JU)_