### PR TITLE
fix(ci): unbreak the quest-perfection loop — startup permissions, artifact names, evidence hand-off

### DIFF
--- a/.github/workflows/quest-perfection.yml
+++ b/.github/workflows/quest-perfection.yml
@@ -301,6 +301,10 @@ jobs:
               include.append({
                   "slug": slug,
                   "plan_file": pf,
+                  # Dash form of the slug for artifact + branch names: artifact
+                  # names reject '/', and it keeps branches consistent with the
+                  # fix lane's automated/quest-fix-<char>-<code>.
+                  "branch_slug": slug.replace("/", "-"),
                   # GitHub matrix values stringify booleans inconsistently; carry an
                   # explicit string the slice job compares as a string.
                   "open_new_fix_prs": "true" if open_new else "false",
@@ -468,7 +472,7 @@ jobs:
         with:
           token: ${{ secrets.AUTO_PR_GITHUB_TOKEN || secrets.PAT_TOKEN || github.token }}
           commit-message: "test(quests): quest walkthrough + ledger update [${{ matrix.slug }}]"
-          branch: automated/quest-perfection-${{ matrix.slug }}
+          branch: automated/quest-perfection-${{ matrix.branch_slug }}
           delete-branch: true
           add-paths: |
             test/quest-validator/walkthroughs/**
@@ -498,7 +502,9 @@ jobs:
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: quest-perfection-${{ matrix.slug }}
+          # branch_slug, not slug — artifact names reject '/'. The fix job below
+          # downloads this same artifact by name, so the two must stay in sync.
+          name: quest-perfection-${{ matrix.branch_slug }}
           path: |
             walk-plan.json
             walk-evidence.json
@@ -544,6 +550,15 @@ jobs:
     # short-circuiting is re-checked INSIDE quest-fix.yml (it reads the ledger before
     # editing), so a slice that became perfect during the walk still ships no fix PR.
     if: ${{ needs.plan.outputs.fix_count != '0' && needs.plan.outputs.fix_matrix != '' }}
+    # The caller job's permissions CAP every job in the called workflow, and GitHub
+    # validates that containment when assembling the workflow graph AT TRIGGER TIME.
+    # quest-fix.yml's `fix` job requests contents:write + pull-requests:write, so
+    # without this explicit grant the whole workflow (gate included) dies as a
+    # startup_failure before a single job runs — the workflow-level default here
+    # is contents:read.
+    permissions:
+      contents: write
+      pull-requests: write
     strategy:
       max-parallel: 1
       fail-fast: false
@@ -551,4 +566,11 @@ jobs:
     uses: ./.github/workflows/quest-fix.yml
     with:
       slug: ${{ matrix.slug }}
+      # Hand the walk's OWN plan + evidence (the slice job's artifact — both
+      # inputs name the same artifact) to the fix lane, so it repairs exactly
+      # what THIS run's walkthrough witnessed instead of re-deriving evidence
+      # with a second expensive agentic execute run. quest-fix still re-derives
+      # anything the artifact turns out not to contain.
+      plan_artifact: quest-perfection-${{ matrix.branch_slug }}
+      evidence_artifact: quest-perfection-${{ matrix.branch_slug }}
     secrets: inherit


### PR DESCRIPTION
## What broke

Every scheduled run of the ♾️ Quest Perfection Loop since it landed has died as a **startup_failure** ([28658579297](https://github.com/bamr87/it-journey/actions/runs/28658579297), plus 07-01 and 07-02) — zero jobs ever ran, and quest-fix.yml has never executed. The error on the run page:

> quest-perfection.yml (Line: 537): Error calling workflow quest-fix.yml. The nested job 'fix' is requesting 'contents: write, pull-requests: write', but is only allowed 'contents: read, pull-requests: none'.

The `fix` caller job (the reusable-workflow call) declared no `permissions:`, so it inherited the workflow-level `contents: read` — and a caller job's permissions **cap** every job in the called workflow. GitHub validates that containment while assembling the workflow graph at trigger time, so the whole workflow (gate included) was rejected before a single job ran. actionlint doesn't check this rule, which is why lint-workflows never caught it.

## The fixes

1. **Startup failure** — grant the `fix` caller job `contents: write` + `pull-requests: write`, exactly what quest-fix.yml's `fix` job requests.
2. **Next-in-line failure** — the slice job named its artifact `quest-perfection-${{ matrix.slug }}`, but slugs contain `/` (`developer/0000`) and upload-artifact v4 rejects `/` in artifact names, so every slice would have gone red at the (`if: always()`) upload step. The plan matrix now carries a dashed `branch_slug`, used for the artifact name **and** the report-PR branch (consistent with the fix lane's `automated/quest-fix-<char>-<code>`).
3. **Evidence hand-off gap** — the orchestrator never passed the walk's plan/evidence artifacts to quest-fix (despite quest-fix.yml documenting that contract), so the fix lane would re-derive evidence with a **second full agentic execute run** — expensive, and it would repair a *different* run's findings than the walkthrough report the human reviews. The fix call now passes `plan_artifact`/`evidence_artifact` pointing at the slice's artifact; quest-fix still re-derives anything the artifact doesn't contain.

## Validation

- **actionlint 1.7.12 at CI parity** (`-shellcheck=`): clean on both workflows.
- **Local simulation of the plan job's matrix step** (extracted heredoc, real ledger + budget): `branch_slug` present in every entry, dashed character keys (`system-engineer`) handled, `fix_matrix` filter intact.
- **Live smoke test** — [dispatch run 28687235664](https://github.com/bamr87/it-journey/actions/runs/28687235664) on this branch with `max_slices=0`: the graph **assembled** (the exact thing that failed at startup), gate ✓, plan ✓ (planner + OODA observed 0 open fix PRs), slice/fix skipped cleanly, run green.

## Reviewer notes

- Merge **before 11:00 UTC** to catch tomorrow's scheduled run — main's copy still startup-fails daily until then.
- All four gate variables (`QUEST_PERFECTION_ENABLED`, `QUEST_FIX_ENABLED`, `QUEST_WALKTHROUGH_ENABLED`, `CONTENT_AUTOMERGE_ENABLED`) are already `true`, so the first post-merge scheduled run will be the loop's **first real execution** — expect up to 6 walkthrough report PRs and up to 3 fix PRs (budget-capped). Walkthrough PR [#421](https://github.com/bamr87/it-journey/pull/421) from the standalone arm shows the walk machinery itself works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)