### PR TITLE
content(quests): forge the Codex Glossary into the realm's naming canon

### DIFF
--- a/.claude/skills/quest-forge/SKILL.md
+++ b/.claude/skills/quest-forge/SKILL.md
@@ -38,6 +38,10 @@ is your only license to quote a PR number or commit hash.** Read issue comments 
 - **Voice:** run the **`brand-voice`** skill for the `quests` section and read
   `_data/brand/sections/quest.md` — the `quest-fantasy` profile (gamified,
   encouraging, emoji-rich; technical accuracy intact under the fantasy wrapper).
+- **Vocabulary:** `pages/_quests/codex/glossary.md` (`/quests/codex/glossary/`)
+  — the canonical fantasy↔technical lexicon. Take names from it; never mint a
+  synonym for a term it already names; a new coinage is added there first (same
+  PR), then used in the quest.
 
 ## 3. Plan the campaign (placement + manifest)
 

--- a/.github/instructions/quest.instructions.md
+++ b/.github/instructions/quest.instructions.md
@@ -325,6 +325,17 @@ Use this mapping consistently for narrative cohesion:
 
 Keep technical accuracy intact — fantasy is a wrapper, never a substitute.
 
+This table is only the authoring quick-reference. The **complete canonical
+lexicon** (~120 entries: geography, classes, spellcraft, chronomancy, bestiary,
+artifacts, great works, law, words of power) lives at
+`pages/_quests/codex/glossary.md` (rendered at `/quests/codex/glossary/`) and is
+the single source of naming truth for quest narrative:
+
+- **Don't mint synonyms** for anything the glossary already names — one realm,
+  one dragon.
+- **New coinages land in the glossary first**: add the entry there in the same
+  PR, then use it in your quest.
+
 ## 9. Validation Workflow
 
 Run before every commit:

--- a/_data/brand/sections/quest.md
+++ b/_data/brand/sections/quest.md
@@ -25,10 +25,9 @@ quests. They want an adventure that still teaches a real, verifiable skill.
 `quest-fantasy` (see `../voice.md`). Second person, imperative, playful, heavily
 fantasy-framed ("wield", "spell", "rank up"). **Emoji are on-brand and are not
 policed for quests** — the fantasy framing (🎯 ⚔️ 🏆 🧙) is expected.
-Fantasy vocabulary comes from the
-[Codex Glossary](../../../pages/_quests/codex/glossary.md)
-(`/quests/codex/glossary/`) — the naming canon: no synonyms for terms it already
-names; new coinages land there first.
+Fantasy vocabulary comes from the [Codex Glossary](/quests/codex/glossary/) —
+the naming canon: no synonyms for terms it already names; new coinages land
+there first.
 
 ## Tone
 

--- a/_data/brand/sections/quest.md
+++ b/_data/brand/sections/quest.md
@@ -25,6 +25,10 @@ quests. They want an adventure that still teaches a real, verifiable skill.
 `quest-fantasy` (see `../voice.md`). Second person, imperative, playful, heavily
 fantasy-framed ("wield", "spell", "rank up"). **Emoji are on-brand and are not
 policed for quests** — the fantasy framing (🎯 ⚔️ 🏆 🧙) is expected.
+Fantasy vocabulary comes from the
+[Codex Glossary](../../../pages/_quests/codex/glossary.md)
+(`/quests/codex/glossary/`) — the naming canon: no synonyms for terms it already
+names; new coinages land there first.
 
 ## Tone
 

--- a/_data/navigation/quests.yml
+++ b/_data/navigation/quests.yml
@@ -62,8 +62,6 @@
     url: /quests/0000/vault/
   - title: '⚔️ Bashcrawl Workshop: File Management Fundamentals'
     url: /quests/0000/workshop/
-  - title: '⚔️ Codex Glossary: Fantasy Terms to IT Reality'
-    url: /quests/codex/glossary/
 - title: Level 0001 - Web Fundamentals
   icon: bi-feather
   url: /quests/0001/

--- a/pages/_quests/codex/glossary.md
+++ b/pages/_quests/codex/glossary.md
@@ -1,81 +1,325 @@
 ---
 title: 'Codex Glossary: Fantasy Terms to IT Reality'
