### PR TITLE
feat(agents): implement the GH-600 disciplines this repo teaches, and map them

### DIFF
--- a/.claude/agents/agent-auditor.md
+++ b/.claude/agents/agent-auditor.md
@@ -28,6 +28,12 @@ actually is, and you open one tightening PR only when they don't.
    - **Least privilege** — does each agent's `tools:` list match what its role needs?
      Flag any agent that can do more than its job (e.g. an editor that doesn't need
      `Write` to infra).
+   - **Policy surface** — does `_data/agents/registry.yml` still match reality
+     (a roster row per `.claude/agents/*.md` definition and vice versa; each row's
+     workflow, lane, and `*_ENABLED` kill switch correct), and do the guardrails
+     named in `_data/agents/autonomy-matrix.yml` and the Warden Pact in `AGENTS.md`
+     still exist as described? A row without a definition, a definition without a
+     row, or a named guardrail that no longer exists is drift to report.
    - **Completeness** — every agent referenced by a workflow exists; every skill an
      agent delegates to exists.
 3. **Apply the smallest edits** that fix real drift — correct a stale path, align a

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -40,6 +40,7 @@ These implement the AI-augmented CMS described in the root `CLAUDE.md` and
 
 | Workflow | Triggers | What it does |
 |---|---|---|
+| `agent-plan-then-act.yml` | dispatch (gated) | **The GH-600 reference pipeline.** A deterministic plan job → `agent-approval` Environment (required-reviewer human gate) → execute job with an artifact-carried plan, a `scripts/ai/drift-guard.sh` verify, a threaded correlation ID, and an audit artifact (instruction → action → outcome). Teaching-grade demo of the control plane the whole fleet shares; no model call, no auth needed. OFF behind `AGENT_DEMO_ENABLED`. Mapped in `/notes/gh-600/implemented-in-it-journey/`. |
 | `content-quality.yml` | PR on content | Deterministic brand lint (`scripts/ci/brand_lint.py`). **Spelling drift fails** the check; hype terms warn. No AI, no cost. |
 | `content-review.yml` | PR on content (gated) | `content-reviewer` agent editorial pass; applies small on-brand fixes, posts bigger ideas as comments. Never merges. |
 | `content-factory.yml` | daily 08:00 UTC (gated) | `content-curator` improves one page per collection from the `.cms` worklist → one `auto:content` PR each. |

