### PR TITLE
fix(ci): persist-credentials:false on the remaining create-pull-request lanes

### DIFF
--- a/.github/workflows/quest-fix.yml
+++ b/.github/workflows/quest-fix.yml
@@ -139,6 +139,12 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTO_PR_GITHUB_TOKEN || secrets.PAT_TOKEN }}
+          # checkout v7 persists credentials via an includeIf'd config file that
+          # create-pull-request v6 can't see — CPR then adds its own auth header
+          # and GitHub 400s the push with 'Duplicate header: Authorization'
+          # (the bug that broke the CMS daily loop). CPR authenticates itself
+          # from its `token:` input; this job has no raw `git push`.
+          persist-credentials: false
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:

--- a/.github/workflows/quest-perfection.yml
+++ b/.github/workflows/quest-perfection.yml
@@ -355,6 +355,12 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTO_PR_GITHUB_TOKEN || secrets.PAT_TOKEN || github.token }}
+          # checkout v7 persists credentials via an includeIf'd config file that
+          # create-pull-request v6 can't see — CPR then adds its own auth header
+          # and GitHub 400s the push with 'Duplicate header: Authorization'
+          # (the bug that broke the CMS daily loop). CPR authenticates itself
+          # from its `token:` input; this job has no raw `git push`.
+          persist-credentials: false
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:

--- a/.github/workflows/quest-walkthrough.yml
+++ b/.github/workflows/quest-walkthrough.yml
@@ -98,6 +98,12 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.AUTO_PR_GITHUB_TOKEN || secrets.PAT_TOKEN || github.token }}
+          # checkout v7 persists credentials via an includeIf'd config file that
+          # create-pull-request v6 can't see — CPR then adds its own auth header
+          # and GitHub 400s the push with 'Duplicate header: Authorization'
+          # (the bug that broke the CMS daily loop). CPR authenticates itself
+          # from its `token:` input; this job has no raw `git push`.
+          persist-credentials: false
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:


### PR DESCRIPTION
## Summary

The follow-up flagged in #411, now urgent because the PAT is re-minted and working: with checkout no longer failing, the quest lanes will reach their **create-pull-request** steps — where the same checkout-v7 + CPR-v6 **`Duplicate header: "Authorization"` → 400** that broke the CMS daily loop is waiting.

**Verified before fixing:** after the token rotation I dispatched 🧭 Quest Walkthrough ([run 28616835914](https://github.com/bamr87/it-journey/actions/runs/28616835914)) — its checkout now **succeeds** (the step that had failed every day since June 30). That run still uses the old workflow config, so its report-PR step may 400; runs after this merge won't.

### Change

`persist-credentials: false` on the checkout of every remaining job that pairs checkout v7 with create-pull-request v6:

| Workflow | Job | Note |
|---|---|---|
| `quest-walkthrough.yml` | `walk` | report PR |
| `quest-fix.yml` | `fix` | fix PR |
| `quest-perfection.yml` | `slice` **only** | ledger/dashboard PR — the `plan` job has no CPR and is untouched |

Audited each job first: none performs a raw `git push` (CPR authenticates itself from its `token:` input), and none does an in-job `git fetch` that would need persisted credentials. Same fix + inline comment as the CMS loop in #411; `content-factory`/`agent-audit`/`issue-autopilot` don't use CPR and need nothing.

## Validation

- YAML parses; yamllint clean (beyond the pre-existing repo-wide warnings)
- CI `actionlint` gates this PR (workflow changes)
- Live evidence for the underlying failure chain in the linked runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEojXuotoSHa7SL7w9W7JU

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEojXuotoSHa7SL7w9W7JU)_