-layout: quest
-author: IT-Journey Team
-description: 'A quick-reference codex decoding the IT-Journey fantasy metaphors, mapping spells to scripts, worlds to operating systems, and the market to GitHub.'
-preview: /images/previews/glossary.png
-categories:
-- notes
-tags:
-- notes
-draft: true
-lastmod: '2023-11-25T11:31:20.000Z'
+description: The canonical lexicon of the IT-Journey realm — every fantasy term decoded into the technology behind it, from spells and scripts to golems and pipelines.
+excerpt: The realm's shared dictionary — fantasy on one side, real technology on the other.
+date: '2023-11-25T14:12:43.000Z'
+lastmod: '2026-07-02T00:00:00.000Z'
+draft: false
 permalink: /quests/codex/glossary/
+author: IT-Journey Team
+layout: default
 level: '0000'
 difficulty: 🟢 Easy
 estimated_time: Variable
 quest_type: side_quest
-keywords:
-  primary:
-  - notes
-  secondary: []
-date: '2023-11-25T14:12:43.000Z'
 quest_series: Codex Reference
 primary_technology: reference
-skill_focus: fullstack
+skill_focus:
+- codex
+- reference
 learning_style: reading
-fmContentType: quest
+fmContentType: codex
+categories:
+- Codex
+- Reference
+tags:
+- codex
+- glossary
+- lexicon
+- fantasy
+- reference
+- world-building
+keywords:
+  primary:
+  - glossary
+  - fantasy metaphors
+  secondary:
+  - lexicon
+  - it terminology
+  - codex
+toc: true
+toc_sticky: true
 ---
-Enterprise
 
-Spells - Scripts
+*Every realm keeps a codex — the book its scribes consult so that a dragon in
+one tale is not a lizard in the next. This is ours: the shared dictionary that
+maps the fantasy of IT-Journey onto the technology it teaches. Met a strange
+word mid-quest? Look it up here. Writing a quest? Take your words from here.
+For where things **are**, see the [World Map](/quests/codex/world-map/); for
+what things are **called**, you're home.*
 
-Ship - Browser
+## 🧭 How to Read This Codex
 
-Equipment - 
+Here is the realm's oldest secret: **the mortals' computing tongue was already
+half fantasy before we arrived.** Daemons run their background chores. Zombie
+processes shamble until reaped. Software installs itself through wizards,
+oracles answer queries, artifacts drop out of build pipelines, and security
+researchers collect bounties. We didn't invent the metaphor — we finished it.
 
-Crafting station - IDE's
+So this codex obeys one law:
 
-Castle - 
+> **The Prime Rule:** fantasy is a wrapper, never a substitute. Every spell is
+> a real command, every place a real system, every monster a real failure mode.
+> The moment a metaphor obscures the technology, the metaphor loses.
 
-Market - GitHub
+Each entry has three parts:
 
-Farm - 
+| Part | What it gives you |
+|---|---|
+| **Fantasy** | The term as quests use it |
+| **In the mortal world** | The technology it stands for |
+| **Field notes** | How it behaves in stories — lines you can lift into a quest |
 
-Factory -
+## 🌍 The Realm — Worlds and Geography
 
