### PR TITLE
fix(ci): sync-gh-pages no longer blocks on its own in-progress check

### DIFF
--- a/.github/workflows/sync-gh-pages.yml
+++ b/.github/workflows/sync-gh-pages.yml
@@ -70,6 +70,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           SHA: ${{ steps.ahead.outputs.sha }}
+          RUN_ID: ${{ github.run_id }}
         run: |
           python3 - <<'PY'
           import json, os, subprocess, sys
@@ -89,9 +90,18 @@ jobs:
                   raise SystemExit(f"gh api failed: {path}")
               return json.loads(r.stdout or "{}")
 
+          # This workflow runs ON main's HEAD, so its own job shows up among the
+          # sha's check runs as in-progress — counting it makes the state
+          # permanently "pending" and the merge step unreachable (the bug that
+          # silently blocked every scheduled sync). Exclude the check suite
+          # belonging to THIS run before judging greenness: never grade yourself.
+          self_suite = gh(f"repos/{repo}/actions/runs/{os.environ['RUN_ID']}").get("check_suite_id")
+
           pending, failed, passed = [], [], []
           for run in gh(f"repos/{repo}/commits/{sha}/check-runs?per_page=100").get("check_runs", []):
               n = run.get("name", "?")
+              if run.get("check_suite", {}).get("id") == self_suite:
+                  continue
               if run.get("status") != "completed":
                   pending.append(n)
               elif run.get("conclusion") in FAILISH:

--- a/.github/workflows/sync-gh-pages.yml
+++ b/.github/workflows/sync-gh-pages.yml
@@ -30,6 +30,7 @@ permissions:
   pull-requests: write     # open + merge the PR
   checks: read             # read main's check-runs
   statuses: read           # read main's commit statuses
+  actions: read            # resolve this run's check_suite_id (self-exclusion)
 
 concurrency:
   group: sync-gh-pages


### PR DESCRIPTION
## Summary

Found while **validating the GH-600 implementation end-to-end**: the site has not actually deployed since June 30 — none of the recently merged content (PRs #405/#406/#407) is live on it-journey.dev, even though every scheduled `sync-gh-pages` run reports success.

### Root cause

The sync's "🟢 Is main's latest commit green?" step counts **every** check run on main's HEAD — including **its own job**, which is always in-progress at the moment it checks. The run-6 log shows it plainly:

```
[ci] state=pending green=11 pending=['Open & merge main → gh-pages when green'] failed=[]
```

Eleven green checks, zero failures — and the only "pending" check is the sync job grading itself. `state=pending` → the merge step skips → "will retry on the next routine run" → which deadlocks the same way, forever. `gh-pages` has been frozen at its June 30 manual sync ever since.

### Fix

Resolve the current run's `check_suite_id` (`repos/{repo}/actions/runs/{run_id}`) and skip any check run in that suite before judging greenness — a grader must never grade itself. Ten added lines, no behavior change for genuinely pending/failed CI.

Fittingly, this is exactly the failure class the Agentic Codex teaches (Domain 4: the evaluator must be independent of the thing it evaluates) — caught by running the validation the campaign prescribes.

### After merge

The next scheduled sync (every 6 h at :20) — or a manual `workflow_dispatch` of **🚀 Sync gh-pages from main** — should open and merge the `main → gh-pages` PR, and Pages will publish the backlog (the CMStyle epic at `/quests/codex/zer0-to-her0-cmstyle/`, the chapter labs, and `/notes/gh-600/implemented-in-it-journey/`).

## Validation

- Diagnosed from the actual run-6 job log (linked evidence above)
- `yamllint` — only pre-existing warnings (`on:` truthy + long lines that predate this change); YAML parses
- CI `actionlint` gates this PR since it touches `.github/workflows/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEojXuotoSHa7SL7w9W7JU

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEojXuotoSHa7SL7w9W7JU)_