--- a/.github/workflows/agent-plan-then-act.yml
+++ b/.github/workflows/agent-plan-then-act.yml
@@ -1,0 +1,173 @@
+# =============================================================================
+# agent-plan-then-act.yml — the GH-600 reference pipeline, live in this repo
+# -----------------------------------------------------------------------------
+# The canonical plan-then-act pattern from The Agentic Codex, implemented as a
+# working workflow so learners (and the fleet) can watch every discipline hold:
+#
+#   D1 — planning is a separate job from acting; the execute job sits WAITING
+#        behind the `agent-approval` Environment until a human approves.
+#   D3 — the plan crosses the job boundary as an ARTIFACT (Tier-2 session
+#        memory), and a drift-guard snapshot aborts the act phase if the
+#        governance surface changed while the run waited (exit 78).
+#   D5 — a correlation ID minted in `plan` is threaded through job outputs,
+#        step summaries, trace lines, and artifact names, so the whole run
+#        reassembles into one auditable narrative.
+#   D6 — least-privilege by omission (`contents: read` is the ONLY grant), an
+#        Environment gate on the irreversible half, and an audit artifact
+#        recording instruction → action → outcome.
+#
+# The "agent" here is deliberately a deterministic stub (no model call, no
+# auth needed): the pipeline demonstrates the CONTROL PLANE the fleet's real
+# workflows share. Swap the stub step for `scripts/ai/run.sh` to make it live.
+#
+# OFF by default behind AGENT_DEMO_ENABLED (a repo variable). One-time setup:
+#   1. Settings → Environments → new environment `agent-approval` → add a
+#      required reviewer (yourself), or:
+#        gh api -X PUT repos/{owner}/{repo}/environments/agent-approval \
+#          --input <(echo '{"reviewers":[{"type":"User","id":<your-id>}]}')
+#   2. gh variable set AGENT_DEMO_ENABLED --body true --repo bamr87/it-journey
+# Until both exist this idles as a clean no-op (and without the environment's
+# required reviewer, the gate would not hold — create it FIRST).
+#
+# Taught by: /quests/0111/agentic-codex-01-agents-in-the-sdlc/ (whole pattern),
+#            /quests/1001/agentic-codex-03-memory-state-and-execution/ (memory),
+#            /quests/1011/agentic-codex-05-multi-agent-coordination/ (tracing),
+#            /quests/1100/agentic-codex-06-guardrails-and-accountability/ (gates).
+# Mapped in: /notes/gh-600/implemented-in-it-journey/
+# =============================================================================
+name: 🜂 Agent Plan-then-Act (GH-600 reference)
+
+on:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: 'One-line task brief the plan is drawn for (the "instruction" of the audit record).'
+        required: false
+        default: 'Demonstrate the plan-then-act control plane end to end.'
+
+permissions:
+  contents: read   # least privilege by omission — this pipeline proposes, it never writes
+
+concurrency:
+  group: agent-plan-then-act
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    if: vars.AGENT_DEMO_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      cid: ${{ steps.mint.outputs.cid }}
+    env:
+      TASK: ${{ inputs.task }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Mint the correlation ID (D5 — one name for the whole run)
+        id: mint
+        run: echo "cid=codex-${{ github.run_id }}-${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
+
+      - name: Produce the structured plan (no changes — planning only)
+        run: |
+          mkdir -p .agent
+          python3 - "$TASK" <<'PY'
+          import json, sys
+          json.dump({
+              "schema": "agent-plan/v1",
+              "task": sys.argv[1],
+              "inputs": ["repository at the pinned run SHA", "the task brief above"],
+              "tools_allowed": ["read_files"],
+              "steps": ["snapshot governance surface", "await human seal", "verify drift", "act"],
+              "success_criteria": ["execute job ran only after approval",
+                                    "drift guard verified before acting",
+                                    "audit artifact records instruction, action, outcome"],
+              "stop_conditions": ["approval rejected", "context drift detected"],
+          }, open(".agent/plan.json", "w"), indent=2)
+          PY
+          echo "Plan written:" && cat .agent/plan.json
+
+      - name: Snapshot the governance surface (D3 — the world the plan was drawn against)
+        run: |
+          DRIFT_SNAPSHOT=.agent/snapshot.sha256 scripts/ai/drift-guard.sh snapshot \
+            AGENTS.md .github/CODEOWNERS _data/agents/autonomy-matrix.yml _data/agents/registry.yml
+
+      - name: Emit the plan-phase trace (D5 — every action, one JSONL line)
+        env:
+          CID: ${{ steps.mint.outputs.cid }}
+        run: |
+          printf '{"cid":"%s","agent":"planner","event":"plan-ready","task":"%s"}\n' \
+            "$CID" "$(echo "$TASK" | tr '"' "'")" >> .agent/trace.jsonl
+          {
+            echo "### 🗺️ Plan ready — run \`$CID\`"
+            echo "- task: $TASK"
+            echo "- the execute job now WAITS for the \`agent-approval\` environment reviewer"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Hand the plan across the job boundary (D3 — Tier-2 session memory)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: agent-plan-${{ steps.mint.outputs.cid }}
+          path: .agent/
+
+  execute:
+    needs: plan
+    if: vars.AGENT_DEMO_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # D1/D6 — the human seal: this job does not start until a required reviewer
+    # on the `agent-approval` environment approves the pending deployment.
+    environment: agent-approval
+    env:
+      CID: ${{ needs.plan.outputs.cid }}
+    steps:
+      # Deliberately the LIVE branch tip, not the pinned run SHA: the approval
+      # wait is real time, and if a commit touched the governance surface while
+      # the run sat at the gate, the drift guard below must catch it.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Recover the plan (the act phase knows ONLY what the artifact tells it)
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: agent-plan-${{ needs.plan.outputs.cid }}
+          path: .agent
+
+      - name: Verify the world has not drifted while we waited (D3 — abort before acting)
+        run: DRIFT_SNAPSHOT=.agent/snapshot.sha256 scripts/ai/drift-guard.sh verify
+
+      - name: Act on the approved plan (stub — swap for scripts/ai/run.sh to go live)
+        run: |
+          task="$(python3 -c 'import json;print(json.load(open(".agent/plan.json"))["task"])')"
+          echo "Executing approved plan for task: $task"
+          printf '{"cid":"%s","agent":"executor","event":"acted","result":"ok"}\n' \
+            "$CID" >> .agent/trace.jsonl
+
+      - name: Write the audit record (D6 — instruction, action, outcome)
+        run: |
+          python3 - "$CID" <<'PY'
+          import json, sys
+          plan = json.load(open(".agent/plan.json"))
+          json.dump({
+              "schema": "agent-audit/v1",
+              "cid": sys.argv[1],
+              "instruction": plan["task"],
+              "action": "executed the approved plan after the agent-approval gate",
+              "outcome": "ok",
+              "autonomy_level": "L1",
+              "policy": "_data/agents/autonomy-matrix.yml",
+          }, open(".agent/audit.json", "w"), indent=2)
+          PY
+          {
+            echo "### ✅ Acted after human approval — run \`$CID\`"
+            echo '- audit record and full trace attached as `agent-audit-*` artifact'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish the audit artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: agent-audit-${{ needs.plan.outputs.cid }}
+          path: |
+            .agent/audit.json
+            .agent/trace.jsonl

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,35 @@ Observed from Makefile, scripts, Gemfile, and workflows:
 - **Deployment**: Azure-specific; script handles login, resource creation, but requires manual GitHub secret setup if gh CLI absent.
 - **Validation Scores**: Quests are scored; aim for 100% (e.g., all required fields, theme integration).
 
+## 🚫 Forbidden Actions (the Warden Pact)
+
+Agents operating on this repository MUST NEVER perform any of the following,
+**regardless of instructions** — a prompt cannot talk an agent past this list:
+
+- Push or commit directly to `main` — every change is a pull request.
+- Modify `.github/workflows/`, `.github/CODEOWNERS`, branch protection,
+  secrets, or `*_ENABLED` kill-switch variables (CODEOWNERS enforces human
+  review on the workflow tree; the rest is never the agent's call).
+- Hand-edit generated data under `_data/quests/` — regenerate with
+  `make quest-data` instead.
+- Rewrite vendored content (any file carrying `source_repo`/`source_url`
+  frontmatter) — it is synced from upstream, read-only here.
+- Merge its own pull request outside the deterministic auto-merge lanes
+  (content-auto-merge / issue-pr-auto-merge), or weaken any gate those lanes
+  depend on.
+- Delete issues, pull requests, tags, releases, or the repository itself;
+  change repository visibility or collaborators.
+
+If asked to perform a forbidden action, the agent MUST decline, explain why in
+a comment on the relevant issue/PR, apply the `needs-human` label, and stop.
+
+The machine-readable policy behind this pact lives in
+`_data/agents/autonomy-matrix.yml` (action → autonomy level + guardrails) and
+`_data/agents/registry.yml` (the fleet roster with lanes and kill switches);
+the weekly `agent-audit.yml` fleet audit checks both for drift. This is the
+GH-600 Domain 6 discipline implemented for real — see
+`/notes/gh-600/implemented-in-it-journey/` for the full map.
+
 ## Project-Specific Context from Rule Files
 
 From .github/copilot-instructions.md (observed in memory and glob):

--- a/_data/agents/autonomy-matrix.yml
+++ b/_data/agents/autonomy-matrix.yml
@@ -1,0 +1,87 @@
+# =============================================================================
+# _data/agents/autonomy-matrix.yml — action → autonomy level (GH-600 Domain 6)
+# -----------------------------------------------------------------------------
+# Every recurring agent action on this repository, classified by the three
+# risk factors the Warden weighs — reversibility, blast radius, predictability —
+# and pinned to the autonomy ladder:
+#
+#   L0 manual · L1 assisted · L2 supervised · L3 monitored · L4 autonomous
+#
+# The rule: assign the HIGHEST level the risk profile allows, not one rung
+# higher. Each row names the guardrails that make its level safe; if a
+# guardrail is removed, the level must drop until it is restored.
+#
+# HAND-MAINTAINED policy, reviewed by the weekly agent-audit.yml fleet audit.
+# Taught by: /quests/1100/agentic-codex-06-guardrails-and-accountability/
+# =============================================================================
+- action: regenerate-quest-data
+  description: make quest-data — regenerate _data/quests/*, navigation, network from frontmatter
+  autonomy_level: L4
+  reversibility: high        # deterministic output of committed inputs; git revert restores
+  blast_radius: minimal
+  guardrails:
+    - quest-validation CI fails on stale or hand-edited generated data
+
+- action: open-content-improvement-pr
+  description: content-factory / issue-resolver / quest-forge propose content PRs
+  autonomy_level: L2
+  reversibility: high        # a PR is a proposal, not a change
+  blast_radius: low
+  guardrails:
+    - '*_ENABLED kill switch + Claude auth secret (OFF by default)'
+    - PR only — agents never push to main (AGENTS.md Warden Pact)
+    - brand-gate + frontmatter + quest-validation required checks
+
+- action: auto-merge-content-pr
+  description: content-auto-merge squash-merges a content-only PR when every check is green
+  autonomy_level: L3
+  reversibility: medium      # squash-merge is revertable, but it shipped
+  blast_radius: low
+  guardrails:
+    - classify_changes.py smuggle guard (content-only diff or no merge)
+    - deterministic brand_lint gate (spelling drift blocks)
+    - all required checks green; human can veto any open PR
+
+- action: fix-walked-quest
+  description: quest-fix repairs a walkthrough's verified issues and opens a fix PR
+  autonomy_level: L3
+  reversibility: high
+  blast_radius: low
+  guardrails:
+    - deterministic keep/revert gate — the model never grades its own work
+    - content-only add-paths; vendored (source_repo) files hard-fail
+    - ledger skip on stuck/needs_human slices
+
+- action: walkthrough-report
+  description: quest-walker plays a slice and publishes an evidence report
+  autonomy_level: L2
+  reversibility: high        # read-only over content; output is a report PR
+  blast_radius: minimal
+  guardrails:
+    - read-only lane; never edits quest content, never merges
+
+- action: close-stale-bot-issue
+  description: issue autopilot closes triaged stale bot-noise issues
+  autonomy_level: L3
+  reversibility: high        # closed issues reopen with one click
+  blast_radius: low
+  guardrails:
+    - triager only labels; a deterministic gated step (ISSUE_AUTOCLOSE_ENABLED) closes
+
+- action: edit-workflows-or-infra
+  description: any change under .github/workflows/, scripts/ci/, or agent definitions
+  autonomy_level: L0
+  reversibility: low         # a bad workflow can act before it is caught
+  blast_radius: high
+  guardrails:
+    - forbidden to the fleet (AGENTS.md Warden Pact)
+    - CODEOWNERS requires @bamr87 review on /.github/workflows/
+
+- action: modify-guardrails
+  description: CODEOWNERS, branch protection, secrets, kill-switch variables, this matrix
+  autonomy_level: L0
+  reversibility: low
+  blast_radius: high
+  guardrails:
+    - never the agent's call — humans only, by definition
+    - the audit trail (workflow logs + PR history) records any attempt

--- a/_data/agents/registry.yml
+++ b/_data/agents/registry.yml
@@ -1,0 +1,106 @@
+# =============================================================================
+# _data/agents/registry.yml — the fleet roster (GH-600 Domain 5: lifecycle)
+# -----------------------------------------------------------------------------
+# The machine-readable source of truth for every AI agent operating on this
+# repository. Provisioning = add a row; deprecation = flip `status` to
+# `deprecated` (it still runs, no new dependencies on it); retirement = flip to
+# `retired` (its workflow gate stays OFF). Past runs stay auditable because
+# workflow logs and PR history outlive the roster row.
+#
+# HAND-MAINTAINED (not generated). The weekly agent-audit.yml fleet audit
+# checks this roster against .claude/agents/*.md and the workflow gates —
+# a row without a definition file, or a definition without a row, is drift.
+#
+# status: active | deprecated | retired
+# lane:   read-only (never edits content) | content-write (edits via gated PRs)
+# Taught by: /quests/1011/agentic-codex-05-multi-agent-coordination/
+# =============================================================================
+- name: agent-auditor
+  definition: .claude/agents/agent-auditor.md
+  workflow: .github/workflows/agent-audit.yml
+  role: Weekly drift audit of the fleet itself — keeps agents/skills/workflows accurate and least-privilege
+  lane: content-write
+  kill_switch: AGENT_AUDIT_ENABLED
+  owner: bamr87
+  status: active
+  review_date: 2026-10-01
+
+- name: content-curator
+  definition: .claude/agents/content-curator.md
+  workflow: .github/workflows/content-factory.yml
+  role: Improves ONE page per collection from the .cms worklist, opens one gated auto:content PR
+  lane: content-write
+  kill_switch: CONTENT_FACTORY_ENABLED
+  owner: bamr87
+  status: active
+  review_date: 2026-10-01
+
+- name: content-reviewer
+  definition: .claude/agents/content-reviewer.md
+  workflow: .github/workflows/content-review.yml
+  role: Editorial pass on content PRs — small on-brand fixes to the branch, bigger ideas as comments
+  lane: content-write
+  kill_switch: CONTENT_REVIEW_ENABLED
+  owner: bamr87
+  status: active
+  review_date: 2026-10-01
+
+- name: issue-triager
+  definition: .claude/agents/issue-triager.md
+  workflow: .github/workflows/issue-autopilot.yml
+  role: Analyzes open issues into PR-sized batches — comments and labels only; a gated step does any closing
+  lane: read-only
+  kill_switch: ISSUE_AUTOPILOT_ENABLED
+  owner: bamr87
+  status: active
+  review_date: 2026-10-01
+
+- name: issue-resolver
+  definition: .claude/agents/issue-resolver.md
+  workflow: .github/workflows/issue-autopilot.yml
+  role: Resolves ONE triaged batch into one grouped auto:issue PR
+  lane: content-write
+  kill_switch: ISSUE_RESOLVE_ENABLED
+  owner: bamr87
+  status: active
+  review_date: 2026-10-01
+
+- name: quest-forge
+  definition: .claude/agents/quest-forge.md
+  workflow: .github/workflows/quest-forge.yml
+  role: Turns an epic-quest proposal issue into a validated campaign in pages/_quests/codex/ — one auto:quest PR
+  lane: content-write
+  kill_switch: QUEST_FORGE_ENABLED
+  owner: bamr87
+  status: active
+  review_date: 2026-10-01
+
+- name: quest-walker
+  definition: .claude/agents/quest-walker.md
+  workflow: .github/workflows/quest-walkthrough.yml
+  role: Plays one (character, level) quest slice end-to-end as a learner — evidence report PR, read-only over content
+  lane: read-only
+  kill_switch: QUEST_WALKTHROUGH_ENABLED
+  owner: bamr87
+  status: active
+  review_date: 2026-10-01
+
+- name: quest-fixer
+  definition: .claude/agents/quest-fixer.md
+  workflow: .github/workflows/quest-fix.yml
+  role: Repairs ONLY a walkthrough's verified issues under a deterministic keep/revert gate — never grades its own work
+  lane: content-write
+  kill_switch: QUEST_FIX_ENABLED
+  owner: bamr87
+  status: active
+  review_date: 2026-10-01
+
+- name: theme-scout
+  definition: .claude/agents/theme-scout.md
+  workflow: .github/workflows/theme-scout.yml
+  role: Frontend canary — classifies theme-vs-content defects and files theme issues upstream; never fixes
+  lane: read-only
+  kill_switch: THEME_SCOUT_ENABLED
+  owner: bamr87
+  status: active
+  review_date: 2026-10-01

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,47 @@
+# Agent Evaluation & Tuning (GH-600 Domain 4, implemented)
+
+How this repository grades its agents with **machine-verifiable signals**,
+diagnoses failures instead of re-running them, and tunes instructions like
+code. This directory is the Domain 4 convention the fleet operates under;
+the campaign that teaches it is
+[Chapter IV — The Oracle Rubric](https://it-journey.dev/quests/1010/agentic-codex-04-evaluation-and-tuning/),
+and the full domain→artifact map is
+[GH-600 in the Wild](https://it-journey.dev/notes/gh-600/implemented-in-it-journey/).
+
+## The rubric: machine-verifiable gates (no vibes)
+
+Every agent-produced change is graded by deterministic signals — never by the
+model's own opinion of its work:
+
+| Signal | Source | Gate |
+|---|---|---|
+| Quest content quality ≥ 70% | `scripts/quest/quest_audit.py` (tier-1 score) | `quest-validation` required check |
+| Brand voice / no spelling drift | `scripts/ci/brand_lint.py` | `brand-gate` required check — drift **blocks auto-merge** |
+| Content-only diff (no smuggling) | `scripts/ci/classify_changes.py` | `content-auto-merge` refuses mixed PRs |
+| Frontmatter contract | `scripts/validation/frontmatter-validator.py` | `frontmatter-validation` required check |
+| Generated data freshness | `make quest-data` diff check | `quest-fix` M2 safety rail hard-fails on stale data |
+| Fix actually helped | tier-1 score + brand lint + sandbox commands, before vs after | quest-fix **deterministic keep/revert gate** |
+
+The keep/revert gate is the purest Domain 4 artifact in the repo: the
+quest-fixer's edit is kept **only** if the deterministic signal improved —
+the model never grades its own work.
+
+## Failure handling: RCA before re-run
+
+Re-running a failed agent without understanding it manufactures intermittent
+failures that never get fixed. When a fleet run fails:
+
+1. Pull the forensic trail: `gh run download <RUN_ID> --dir ./forensics/run-<RUN_ID>`
+2. Classify the failure by **layer** (reasoning / tool misuse / permissions /
+   context drift / environment / completion).
+3. Drive it to a root cause with 5-Why using [`rca-template.md`](rca-template.md).
+4. Ship the prevention, and record it in the instruction changelog below.
+
+## Tuning: instructions are code
+
+Changes to agent behavior land in `.claude/agents/*.md`, `.claude/skills/`,
+`AGENTS.md`, or `.github/copilot-instructions.md` — versioned, reviewed, and
+logged in [`instructions-changelog.md`](instructions-changelog.md) with the
+reason and the measured (or pending) outcome. One variable at a time;
+baseline before, measure after. The weekly `agent-audit.yml` fleet audit is
+the standing review that keeps instructions, registry, and reality aligned.

--- a/docs/agents/instructions-changelog.md
+++ b/docs/agents/instructions-changelog.md
@@ -1,0 +1,32 @@
+# Agent Instruction Changelog
+
+Every change to agent behavior — `AGENTS.md`, `.claude/agents/*.md`,
+`.claude/skills/`, `.github/copilot-instructions.md`, or the policy data under
+`_data/agents/` — gets an entry: **what changed, why (the observation that
+motivated it), and the measured outcome**. One variable at a time. This is the
+GH-600 Domain 4 discipline of treating instructions like code; the format is
+taught in [Chapter IV — The Oracle Rubric](https://it-journey.dev/quests/1010/agentic-codex-04-evaluation-and-tuning/).
+
+## 2026-07-01
+
+### AGENTS.md
+
+- **Added:** the "🚫 Forbidden Actions (the Warden Pact)" section — an explicit
+  list of actions no agent may take regardless of instructions, with the
+  decline-comment-label-stop protocol.
+  - **Reason:** the fleet's boundaries lived implicitly across nine workflow
+    header comments and agent definitions; nothing stated them in the one file
+    every agent reads first. GH-600 Domain 6 implementation surfaced the gap.
+  - **Outcome:** TBD — first measure at the next weekly `agent-audit.yml`
+    fleet audit (does the auditor find zero pact/reality drift?).
+
+### _data/agents/ (new policy surface)
+
+- **Added:** `registry.yml` (fleet roster: lane, kill switch, status,
+  review date per agent) and `autonomy-matrix.yml` (recurring action →
+  L0–L4 autonomy level + the guardrails that justify it).
+  - **Reason:** lifecycle management (D5) and risk-based autonomy (D6) need a
+    machine-readable source of truth, not folklore; the weekly audit now has
+    a contract to check the fleet against.
+  - **Outcome:** TBD — measured by audit findings over the next quarter
+    (`review_date: 2026-10-01` on every roster row).

--- a/docs/agents/rca-template.md
+++ b/docs/agents/rca-template.md
@@ -1,0 +1,43 @@
+# Agent Failure RCA — <date> <short title>
+
+> Copy this file to `docs/agents/rca/<YYYY-MM-DD>-<slug>.md` and fill it in
+> before any re-run. Taxonomy and method are taught in
+> [Chapter IV — The Oracle Rubric](https://it-journey.dev/quests/1010/agentic-codex-04-evaluation-and-tuning/).
+
+## Incident
+
+- **Run:** <Actions run URL>
+- **Agent / workflow:** <name from `_data/agents/registry.yml`>
+- **Task:** <issue/PR link or slice id>
+- **Failure mode (one sentence):**
+
+## Layer classification
+
+Pick ONE primary layer (the fix differs entirely by layer):
+
+- [ ] Reasoning / planning — the agent built the wrong thing
+- [ ] Tool misuse — a tool was called with bad arguments
+- [ ] Permissions — an API refused the token's scope
+- [ ] Context drift — the world changed under the plan
+- [ ] Environment — a file, secret, or dependency was missing
+- [ ] Completion — success declared before the signals said so
+
+**Evidence** (log lines, diff, trace excerpt):
+
+## 5-Why
+
+1. Why did it fail? →
+2. Why? →
+3. Why? →
+4. Why? →
+5. Why? →
+
+## Root cause
+
+<Almost always terminates at *our* system — instructions, tools, environment —
+not at "the model is dumb". Name the file that owns the fix.>
+
+## Prevention (shipped)
+
+- <change + PR link>
+- Recorded in [`instructions-changelog.md`](instructions-changelog.md): yes/no

--- a/pages/_notes/gh-600/implemented-in-it-journey.md
+++ b/pages/_notes/gh-600/implemented-in-it-journey.md
@@ -1,0 +1,120 @@
+---
+title: 'GH-600 in the Wild: Implemented in IT-Journey'
+description: Every GH-600 domain implemented in the IT-Journey repo — live workflows, policy data, and scripts demonstrating each exam skill, mapped file by file.
+date: '2026-07-01T00:00:00.000Z'
+lastmod: '2026-07-01T00:00:00.000Z'
+layout: default
+permalink: /notes/gh-600/implemented-in-it-journey/
+author: IT-Journey Team
+tags:
+- gh-600
+- agentic-ai
+- reference-implementation
+- automation
+categories:
+- Notes
+draft: false
+---
+# GH-600 in the Wild: Implemented in IT-Journey
+
+The Agentic Codex is not a thought experiment — **this repository runs on the
+disciplines the exam tests.** An AI fleet drafts content, walks quests as a
+learner, repairs what it witnessed breaking, triages issues, and audits
+itself — every lane behind kill switches, deterministic gates, and a human
+merge button. This note maps each GH-600 domain to the live artifact that
+implements it, so you can read real source instead of imagining it.
+
+**How to use this page:** study a chapter, then open the artifact and see the
+same pattern holding production weight. Each path links to the source on
+GitHub; each row names the chapter that teaches the concept.
+
+## The control plane in one workflow
+
+[`.github/workflows/agent-plan-then-act.yml`](https://github.com/bamr87/it-journey/blob/main/.github/workflows/agent-plan-then-act.yml)
+is the campaign's reference pipeline, live: a `plan` job that only plans, an
+`execute` job held **Waiting** behind the `agent-approval` Environment, the
+plan crossing the boundary as an artifact, a drift-guard verify before acting,
+a correlation ID threading every step, and an audit artifact recording
+instruction → action → outcome. It is OFF by default behind
+`AGENT_DEMO_ENABLED`, exactly like every other agent lane here.
+
+## Domain 1 — Agentic AI in the SDLC (18%)
+
+| Sub-skill | Implemented by | What it proves |
+|---|---|---|
+| Bounded agents with defined entry/exit | [`_data/agents/registry.yml`](https://github.com/bamr87/it-journey/blob/main/_data/agents/registry.yml) + [`.claude/agents/`](https://github.com/bamr87/it-journey/tree/main/.claude/agents) | Nine named agents, each with ONE role, a lane (read-only vs content-write), and a kill switch |
+| Plan vs action separation | [`agent-plan-then-act.yml`](https://github.com/bamr87/it-journey/blob/main/.github/workflows/agent-plan-then-act.yml); walk→fix split in [`quest-perfection.yml`](https://github.com/bamr87/it-journey/blob/main/.github/workflows/quest-perfection.yml) | The quest loop's *walker* only witnesses (read-only); a separate *fixer* acts — planning and acting are different jobs, even different workflows |
+| Observability & control | Workflow step summaries + committed [`.quests/ledger.json`](https://github.com/bamr87/it-journey/blob/main/.quests/README.md) + `.quests/DASHBOARD.md` | Every autonomous run leaves a trace a human can audit without re-running |
+
+*Taught by [Chapter I — Initiation Rites](/quests/0111/agentic-codex-01-agents-in-the-sdlc/).*
+
+## Domain 2 — Tool Use & Environment (18%)
+
+| Sub-skill | Implemented by | What it proves |
+|---|---|---|
+| Tool selection & least privilege | `permissions:` blocks in every workflow (default `contents: read`); [`scripts/ai/run.sh`](https://github.com/bamr87/it-journey/blob/main/scripts/ai/run.sh) `--tools` allow-list | Grants are per-job and by omission; the runner passes agents only the tools the task names |
+| MCP server configuration | [`.vscode/mcp.json`](https://github.com/bamr87/it-journey/blob/main/.vscode/mcp.json) (editor, `promptString` token) + [`scripts/ai/mcp/github-readonly.json`](https://github.com/bamr87/it-journey/blob/main/scripts/ai/mcp/github-readonly.json) (runner, env token) | Declared servers, secrets never committed, allow-list at the call site |
+| Environment integration | [`AGENTS.md`](https://github.com/bamr87/it-journey/blob/main/AGENTS.md) + [`.github/copilot-instructions.md`](https://github.com/bamr87/it-journey/blob/main/.github/copilot-instructions.md) + [`_data/ai.yml`](https://github.com/bamr87/it-journey/blob/main/_data/ai.yml) | The realm's law, written for the agent; ONE config file for every model call |
+| Safe execution paths | Claude-Code→API fallback in `run.sh`; `timeout-minutes` + `concurrency` on every lane; `needs-human` escalation | Failures retry once (fallback), then surface loudly — never a silent green |
+
+*Taught by [Chapter II — Forging the Arsenal](/quests/1000/agentic-codex-02-tool-use-and-environment/).*
+
+## Domain 3 — Memory, State & Execution (19%)
+
+| Sub-skill | Implemented by | What it proves |
+|---|---|---|
+| Three memory tiers | Job outputs (ephemeral) · walk-plan/evidence **artifacts** between walk and fix jobs (session) · committed [`.quests/ledger.json`](https://github.com/bamr87/it-journey/blob/main/.quests/README.md) + [`.cms/`](https://github.com/bamr87/it-journey/blob/main/.cms/README.md) index (persistent) | State lives in the tier that matches how long it must survive |
+| Durable progress, resumability | The quest-perfection **ledger**: each slice's status survives across daily runs; stuck/needs_human slices are skipped, not repeated | The next run reads the register and continues instead of repeating |
+| Context-drift detection | [`scripts/ai/drift-guard.sh`](https://github.com/bamr87/it-journey/blob/main/scripts/ai/drift-guard.sh), wired between plan and act in the reference pipeline | Snapshot at plan time, verify before acting, exit 78 aborts on a moved world |
+
+*Taught by [Chapter III — Vaults of Recollection](/quests/1001/agentic-codex-03-memory-state-and-execution/).*
+
+## Domain 4 — Evaluation & Tuning (19%)
+
+| Sub-skill | Implemented by | What it proves |
+|---|---|---|
+| Machine-verifiable success criteria | [`scripts/quest/quest_audit.py`](https://github.com/bamr87/it-journey/blob/main/scripts/quest/quest_audit.py) (tier-1 score ≥ 70%) · [`scripts/ci/brand_lint.py`](https://github.com/bamr87/it-journey/blob/main/scripts/ci/brand_lint.py) · [`scripts/ci/classify_changes.py`](https://github.com/bamr87/it-journey/blob/main/scripts/ci/classify_changes.py) | "Done" is a function of signals, not an opinion — drift blocks the merge |
+| The model never grades itself | The **deterministic keep/revert gate** in [`quest-fix.yml`](https://github.com/bamr87/it-journey/blob/main/.github/workflows/quest-fix.yml) | An edit is kept only if the deterministic signal improved — never on the model's own grade |
+| Failure RCA | [`docs/agents/rca-template.md`](https://github.com/bamr87/it-journey/blob/main/docs/agents/rca-template.md) + `gh run download` forensics convention | Classify by layer, 5-Why to a root cause in *our* system, then ship the prevention |
+| Instructions as code | [`docs/agents/instructions-changelog.md`](https://github.com/bamr87/it-journey/blob/main/docs/agents/instructions-changelog.md) | Every behavior change carries its reason and its measured outcome |
+
+*Taught by [Chapter IV — The Oracle Rubric](/quests/1010/agentic-codex-04-evaluation-and-tuning/).*
+
+## Domain 5 — Multi-Agent Coordination (17%)
+
+| Sub-skill | Implemented by | What it proves |
+|---|---|---|
+| Orchestration patterns | [`quest-perfection.yml`](https://github.com/bamr87/it-journey/blob/main/.github/workflows/quest-perfection.yml) **chains** walk → fix per slice; the fleet's daily lanes run in parallel isolation (one PR each, non-overlapping scopes) | Chain for dependent work, fan-out for independent work, reconciliation at the join (auto-merge lanes) |
+| Distributed tracing | Correlation ID threaded through jobs, summaries, and artifact names in [`agent-plan-then-act.yml`](https://github.com/bamr87/it-journey/blob/main/.github/workflows/agent-plan-then-act.yml); slice ids + ledger entries across walk/fix | One identifier reassembles a multi-job run into a single narrative |
+| Failure recovery | `continue-on-error`/skip semantics in the perfection loop; ledger marks slices `stuck`/`needs_human` (escalate) instead of blind retry | Stalled vs conflicting handled differently; escalation is a first-class outcome |
+| Lifecycle management | [`_data/agents/registry.yml`](https://github.com/bamr87/it-journey/blob/main/_data/agents/registry.yml) + weekly [`agent-audit.yml`](https://github.com/bamr87/it-journey/blob/main/.github/workflows/agent-audit.yml) | Provision by row, deprecate by status flip, audited quarterly (`review_date`) |
+
+*Taught by [Chapter V — The Council of Many](/quests/1011/agentic-codex-05-multi-agent-coordination/).*
+
+## Domain 6 — Guardrails & Accountability (9%)
+
+| Sub-skill | Implemented by | What it proves |
+|---|---|---|
+| Risk-based autonomy levels | [`_data/agents/autonomy-matrix.yml`](https://github.com/bamr87/it-journey/blob/main/_data/agents/autonomy-matrix.yml) | Every recurring action classified L0–L4 by reversibility, blast radius, predictability — with the guardrails that justify the level |
+| File-scope boundary | [`.github/CODEOWNERS`](https://github.com/bamr87/it-journey/blob/main/.github/CODEOWNERS) | The workflow tree and quest framework demand a named human reviewer |
+| Human approval gate | The `agent-approval` Environment in the reference pipeline; every AI lane's `*_ENABLED` kill switch + auth secret (both required, OFF by default) | Autonomy is opt-in twice, and the irreversible half waits for a human |
+| Forbidden-actions pact | The Warden Pact in [`AGENTS.md`](https://github.com/bamr87/it-journey/blob/main/AGENTS.md) | A constraint that holds regardless of instruction — decline, comment, label, stop |
+| Audit trail | Committed ledger + Actions run logs + PR history + the audit artifact in the reference pipeline | Instruction, action, and outcome reconstructable from the repo's own history |
+
+*Taught by [Chapter VI — The Warden Pact](/quests/1100/agentic-codex-06-guardrails-and-accountability/).*
+
+## Try it yourself
+
+1. Read a chapter, then its artifact above — the pattern is identical, at scale.
+2. Run the reference pipeline in your fork: create the `agent-approval`
+   Environment with yourself as required reviewer, set
+   `AGENT_DEMO_ENABLED=true`, dispatch **🜂 Agent Plan-then-Act**, and watch the
+   execute job wait for your seal.
+3. Face the [Grand Capstone](/quests/1100/agentic-codex-capstone-exam-trial/) —
+   this repository is a worked answer key, but the trial wants *your* build.
+
+## Related
+
+- [Epic Quest: The Agentic Codex](/quests/codex/agentic-codex/) — the campaign hub
+- [GH-600 Study Hub](/notes/gh-600/) — domains, weights, and the quest line
+- [Epic Quest: The Self-Operating Website](/quests/codex/self-operating-website/) — the campaign that *builds* a fleet like this one

--- a/pages/_notes/gh-600/index.md
+++ b/pages/_notes/gh-600/index.md
@@ -31,6 +31,7 @@ Quick-reference materials for the **GH-600: Developing in Agentic AI Systems** c
 | [MCP Quick Reference](mcp-quickref/) | MCP server setup commands and configuration |
 | [Autonomy Levels Matrix](autonomy-levels-matrix/) | L0–L4 spectrum, task classification |
 | [Evaluation Signals Table](evaluation-signals-table/) | GitHub signals mapped to acceptance criteria types |
+| [GH-600 in the Wild](implemented-in-it-journey/) | Every domain mapped to the live artifact implementing it in this repository |
 | [Glossary](glossary/) | Key terms from all six domains |
 
 ## Hands-On Quest Arc

--- a/pages/_quests/0111/agentic-codex-01-agents-in-the-sdlc.md
+++ b/pages/_quests/0111/agentic-codex-01-agents-in-the-sdlc.md
@@ -472,6 +472,7 @@ The familiars now know their bounds, wait at the gate, and leave footprints. Nex
 - [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) — the tool-and-context standard you arm agents with in Chapter 2
 - [GitHub Actions: environments & required reviewers](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) — the human-approval gate behind plan-then-act
 - [Workflow commands: job summaries](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary) — `$GITHUB_STEP_SUMMARY` for inspectable agent traces
+- 🏰 **In the wild (this repo):** [`agent-plan-then-act.yml`](https://github.com/bamr87/it-journey/blob/main/.github/workflows/agent-plan-then-act.yml) is this chapter's pattern running for real — plan job, `agent-approval` gate, observable trace. Full domain map: [GH-600 in the Wild](/notes/gh-600/implemented-in-it-journey/)
 
 ## 🕸️ Knowledge Graph
 

--- a/pages/_quests/1000/agentic-codex-02-tool-use-and-environment.md
+++ b/pages/_quests/1000/agentic-codex-02-tool-use-and-environment.md
@@ -473,6 +473,7 @@ The agent now holds its weapons and stands inside the realm's walls — but it h
 - [Copilot coding agent — GitHub Docs](https://docs.github.com/en/copilot/using-github-copilot/coding-agent) — the asynchronous, PR-opening agent
 - [Controlling permissions for `GITHUB_TOKEN`](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) — the least-privilege `permissions:` block
 - [Using environments for deployment — GitHub Docs](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) — environment protection rules and required reviewers
+- 🏰 **In the wild (this repo):** [`.vscode/mcp.json`](https://github.com/bamr87/it-journey/blob/main/.vscode/mcp.json) (editor MCP, prompt-supplied token), [`scripts/ai/mcp/github-readonly.json`](https://github.com/bamr87/it-journey/blob/main/scripts/ai/mcp/github-readonly.json) (runner MCP + allow-list convention), and the least-privilege `permissions:` blocks in every workflow. Full domain map: [GH-600 in the Wild](/notes/gh-600/implemented-in-it-journey/)
 
 ## 🕸️ Knowledge Graph
 

--- a/pages/_quests/1001/agentic-codex-03-memory-state-and-execution.md
+++ b/pages/_quests/1001/agentic-codex-03-memory-state-and-execution.md
@@ -478,6 +478,7 @@ The vaults are carved and the world can no longer drift out from under your agen
 - [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) — stateless tool surfaces that need explicit shared state
 - [GitHub Models](https://docs.github.com/en/github-models) — the reasoning engine behind cheap re-planning
 - [GH-600 Study Hub](/notes/gh-600/) — the campaign map: domains, weights, and the full quest line
+- 🏰 **In the wild (this repo):** [`scripts/ai/drift-guard.sh`](https://github.com/bamr87/it-journey/blob/main/scripts/ai/drift-guard.sh) is this chapter's drift detector in production, and the committed [`.quests/` ledger](https://github.com/bamr87/it-journey/blob/main/.quests/README.md) is Tier-3 memory the quest-perfection loop resumes from daily. Full domain map: [GH-600 in the Wild](/notes/gh-600/implemented-in-it-journey/)
 
 ## 🕸️ Knowledge Graph
 

--- a/pages/_quests/1010/agentic-codex-04-evaluation-and-tuning.md
+++ b/pages/_quests/1010/agentic-codex-04-evaluation-and-tuning.md
@@ -533,6 +533,7 @@ You can now grade an agent, diagnose its failures, and reforge its mind. The nex
 - [GitHub Models](https://docs.github.com/en/github-models) — adding an LLM-as-judge signal for qualitative criteria
 - [Code scanning REST API](https://docs.github.com/en/rest/code-scanning) — reading the "no new alerts" signal
 - [Evaluation Signals Table (GH-600 notes)](/notes/gh-600/evaluation-signals-table/) — every Domain 4 signal and the API call that reads it
+- 🏰 **In the wild (this repo):** the quest-fix **deterministic keep/revert gate** ([`quest-fix.yml`](https://github.com/bamr87/it-journey/blob/main/.github/workflows/quest-fix.yml)) keeps an agent's edit only if tier-1 score + brand lint improved — the model never grades its own work; the RCA template and instruction changelog live in [`docs/agents/`](https://github.com/bamr87/it-journey/tree/main/docs/agents). Full domain map: [GH-600 in the Wild](/notes/gh-600/implemented-in-it-journey/)
 
 ## 🕸️ Knowledge Graph
 

--- a/pages/_quests/1011/agentic-codex-05-multi-agent-coordination.md
+++ b/pages/_quests/1011/agentic-codex-05-multi-agent-coordination.md
@@ -435,6 +435,7 @@ The council convenes, traces its own work, and survives a fallen familiar. But a
 - [Storing and sharing workflow data with artifacts](https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts) — where the correlation-ID traces live
 - [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) — the tool-integration standard agents share across a council
 - [GitHub Models](https://docs.github.com/en/github-models) — the Models API for reconciling agent outputs in the collector
+- 🏰 **In the wild (this repo):** [`_data/agents/registry.yml`](https://github.com/bamr87/it-journey/blob/main/_data/agents/registry.yml) is the living roster (nine agents, lanes, kill switches, review dates), [`quest-perfection.yml`](https://github.com/bamr87/it-journey/blob/main/.github/workflows/quest-perfection.yml) chains walk → fix per slice, and the weekly [`agent-audit.yml`](https://github.com/bamr87/it-journey/blob/main/.github/workflows/agent-audit.yml) is lifecycle management running on a schedule. Full domain map: [GH-600 in the Wild](/notes/gh-600/implemented-in-it-journey/)
 
 ## 🕸️ Knowledge Graph
 

--- a/pages/_quests/1100/agentic-codex-06-guardrails-and-accountability.md
+++ b/pages/_quests/1100/agentic-codex-06-guardrails-and-accountability.md
@@ -492,6 +492,7 @@ The Warden stands her post; the gate holds. Every clause of the Pact is sworn �
 - [Controlling permissions for `GITHUB_TOKEN`](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) — least-privilege `permissions:` blocks
 - [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) — the tool surface you scope and allow-list
 - [GitHub Models](https://docs.github.com/en/github-models) — summarize the audit ledger and reason over agent runs
+- 🏰 **In the wild (this repo):** [`_data/agents/autonomy-matrix.yml`](https://github.com/bamr87/it-journey/blob/main/_data/agents/autonomy-matrix.yml) classifies every recurring agent action L0–L4, [`.github/CODEOWNERS`](https://github.com/bamr87/it-journey/blob/main/.github/CODEOWNERS) holds the file-scope boundary, and the Warden Pact itself lives in [`AGENTS.md`](https://github.com/bamr87/it-journey/blob/main/AGENTS.md). Full domain map: [GH-600 in the Wild](/notes/gh-600/implemented-in-it-journey/)
 
 ## 🕸️ Knowledge Graph
 

--- a/pages/_quests/1100/agentic-codex-capstone-exam-trial.md
+++ b/pages/_quests/1100/agentic-codex-capstone-exam-trial.md
@@ -138,6 +138,8 @@ graph TD
 
 The following 6 chapters map directly to the GH-600 exam domains.
 
+> 🏰 **A worked answer key exists.** The IT-Journey repository itself implements every seal below — its AI fleet, kill switches, autonomy matrix, drift guard, and audit trails are mapped file-by-file in [GH-600 in the Wild](/notes/gh-600/implemented-in-it-journey/). Consult it when you are stuck, the way you would check a solved example — but the trial wants *your* build, in *your* repository.
+
 ---
 
 ## ⚔️ Seal 1: The Agentic SDLC (Domain 1 — 18%)

--- a/pages/_quests/codex/agentic-codex.md
+++ b/pages/_quests/codex/agentic-codex.md
@@ -147,6 +147,8 @@ The six chapters map one-to-one to the six GH-600 exam domains, with the same we
 
 > 🧪 **Every chapter ends at a workbench.** Each chapter closes with a hands-on lab you can run in minutes — most entirely on your own machine with `bash`, `jq`, and the `gh` CLI, no Copilot subscription required — so every domain's key pattern (the approval gate, the retry harness, the drift guard, the rubric grader, the council trace, the warden policy) is something you have actually watched work *and* watched fail.
 
+> 🏰 **The Codex is load-bearing here.** This very repository practices what the campaign preaches: an AI fleet drafts content, walks quests as a learner, repairs what it witnessed breaking, and audits itself — behind kill switches, deterministic gates, an autonomy matrix, and a human merge button. Every domain is mapped to its live artifact, file by file, in **[GH-600 in the Wild: Implemented in IT-Journey](/notes/gh-600/implemented-in-it-journey/)** — read the chapter, then read the running source.
+
 > 🏆 **Capstone gate.** The [Grand Capstone](/quests/1100/agentic-codex-capstone-exam-trial/) stands beyond Chapter VI. You cannot face the Trial of the Agentic Codex until all six domain seals are broken — it integrates every domain into a single working multi-agent system with observability, evaluation, and governance in place.
 
 ## 🌍 Choose Your Adventure Platform
@@ -348,6 +350,7 @@ The conceptual companion to the chapters lives in the **GH-600 reference notes**
 - [Exam Overview & Logistics](/notes/gh-600/exam-overview/) — scoring, scheduling, renewal
 - [Glossary](/notes/gh-600/glossary/) — agent, MCP, HITL, drift, autonomy, and more
 - [MCP Quick Reference](/notes/gh-600/mcp-quickref/) — server config, registries, allow-list syntax
+- [GH-600 in the Wild](/notes/gh-600/implemented-in-it-journey/) — every domain mapped to the live artifact implementing it in this repository
 
 **Deeper study (in notes):**
 - [Skills Measured — Full Breakdown](/notes/gh-600/skills-measured/) — every sub-skill, domain by domain

--- a/scripts/ai/README.md
+++ b/scripts/ai/README.md
@@ -194,3 +194,15 @@ Add the `needs-human` label to any PR or issue to force manual handling.
 - **Meta audit** — `agent-audit` keeps the agents/skills accurate to the repo.
 - **Kill switches** — every AI workflow gates on its `*_ENABLED` variable + auth,
   so the fleet is off until you opt in and stops the instant you unset a variable.
+- **Policy as data** — the fleet roster (`_data/agents/registry.yml`: lane, kill
+  switch, status, review date per agent) and the autonomy matrix
+  (`_data/agents/autonomy-matrix.yml`: recurring action → L0–L4 level + the
+  guardrails that justify it) are the machine-readable contract the weekly
+  audit checks reality against; the forbidden-actions Warden Pact lives in
+  `AGENTS.md`.
+- **Drift guard** — `scripts/ai/drift-guard.sh` snapshots watched files at plan
+  time and aborts (exit 78) before an agent acts on a world that changed while
+  it waited; `scripts/ai/mcp/` holds committed MCP server configs (tokens come
+  from the environment, allow-lists at the `run.sh --tools` call site). Both are
+  demonstrated end-to-end by `.github/workflows/agent-plan-then-act.yml` — the
+  GH-600 reference pipeline, mapped in `/notes/gh-600/implemented-in-it-journey/`.

--- a/scripts/ai/drift-guard.sh
+++ b/scripts/ai/drift-guard.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# =============================================================================
+# drift-guard.sh — state-snapshot context-drift detector for agent runs
+# -----------------------------------------------------------------------------
+# GH-600 Domain 3 (Memory, State & Execution) implemented for this repo: an
+# agent plans against a snapshot of the world; before it ACTS, the world must
+# still match the snapshot. If a watched file changed between planning and
+# acting, the run must abort or re-plan — never act on a stale belief.
+#
+#   scripts/ai/drift-guard.sh snapshot FILE...   # hash the watched files
+#   scripts/ai/drift-guard.sh verify             # re-hash and compare
+#
+# The snapshot lives at $DRIFT_SNAPSHOT (default .agent/snapshot.sha256) so a
+# plan job can write it, ship it inside an artifact, and an execute job can
+# verify it after a human-approval delay — see
+# .github/workflows/agent-plan-then-act.yml for the reference wiring.
+#
+# Exit codes: 0 = no drift / snapshot written; 78 = drift detected (abort
+# before acting); 1 = usage error. 78 is deliberate: distinguishable from an
+# ordinary failure so an orchestrator can route it to a re-plan path.
+#
+# Taught by: /quests/1001/agentic-codex-03-memory-state-and-execution/
+# =============================================================================
+set -euo pipefail
+
+SNAP="${DRIFT_SNAPSHOT:-.agent/snapshot.sha256}"
+cmd="${1:-}"
+
+case "$cmd" in
+  snapshot)
+    shift
+    [ "$#" -gt 0 ] || { echo "usage: drift-guard.sh snapshot FILE..." >&2; exit 1; }
+    mkdir -p "$(dirname "$SNAP")"
+    sha256sum "$@" > "$SNAP"
+    echo "Snapshot of $# file(s) written to $SNAP"
+    ;;
+  verify)
+    [ -f "$SNAP" ] || { echo "::error::No snapshot at $SNAP — run 'snapshot' first." >&2; exit 1; }
+    if sha256sum -c "$SNAP" --quiet 2>/dev/null; then
+      echo "No drift — the world still matches the snapshot. Safe to act."
+    else
+      echo "::warning::Context drift detected — watched files changed since the snapshot was taken."
+      sha256sum -c "$SNAP" 2>&1 | grep -v ': OK$' || true
+      exit 78
+    fi
+    ;;
+  *)
+    echo "usage: drift-guard.sh {snapshot FILE...|verify}" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/ai/mcp/github-readonly.json
+++ b/scripts/ai/mcp/github-readonly.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "GH-600 Domain 2 implemented for this repo: a declared MCP server with the token supplied from the environment (never committed). Pass to the universal runner with `scripts/ai/run.sh --mcp scripts/ai/mcp/github-readonly.json`. The ALLOW-LIST lives at the runner call site: pair this file with `--tools 'mcp__github__get_issue,mcp__github__get_pull_request,mcp__github__list_pull_requests'` so the agent may call only the read tools its task needs — omission is denial. Taught by /quests/1000/agentic-codex-02-tool-use-and-environment/.",
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_MCP_TOKEN}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements the practices and concepts from the **GH-600 epic quest (The Agentic Codex)** into this repository itself — so every certification domain is demonstrated by working, referenceable source — then documents the mapping and updates the quest content to point at the live implementations.

The repo's existing AI fleet already embodied much of the exam (kill switches, one-runner config, deterministic gates, the `.quests/` ledger, CODEOWNERS). This PR fills the genuine gaps and makes the whole picture navigable.

### New artifacts (the gaps, filled)

| Domain | Artifact | What it demonstrates |
|---|---|---|
| D1+D3+D5+D6 | `.github/workflows/agent-plan-then-act.yml` | **The reference pipeline**: plan job → `agent-approval` Environment (required-reviewer human gate) → execute job. Plan crosses the boundary as an artifact (Tier-2 memory); drift-guard verify before acting; correlation ID threaded through jobs, summaries, and artifact names; `contents: read` only; audit artifact recording instruction → action → outcome. Deterministic stub (no model call, no auth), **OFF by default** behind `AGENT_DEMO_ENABLED` |
| D3 | `scripts/ai/drift-guard.sh` | Snapshot/verify context-drift detector; `exit 78` aborts before acting on a moved world. The execute job deliberately checks out the *live branch tip* so a commit landing during the approval wait is really caught. Tested locally (0 / 78 paths verified) |
| D2 | `scripts/ai/mcp/github-readonly.json` + `.vscode/mcp.json` | Committed MCP server configs — token from env / secure prompt, never committed; allow-list convention at the `run.sh --tools` call site |
| D5 | `_data/agents/registry.yml` | Machine-readable fleet roster: nine agents with definition, workflow, lane (read-only vs content-write), kill switch (verified against the real `*_ENABLED` variables), owner, status, `review_date` |
| D6 | `_data/agents/autonomy-matrix.yml` | Every recurring agent action classified L0–L4 by reversibility/blast radius/predictability, with the guardrails that justify each level |
| D6 | Warden Pact in `AGENTS.md` | Explicit forbidden-actions list with the decline → comment → label → stop protocol, referencing the policy data |
| D4 | `docs/agents/` (README + `rca-template.md` + `instructions-changelog.md`) | The machine-verifiable gate table (tier-1 score, brand lint, smuggle guard, keep/revert gate), a 5-Why RCA template, and an instruction changelog **seeded with this PR's own changes** (outcome: TBD, measured at the next fleet audit) |
| D5 | `agent-auditor` scope extension | The weekly fleet audit now checks the registry + matrix + pact against reality, so the roster's "audited" claim is true, not aspirational |

### Documentation & quest updates

- **`/notes/gh-600/implemented-in-it-journey/`** — the centerpiece: every domain and sub-skill mapped to the live artifact implementing it, with GitHub source links and the chapter that teaches it, plus try-it-yourself setup for the reference pipeline.
- **Quest content updated** to reference the demonstrations: a "Codex is load-bearing here" callout on the epic hub, an 🏰 *In the wild (this repo)* resource line in each of the six chapters pointing at that domain's artifact, a "worked answer key" pointer in the Grand Capstone, and the new note in the GH-600 study-hub index.
- Inventory rows added to `.github/workflows/README.md` and the fleet guardrails section of `scripts/ai/README.md`.

### Safety

- Nothing autonomous turns on: the new workflow idles behind `AGENT_DEMO_ENABLED` (unset) and requires the `agent-approval` Environment to be created with a required reviewer first (setup documented in the workflow header and the note).
- New workflow follows house conventions: least-privilege `permissions:`, SHA-pinned actions, `concurrency` group, untrusted input via `env:`.
- All policy files are hand-maintained data; no generated data touched.

## Validation

- `make quest-audit` / `make content-audit` / `make liquid-check` — ✅ all pass
- `yamllint` on the new workflow + data files — ✅ clean (only the universal `on:` truthy warning every workflow shares)
- `scripts/ai/drift-guard.sh` — ✅ exercised locally: snapshot → verify (exit 0) → mutate → verify (exit 78)
- `scripts/ci/brand_lint.py` on all touched content — ✅ on-brand
- Registry kill-switch names verified against the actual `vars.*_ENABLED` gates in the workflows

Content + additive infra (one OFF-by-default workflow, data files, docs); no layout/CSS/JS changes, so no screenshots required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEojXuotoSHa7SL7w9W7JU

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEojXuotoSHa7SL7w9W7JU)_