-Research
+| Fantasy | In the mortal world | Field notes |
+|---|---|---|
+| **The Realm** | All of computing — every machine, network, and system your journey touches | You never leave it; you only uncover more of the map. |
+| **Worlds** | Operating systems | Each world has its own physics, customs, and native tongue. Travelers eventually walk them all. |
+| **The Microsoft Kingdom** | Windows | Vast and orderly; its court speaks PowerShell. |
+| **The Apple Empire** | macOS | Polished marble over Unix stone — a walled garden with excellent weather. |
+| **The Penguin's Domain** | Linux | A thousand provinces (distributions), open borders, and the terminal as the king's road. |
+| **The Digital Heavens** | The cloud (AWS, Azure, GCP) | Castles rented by the hour, floating above someone else's Farmlands. Ascend at [Level 1000](/quests/1000/). |
+| **Your Home Village** | `localhost` (127.0.0.1) | Where every journey begins. There's no place like 127.0.0.1. |
+| **The Proving Grounds** | Staging and test environments | Where work faces its trials before meeting the world. Break things here — that is what the grounds are for. |
+| **The Frontier** | Production | Real users, real stakes, real dragons. Nothing crosses without the Wardens' seal. |
+| **The Wilds** | The open internet | Beautiful, vast, unpoliced. Keep your wards up and your potions patched. |
+| **The Great Sea** | The World Wide Web | Sailed daily, never the same waters twice. |
+| **Your Ship** | The web browser | Your vessel on the Great Sea. Tabs are cargo — load too many and she rides low in the water. |
+| **City Gates** | Ports | Numbered doors into any stronghold. Gate 443 demands the Royal Seal; gate 22 opens only for keyholders. |
+| **Portals** | URLs and API endpoints | Step through, arrive elsewhere. Every portal has an address and rules of passage (protocol, authentication). |
+| **Roads and Trade Routes** | Networks | Everything travels them — messages, treasure, and plagues. Rangers know every shortcut. |
+| **The Cartographers' Guild** | DNS | Keeps the atlas that turns names into places (`it-journey.dev` → an IP address). When the Guild errs, the whole realm gets lost. |
+| **The Farmlands** | Data centers and server farms | Endless rows of humming iron, tended day and night. The Digital Heavens rest on them. |
+| **The Dungeon** | A deep debugging session | Descend with a torch (the logs) and a map (the stack trace). The loot is understanding. |
+| **The Labyrinth** | An undocumented legacy codebase | Bring thread: write down your path as you go, so the next traveler doesn't wander where you did. |
+| **The Void** | `/dev/null` | A place of no return for unwanted output. See *Words of Power* before casting anything into it. |
+| **The Molten Core** | The kernel | The deepest layer of any world, where its laws are enforced. Few descend; all depend on it. |
+| **The Overworld** | The [master quest map](/quests/home/) | The view from above — all sixteen levels at once, and your own footprints across them. |
+| **Init World** | [Level 0000](/quests/0000/) | Where characters are created and every journey begins. |
 
-Journal
+## 🏰 Strongholds and Workshops — Where the Work Happens
 
-Log
+| Fantasy | In the mortal world | Field notes |
+|---|---|---|
+| **Your Fortress** | Your development machine | Provision it early and raise the walls: updates, encryption, backups. First provisioned in [Init World](/quests/0000/). |
+| **Your Castle** | Your personal website and domain | Every traveler should raise one — the realm judges you by what you've built. Foundations are laid at [Level 0001](/quests/0001/). |
+| **The Bit Forge** | Your IDE or editor | Where raw ideas are hammered into working code. VS Code is the realm's most crowded forge floor. |
+| **The Grand Bazaar** | GitHub | Market, meeting hall, and commons in one: work is offered, copied (forked), improved, and given back. Karma is earned here. |
+| **Market Stalls** | Package registries (npm, PyPI, RubyGems) | Potions by the hundred thousand. Read the label and know your brewer — see *Potions*. |
+| **The Factory** | CI/CD pipelines | A golem-run assembly line: every change walks the same gauntlet, no exceptions, no moods. Built at [Level 0101](/quests/0101/). |
+| **The Library** | Documentation, manuals, references | The realm's collected knowledge; the strongest adventurers are the ones you meet here mid-quest. Its reference wing holds the [cheatsheets](/notes/cheatsheets/). |
+| **Your Grimoire** | Your personal notes ([/notes/](/notes/)) | Spells that worked, monsters slain, and how. Future-you is its most grateful reader. |
+| **The Tavern** | Stack Overflow, Discord, forums | Where travelers trade war stories and answers. Tavern manners: search before you shout, and show what you tried. |
+| **The Training Grounds** | Sandboxes, tutorials, katas | Wooden swords, real technique. Mini-games — coding challenges and capture-the-flag contests — are played here for sport and skill. |
+| **The Vault** | Secrets managers (environment variables, GitHub Secrets) | Keys, tokens, and passwords under lock. Never inscribe a secret on a public scroll — the Bazaar never forgets, and neither does git history. |
+| **The Watchtower** | Monitoring and dashboards | Where Sentinels scry the horizon. Climb it at [Level 1010](/quests/1010/). |
+| **The Archives** | Databases | The realm's memory vaults — information kept, indexed, and guarded. Librarians keep them; SQL is the formal speech for petitioning them. Delve at [Level 0110](/quests/0110/). |
+| **The Treasury** | Your computing budget | Funds are computing power. The Digital Heavens bill by the hour — someone must watch the coin. |
+| **The Empire** | Enterprise organizations and their systems | Many castles, old maps, much ceremony. Adventuring rules differ inside its walls, and it pays well for those who learn them. |
 
-Mini games
+## 🧙 The Traveler — You and Your Progression
 
-Fortress 
+*You are the character. Everything below tracks who you are becoming.*
 
-Governance
+| Fantasy | In the mortal world | Field notes |
+|---|---|---|
+| **zer0 → her0** | The journey from beginner to practitioner | The realm's founding prophecy — always written with zeroes. |
+| **n00b** | An absolute beginner | A title of honor here, never an insult. Every Master remembers wearing it. |
+| **Your Character** | Your professional identity | Forged in [Init World](/quests/0000/), leveled everywhere else. |
+| **Character Class** | Your IT specialization | Eight to choose from (see below). Multi-classing is common and encouraged. |
+| **XP** | Experience points | Earned by completing quests, 0 to 9000+. The count is honest: no quest, no XP. |
+| **Levels** | The sixteen stages, 0000 → 1111 | The realm counts in binary, its native tongue: 1111 is 15. Read a level aloud and you've counted like a machine. |
+| **The Quest Log** | Your progress tracker | This realm keeps yours in your own browser (localStorage). Consult it from the [Overworld](/quests/home/). |
+| **Badges and Loot** | Skills and portfolio artifacts | The loot that matters is the working thing you built — and the proof you understand it. |
+| **Karma** | Open-source contributions | Green sigils on your Bazaar profile. Earned, never bought. |
+| **Your Party** | Your team, your pair-programming partner | Dungeons are safer with company. So is production. |
+| **Guilds** | Communities and organizations | Shared halls in the Grand Bazaar. Join several; lurk politely; contribute when ready. |
+| **Alliances** | Cross-project collaboration, upstream and downstream | Your castle stands on stones a thousand strangers cut. Send improvements upstream — that is the whole economy. |
 
-Diplomacy
+### The Four Tiers
 
-Alliances
+| Tier | Levels | The shape of it |
+|---|---|---|
+| 🌱 **Apprentice** | 0000–0011 | Foundations: your fortress, first incantations, first familiars. |
+| ⚔️ **Adventurer** | 0100–0111 | Real crafts: interfaces, summoning circles, factories, and portals. |
+| 🔥 **Warrior** | 1000–1011 | The Heavens, the legions, the watchtowers, and the wards. |
+| ⚡ **Master** | 1100–1111 | Alchemy, prophecy, architecture — and leading other travelers. |
 
+### The Eight Classes
 
-Lores
+Chosen — and re-chosen — in the [Character Selection quest](/quests/0000/character-selection/):
 
-Items - apps, 
+| Class | Mortal title | Powers |
+|---|---|---|
+| 🧙 **Wizard** | Software Developer | Turns intention into runnable spells. |
+| 🛡️ **Paladin** | Systems Administrator | Keeps the strongholds standing; sworn to uptime. |
+| 🏹 **Ranger** | Network Engineer | Knows every road, gate, and shortcut in the realm. |
+| 🗡️ **Rogue** | Security Specialist | Thinks like an intruder so the walls hold against real ones. |
+| 📜 **Sage** | Data Scientist | Reads meaning in rivers of data. |
+| 🔮 **Mystic** | Cloud Engineer | Commands castles that exist only in the Heavens. |
+| ⚙️ **Artificer** | DevOps Engineer | Builds the golems and factories that build everything else. |
+| 📚 **Librarian** | Database Administrator | Guardian of the Archives; fluent in SQL. |
 
-Funds - Computing power
+## ✨ Spellcraft — Code and Command
 
-Class
+| Fantasy | In the mortal world | Field notes |
+|---|---|---|
+| **Magic** | Software | Any sufficiently documented magic is indistinguishable from technology. |
+| **Spells** | Scripts and programs | Written words that make machines act. Wizards keep theirs under version control. |
+| **Incantations** | Terminal commands | Cast one line at a time. `ls`, `cd`, `grep` — cantrips first, rituals later. |
+| **Your Spellbook** | The terminal (the shell) | *"Your terminal is a spellbook you haven't opened yet."* Open it daily; it opens everything else. Mastered at [Level 0010](/quests/0010/). |
+| **Personal Enchantments** | Dotfiles and shell configuration | Notes in your spellbook's margins — `.zshrc`, aliases, prompts. Carried from fortress to fortress in a dotfiles repository. |
+| **Algorithm Weaving** | Programming | The craft itself: threads of logic woven into cloth that bears weight. |
+| **Runecraft** | Regular expressions | Dense symbols, great force, easy to miscast. Test your runes before etching them into a spell. |
+| **Enchantment** | Configuration | A lasting charm on an object: config changes behavior without reforging (recompiling). |
+| **Rituals** | Practiced workflows | Pull, branch, build, verify — in that order, every time. Rituals exist so tired hands still do the steps. |
+| **Casting** | Running or executing | A cast spell does exactly what is written — not what you meant. This is the realm's First Law of Spellcraft. |
+| **A Miscast** | An error message | The spell fizzles *and speaks*. Read what it says — a miscast usually names its own cure. |
+| **Tongues of the Realm** | Programming languages | Bash, ancient tongue of the spellbook. JavaScript, spoken aboard every Ship. Python, the Sages' tongue. SQL, formal speech of the Archives. YAML, the scribes' ledger-tongue, where indentation is ceremony and posture is law. |
+| **Mana** | Compute, quotas, and rate limits | Every spell draws on it; every portal meters it. Spend too fast and you are rate-limited until it regenerates. |
 
-Karma - contributions
+## 🕰️ Chronomancy — Git and the Weave of Time
 
-Map - System arch
+*Git is the realm's school of time magic: chronicle branching and timeline
+weaving. It is taught early — [Level 0001](/quests/0001/) — because
+chronomancers fear almost nothing: every mistake sits one counter-spell from
+undone.*
 
-Languages
+| Fantasy | In the mortal world | Field notes |
+|---|---|---|
+| **The Chronicle** | A repository's git history | The true lore of a codebase: every change, whose hand made it, and — if the seals are well written — why. |
+| **A Chronicle Entry** | A commit | A sealed moment in time. Write the seal (the message) for the traveler reading it five years hence. |
+| **Parallel Timelines** | Branches | Split reality, explore a future, keep the present safe. |
+| **Weaving** | Merging | Two timelines become one. |
+| **A Tangle in the Weave** | A merge conflict | Two timelines changed the same thread. Not a disaster — a conversation the chronomancer (you) settles by hand. |
+| **Timewalking** | `git checkout` / `git switch` | Step into any recorded moment. Look freely; change nothing you don't mean to. |
+| **The Counter-spell** | `git revert` | Undoes a change by adding a new one. History stays honest. |
+| **Rewriting History** | `git rebase` | Lawful on your own private timeline; forbidden sorcery on shared ones. |
+| **Monuments** | Tags and releases | Stones raised at moments worth remembering: `v1.0.0`. |
+| **Consulting the Chronicle** | `git blame` | Learn whose hand inscribed a line, and when — for context, never for condemnation. |
+| **A Fork** | Your own copy of another's work | The Bazaar's founding custom: take, improve, offer back. See *Emissary*. |
 
-Worlds - OS
+## 🐉 The Bestiary — Creatures of the Realm
+
+| Fantasy | In the mortal world | Field notes |
+|---|---|---|
+| **Bugs** | Defects | The realm's common vermin. Hunting them is not a distraction from the craft — it *is* the craft. |
+| **The Heisenbug** | A bug that vanishes when observed | Add a print statement and it hides. Set traps that watch without touching: logging over guesswork. |
+| **The Hydra** | A regression-prone defect | Cut one head, two grow back. Pin it with a failing test *before* you swing. |
+| **Gremlins** | Flaky tests | Appear only when nobody watches; vanish on re-run. Starve them of randomness and shared state and they leave. |
+| **Daemons** | Background processes | A real Unix word. Quiet spirits doing chores no one sees — schedulers, servers, watchers. Treat them well. |
+| **Zombies** | Zombie processes | Also a real word: finished, but never reaped by their parent. The mortals named it before we did. |
+| **Golems** | Bots and autonomous agents | Tireless servants shaped from prompts and code. This realm's own golems — its AI fleet — are oath-bound; see *The Warden Pact*. |
+| **Familiars** | AI coding assistants | A summoned companion that drafts, explains, and fetches. Yours to command — and yours to double-check. |
+| **The Oracle** | An AI chat (a large language model) | Answers the question you asked, not the one you meant. Phrase with care; verify with your own eyes. Prophecy is not proof. |
+| **Dragons** | Production incidents | *Here be dragons* marks unmapped territory on old charts and legacy systems alike. The prepared carry runbooks. |
+| **Mimics** | Phishing | Shaped exactly like treasure — an invoice, a password-reset scroll — and bites when touched. Check the sender's true address before opening any chest. |
+| **Trolls** | Trolls | The word crossed over unchanged. Do not feed. |
+| **Sirens** | Scope creep | They sing *"wouldn't it be cool if…"* mid-quest. Lash yourself to the acceptance criteria and sail on. |
+| **The Plague** | Malware | Spreads by contact: strange downloads, unknown brews. Wards beat cures — keep systems patched and privileges few. |
+| **The Siege** | A denial-of-service attack | A horde battering your gates until real visitors can't enter. Met at the walls: rate limits, caches, calm. |
+
+## ⚒️ Artifacts and Inventory — Items and Gear
+
+| Fantasy | In the mortal world | Field notes |
+|---|---|---|
+| **Items** | Applications and programs | The realm's countless tools. Judge an item by its upkeep, not its shine — abandoned items rust into relics. |
+| **Your Inventory** | Installed packages and tools | `brew list` opens it. Carry what you use; a hoard slows the fortress. |
+| **Gear** | Hardware | Keyboard, iron, and glass. Good gear helps; practiced hands matter more. |
+| **Potions** | Dependencies | Drink one (`pip install …`) and gain an ability a stranger brewed. Check the label (version), the brewer (maintainer), and the recipe (lockfile) — unknown brews carry supply-chain curses. |
+| **Artifacts** | Build artifacts | Another word the mortals already had: the treasure your Factory forges from source — binaries, images, site builds. |
+| **Relics** | Legacy systems | Ancient, load-bearing, still humming in a basement. Respect them; the realm runs on more relics than anyone admits. |
+| **Keys** | SSH keys, API keys, passwords | Literal keys. One per gate — a key reused is a key multiplied against you. Rotate them; guard the ring. |
+| **Talismans** | Auth tokens and two-factor codes | Proof of who you are. Carry a second talisman (2FA) so a stolen watchword alone opens nothing. |
+| **The Royal Seal** | TLS certificates (the padlock) | Proof a portal is what it claims to be. Ships refuse unsealed portals for good reason. |
+| **Sealing Wax** | Signed commits (GPG) | Proves a chronicle entry truly came from your hand. |
+| **Scrolls** | READMEs and Markdown files | Every repository posts one at its gate. Read the gate scroll first — the realm's oldest law. |
+| **The Elder Tomes** | man pages and official manuals | Terse, ancient, correct. `man grep` before you ask the Tavern. |
+| **Sigils** | Status badges | Small marks of standing on a repository's banner: trials passing, version, coverage. |
+| **Maps** | Architecture diagrams | A system you can't draw is a system you don't yet understand. Mermaid is this realm's cartographer's ink. |
+
+## 🏭 The Great Works — Building, Shipping, Running
+
+| Fantasy | In the mortal world | Field notes |
+|---|---|---|
+| **The Forge** | Build systems and compilers | Raw source in, artifact out, sparks along the way. The sparks are warnings — heed them. |
+| **The Gauntlet of Trials** | The test suite | Truth-table trials: every claim your code makes, challenged in order. Write the trial before you slay the hydra. |
+| **The Ship's Log** | Application and system logs | What *actually* happened, timestamped. Read the log before forming theories — it is the dungeon's torch. |
+| **Scrying** | Monitoring and observability | Watching distant events through enchanted glass: dashboards, traces, metrics. The Watchtower's craft, mastered at [Level 1010](/quests/1010/). |
+| **The Sentinel's Horn** | Alerts and paging | Sounded only for true danger. A horn that cries nightly is soon ignored — that fatigue has a name in both worlds. |
+| **Summoning** | Deployment | The work steps out of the chronicle and into the world — digital manifestation. Summon to the Proving Grounds before the Frontier. |
+| **Summoning Circles** | Containers | A Dockerfile inscribes the circle; the creature bound inside behaves identically in every world. *"Works in my fortress"* ceases to be an excuse. Drawn at [Level 0100](/quests/0100/). |
+| **The Marshal of Legions** | Kubernetes | Commands armies of summoned creatures: replaces any that fall (self-healing), raises more when the horde swells (autoscaling). Sworn in at [Level 1001](/quests/1001/). |
+| **Wards** | Firewalls, authentication, hardening | Layered protections placed *before* trouble: walls, gates, watchwords. Raised properly at [Level 1011](/quests/1011/). |
+| **Benign Necromancy** | Backups and disaster recovery | The one school of necromancy the realm honors: raising dead systems whole. No backup, no resurrection — only permadeath. Rehearse the rites (restore drills) before you need them. |
+| **Transmutation** | Refactoring | Change the form, preserve the essence. The Gauntlet proves the essence held. |
+| **Alchemy** | Data engineering | Distilling rivers of raw data into gold. Pipelines are the stills; [Level 1100](/quests/1100/) is the school. |
+| **Prophecy** | Machine learning | Foretelling from patterns of the past. Honest prophets state their confidence — every prophecy carries error bars. Studied at [Level 1101](/quests/1101/). |
+
+## 🏛️ Law and Fellowship — Governance and Community
+
+| Fantasy | In the mortal world | Field notes |
+|---|---|---|
+| **The Laws** | Open-source licenses | Read before you take. MIT: a generous charter. GPL: a share-alike covenant that travels with the code. No license: all rights reserved — admire, don't take. |
+| **The Wardens** | Branch protection and CI gates | Nothing enters the main timeline without their seal. Inconvenient by design; the Frontier stands because of them. |
+| **The Warden Pact** | The rules binding this realm's own golems | The oaths IT-Journey's AI fleet cannot break — never push to main, never touch the gates, never merge their own work unwatched. Even golems answer to law. |
+| **The Council** | Maintainers and code owners | Stewards of a codebase. Their review is a gift of attention — make it easy to give. |
+| **An Emissary** | A pull request | Your work sent to another stronghold, with a letter explaining itself. Small, well-spoken emissaries are granted audiences fastest. |
+| **A Petition** | An issue | A formal request for aid or change. The good ones state what happened, what was expected, and how to summon the problem again. |
+| **Diplomacy** | Code review | Critique the work, honor the worker. The realm's strongest alliances were forged in review threads. |
+| **Bounties** | Bug bounties | Posted rewards for finding weaknesses honorably and reporting them quietly. Another word that crossed over intact. |
+| **Bards** | Developer advocates and bloggers | Carry tales of quests to distant taverns. This realm's bards sing their chronicles at [lifehacker.dev](https://lifehacker.dev). |
+| **Scribes** | Technical writers and quest authors | Nothing truly exists in the realm until a scribe records it. See *For Quest Scribes* below. |
+| **The Lore** | Decision records, changelogs, architecture notes | *Why* the realm is shaped this way. When you catch yourself asking "why on earth—", consult the lore before redrawing the map. |
+| **The Journal** | Changelogs and learning logs | A project's public journal is its CHANGELOG; a traveler's private one lives in the grimoire. Keep both. |
+
+## 🗝️ Words of Power — Commands That Demand Respect
+
+*Some incantations are strong enough that the realm pauses before granting
+them. Speak them deliberately.*
+
+| Word of Power | What it invokes | The caution |
+|---|---|---|
+| `sudo` | The crown's own authority | The realm obeys completely — wise command or not. Pause the length of one breath first. |
+| `rm -rf` | The Unmaking | Erases without appeal or afterlife. There is no resurrection for what was never backed up. Read the path aloud before you cast. |
+| `kill` / `kill -9` | Banishment, polite then absolute | First ask the daemon to leave (`SIGTERM`); `-9` removes it mid-sentence — no farewells, no cleanup. |
+| `> /dev/null` | Casting into the Void | Silences a spell's voice forever. Handy — until you silence the one line that named the problem. |
+| `--force` | Overriding the wards | The wards were placed for a reason. Know the reason before you push past them — above all on shared timelines. |
+| *Turn it off and on again* | The First Rite of Restoration | Mocked in every tavern, effective in every age. Banish, breathe, re-summon. |
+
+## ✍️ For Quest Scribes — Using This Lexicon
+
+This codex is the **single source of naming truth** for quest narrative. To
+keep the realm speaking one tongue:
+
+1. **Obey the Prime Rule.** The fantasy dresses the technology; it never
+   replaces it. Commands stay real, outputs stay real, and the learner must
+   finish able to *do* the thing.
+2. **Decode on first use.** Introduce a term with its translation in tow —
+   *"open your spellbook (the terminal)"* — then use either freely.
+3. **Don't mint synonyms.** If a thing is named here, use this name. One realm,
+   one dragon.
+4. **New coinages land here first.** Found a mapping this codex lacks? Send an
+   emissary (a pull request) adding it, then use it in your quest.
+5. **The deeper laws live elsewhere.** Quest structure belongs to
+   `.github/instructions/quest.instructions.md`; voice and tone to
+   `_data/brand/`. Structure there, vocabulary here.
+
+**The lexicon at work.** A plain instruction:
+
+> Open a terminal and run the setup script. If it fails, check the log file.
+
+becomes a quest line without losing a single fact:
+
+> Open your spellbook (the terminal) and cast `./setup.sh`. If the spell
+> fizzles, read the ship's log at `logs/setup.log` — a miscast names its own
+> cure.
+
+---
+
+*The Codex Glossary is a living artifact — it grows as the realm does. Spotted
+a term in the wild that belongs here? [Send an emissary](https://github.com/bamr87/it-journey/pulls).*
 
 ## 🕸️ Knowledge Graph
 
@@ -84,4 +328,3 @@ Worlds - OS
 **Level hub:** [[Level 0000 - Foundation & Init World]]
 **Overworld:** [[🏰 Overworld - Master Quest Map]]
 **Obsidian docs:** [[Obsidian Knowledge Graph and Wiki Links]]
-


### PR DESCRIPTION
## Summary

- Rewrites [`pages/_quests/codex/glossary.md`](../../blob/claude/keen-moore-de139d/pages/_quests/codex/glossary.md) from a ~20-line word sketch into a ~120-entry canonical lexicon spanning geography (worlds/OSes, the Digital Heavens/cloud, City Gates/ports), the traveler (classes, tiers, XP), spellcraft (scripts, terminal, languages), chronomancy (git), a bestiary (bugs, daemons, dragons/incidents, phishing/mimics), artifacts (dependencies-as-potions, build artifacts), the great works (build/test/deploy/monitor), law & fellowship (licenses, PRs-as-emissaries, the Warden Pact), and "words of power" (`sudo`, `rm -rf`, `--force`) — each entry giving the fantasy term, the real technology, and a usable field note.
- Publishes the page (`draft: true` → `false`) — it was already linked from the Codex hub and quest nav despite never rendering.
- Points `.github/instructions/quest.instructions.md` §8, the `quest-forge` skill, and `_data/brand/sections/quest.md` at the glossary as the single naming canon: no synonyms for terms it already names, new coinages land there first.
- `_data/navigation/quests.yml` regenerated via `make quest-data` (glossary frontmatter changed).

## Why

Quest narrative was inventing fantasy metaphors ad hoc per quest with only a 9-row reference table to anchor consistency. This gives authors (human and the quest-forge/content-curator AI fleet) one place to pull vocabulary from, so "a dragon in one tale isn't a lizard in the next."

## Test plan

- [x] `python3 scripts/ci/brand_lint.py pages/_quests/codex/glossary.md` — on-brand, no drift
- [x] `python3 test/quest-validator/quest_validator.py pages/_quests/codex/glossary.md` — passed
- [x] `make quest-audit` — passed (content + network + freshness)
- [x] `make content-audit` — passed
- [x] All internal links in the new glossary verified against real permalinks (fixed two that pointed at collections removed in the 2026 overhaul)

🤖 Generated with [Claude Code](https://claude.com/claude-code)