### PR TITLE
♾️ Quest perfection — walkthroughs + ledger: 2026-07-05

### DIFF
--- a/.claude/skills/quest-walkthrough/SKILL.md
+++ b/.claude/skills/quest-walkthrough/SKILL.md
@@ -48,6 +48,12 @@ on-disk `path`). This linked, dependency-sorted chain is the **session's syllabu
 If `quests` is empty, read `reason`, write a one-line "no-walkable-slice" report, and
 **STOP** — do not substitute a different level.
 
+The perfection loop plans with `--window N` (`stats.window` present): a big level
+is swept N quests per day, and the ledger accumulates coverage across runs, so your
+`quests` list may be a **window** of the full slice, not the whole level. Walk
+exactly the quests you were given — `stats.total_quests` tells you the full size for
+context, but you never expand beyond the planned window.
+
 ## 2. Execute each quest in the sandbox (the rigorous evidence pass)
 
 Drive the existing **agentic execute engine** over exactly the planned files, in

--- a/.github/workflows/quest-fix.yml
+++ b/.github/workflows/quest-fix.yml
@@ -262,9 +262,15 @@ jobs:
         run: |
           set -euo pipefail
           if [ ! -s walk-plan.json ]; then
+            # Same rotating-window cap as the walk arm (budget.yml) so a re-derive
+            # fallback can't run the engine over the whole unbounded level and
+            # exhaust the token. Normally the orchestrator's artifact supplies the
+            # already-windowed plan and this branch never fires.
+            window=$(python3 -c "import yaml;print((yaml.safe_load(open('.quests/budget.yml')) or {}).get('caps',{}).get('max_quests_per_slice',5) or 0)" 2>/dev/null || echo 5)
             python3 scripts/quest/walkthrough_plan.py \
               --character "${{ steps.slice.outputs.character }}" \
               --level "${{ steps.slice.outputs.level }}" \
+              --window "$window" \
               --json walk-plan.json
           fi
           if [ ! -s walk-evidence.json ]; then

--- a/.github/workflows/quest-perfection.yml
+++ b/.github/workflows/quest-perfection.yml
@@ -147,6 +147,16 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p plans
+          # ROTATING WINDOW — cap each slice to caps.max_quests_per_slice quests per
+          # run (a level can hold 20-30; walking them all runs the engine for hours
+          # and exhausts the OAuth token). The planner rotates the window by --date,
+          # so following days sweep the rest; the ledger accumulates coverage. Pin
+          # the date so the slice job's re-derive reproduces THIS window exactly.
+          WINDOW=$(python3 -c "import yaml;print((yaml.safe_load(open('.quests/budget.yml')) or {}).get('caps',{}).get('max_quests_per_slice',5) or 0)")
+          PLAN_DATE=$(date -u +%F)
+          echo "window=$WINDOW" >> "$GITHUB_OUTPUT"
+          echo "plan_date=$PLAN_DATE" >> "$GITHUB_OUTPUT"
+          echo "quest window per slice: $WINDOW (date $PLAN_DATE)"
           # --all-paths is the daily default; an explicit `all_paths: false` dispatch
           # narrows to a single priority slice. Either way this step must end with
           # one plans/walk-plan-<char>-<code>.json per chosen slice AND a JSON slug
@@ -155,7 +165,8 @@ jobs:
           # plan document via --json), so that branch adapts the output here.
           if [ "${ALL_PATHS:-true}" = "false" ]; then
             python3 scripts/quest/walkthrough_plan.py \
-              --priority --ledger .quests/ledger.json --json plans/single.json
+              --priority --ledger .quests/ledger.json \
+              --window "$WINDOW" --date "$PLAN_DATE" --json plans/single.json
             python3 - <<'PY'
           import json
           from pathlib import Path
@@ -175,6 +186,7 @@ jobs:
             python3 scripts/quest/walkthrough_plan.py \
               --all-paths --priority \
               --ledger .quests/ledger.json \
+              --window "$WINDOW" --date "$PLAN_DATE" \
               --out-dir plans \
               | tee plans/slugs.json
           fi
@@ -200,6 +212,10 @@ jobs:
           echo "open auto:quest-fix PRs: $open_fix_prs"
           export OPEN_FIX_PRS="$open_fix_prs"
           export MAX_SLICES="${MAX_SLICES:-}"
+          # The window + pinned date the plan step used — carried into every matrix
+          # entry so the slice job re-derives the SAME rotating window.
+          export WINDOW="${{ steps.plan.outputs.window }}"
+          export PLAN_DATE="${{ steps.plan.outputs.plan_date }}"
           python3 - <<'PY' >> "$GITHUB_OUTPUT"
           import json, os, glob, re, sys
           from datetime import datetime, timezone, timedelta
@@ -335,6 +351,11 @@ jobs:
                   # names reject '/', and it keeps branches consistent with the
                   # fix lane's automated/quest-fix-<char>-<code>.
                   "branch_slug": slug.replace("/", "-"),
+                  # The rotating-window params the plan step used — the slice job
+                  # re-derives walk-plan.json with EXACTLY these so it walks the same
+                  # quests (not the whole unbounded level).
+                  "window": os.environ.get("WINDOW", "5"),
+                  "plan_date": os.environ.get("PLAN_DATE", ""),
                   # GitHub matrix values stringify booleans inconsistently; carry an
                   # explicit string the slice job compares as a string.
                   "open_new_fix_prs": "true" if open_new else "false",
@@ -382,6 +403,9 @@ jobs:
       SLUG: ${{ matrix.slug }}
       PLAN_FILE: ${{ matrix.plan_file }}
       OPEN_NEW_FIX_PRS: ${{ matrix.open_new_fix_prs }}
+      # The rotating-window params the plan step pinned — re-derive the SAME window.
+      WINDOW: ${{ matrix.window }}
+      PLAN_DATE: ${{ matrix.plan_date }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -404,8 +428,9 @@ jobs:
       # Re-derive this slice's plan deterministically so the log shows exactly
       # what will be walked and the rest of the job has a stable walk-plan.json.
       # The orchestrator's plan job emitted plans/walk-plan-<slug>.json; this run
-      # re-plans the same slice from the same data, fail-fast if the slice is now
-      # empty/broken.
+      # re-plans the same slice with the SAME rotating window + pinned date, so it
+      # walks exactly that window (NOT the whole unbounded level), fail-fast if the
+      # slice is now empty/broken.
       - name: Materialize this slice's plan
         id: plan
         run: |
@@ -415,11 +440,18 @@ jobs:
           level="${SLUG##*/}"
           python3 scripts/quest/walkthrough_plan.py \
             --character "$character" --level "$level" \
+            --window "${WINDOW:-5}" ${PLAN_DATE:+--date "$PLAN_DATE"} \
             --json walk-plan.json
           python3 - <<'PY' >> "$GITHUB_OUTPUT"
           import json
           p = json.load(open("walk-plan.json"))
+          s = p.get("stats") or {}
+          w = s.get("window") or {}
           print(f"empty={'true' if not p.get('quests') else 'false'}")
+          if w:
+              print(f"::notice::slice {p['character']['key']}/{p['level']['code']} — "
+                    f"window {w.get('index',0)+1}/{w.get('of','?')}, "
+                    f"{s.get('count')} of {s.get('total_quests')} quests this run")
           PY
 
       # (1) EVIDENCE — run the agentic execute engine as a DETERMINISTIC workflow
@@ -612,8 +644,8 @@ jobs:
               except Exception:
                   led = {}
           slices = led.get("slices", {}) or {}
-          print("| slice | walk | state | note |")
-          print("|---|---|---|---|")
+          print("| slice | walk | window | coverage | state | note |")
+          print("|---|---|---|---|---|---|")
           for f in sorted(glob.glob("slices/*/walk-plan.json")):
               try:
                   p = json.loads(Path(f).read_text())
@@ -621,10 +653,15 @@ jobs:
                   continue
               slug = f"{p['character']['key']}/{p['level']['code']}"
               s = slices.get(slug) or {}
+              st = p.get("stats") or {}
+              w = st.get("window") or {}
               ev = (Path(f).parent / "walk-evidence.json").is_file()
               walk = "✅ evidenced" if ev else "⚠️ no evidence"
-              state = "🏆 perfect" if s.get("perfect") else ("🛑 stuck" if s.get("stuck") or s.get("needs_human") else "🔁 not yet perfect")
-              print(f"| `{slug}` | {walk} | {state} | {s.get('reason') or ''} |")
+              win = f"{w.get('index',0)+1}/{w.get('of','?')} ({st.get('count','?')}q)" if w else "full"
+              tot = s.get("total_quests")
+              cov = f"{s.get('covered','?')}/{tot}" if isinstance(tot, int) and tot else "—"
+              state = "🏆 perfect" if s.get("perfect") else ("🛑 stuck" if s.get("stuck") or s.get("needs_human") else "🔁 sweeping")
+              print(f"| `{slug}` | {walk} | {win} | {cov} | {state} | {s.get('reason') or ''} |")
           PY
           {
             echo "## ♾️ Quest perfection — daily walkthroughs + ledger"
@@ -689,7 +726,11 @@ jobs:
     # this job fans out over that. Per-slice "already perfect" / circuit-breaker
     # short-circuiting is re-checked INSIDE quest-fix.yml (it reads the ledger before
     # editing), so a slice that became perfect during the walk still ships no fix PR.
-    if: ${{ needs.plan.outputs.fix_count != '0' && needs.plan.outputs.fix_matrix != '' }}
+    # !cancelled() (not the default all-success): the `slice` matrix runs fail-fast:
+    # false, so one throttled/failed slice must NOT skip the fix lane for the slices
+    # that DID produce evidence. A granted slice with no evidence just no-ops in
+    # quest-fix (M7); a successful sibling still gets its fix PR.
+    if: ${{ !cancelled() && needs.plan.result == 'success' && needs.plan.outputs.fix_count != '0' && needs.plan.outputs.fix_matrix != '' }}
     # The caller job's permissions CAP every job in the called workflow, and GitHub
     # validates that containment when assembling the workflow graph AT TRIGGER TIME.
     # quest-fix.yml's `fix` job requests contents:write + pull-requests:write, so

--- a/.quests/DASHBOARD.md
+++ b/.quests/DASHBOARD.md
@@ -6,10 +6,10 @@ _Generated 2026-07-04T10:50:12+00:00. Source of truth: `.quests/ledger.json` (co
 
 ## Slices (worst-first)
 
-| Slice | Theme | Verdict | Avg | Open | Perfect | Stuck | Last run | Report |
-| --- | --- | :-: | --: | --: | :-: | :-: | --- | --- |
-| `system-engineer/0010` | Terminal Mastery | ⚠️ warn | — | 0 |  |  | 2026-07-04 | [run](https://github.com/bamr87/it-journey/actions/runs/28703664065) |
-| `developer/0000` | Foundation & Init World | ⚠️ warn | 87.6 | 0 |  |  | 2026-07-03 | [run](https://github.com/bamr87/it-journey/actions/runs/28656175477) |
+| Slice | Theme | Verdict | Avg | Cov | Open | Perfect | Stuck | Last run | Report |
+| --- | --- | :-: | --: | :-: | --: | :-: | :-: | --- | --- |
+| `system-engineer/0010` | Terminal Mastery | ⚠️ warn | — | — | 0 |  |  | 2026-07-04 | [run](https://github.com/bamr87/it-journey/actions/runs/28703664065) |
+| `developer/0000` | Foundation & Init World | ⚠️ warn | 87.6 | — | 0 |  |  | 2026-07-03 | [run](https://github.com/bamr87/it-journey/actions/runs/28656175477) |
 
 ## Per-character roll-up
 

--- a/.quests/budget.yml
+++ b/.quests/budget.yml
@@ -12,6 +12,12 @@
 # ENFORCED by quest-perfection.yml's matrix step:
 caps:
   max_walkthroughs_per_run: 6   # at most N (character, level) slices walked per run (one per path)
+  max_quests_per_slice: 5       # ROTATING WINDOW: walk at most N quests of a slice per run,
+                                #   sweeping the rest over following days (planner --window). A level
+                                #   can hold 20-30 quests; walking them all in one run runs the engine
+                                #   for hours and exhausts the OAuth token's rate limit. The ledger
+                                #   accumulates per-quest coverage across runs and certifies a slice
+                                #   `perfect` only once the whole sweep is covered + passing.
   max_fix_prs_per_run: 3        # at most N auto:content quest-fix PRs proposed per run
   max_open_quest_prs: 6         # never open new fix PRs once N are already awaiting review
   skip_perfect_within_days: 7   # don't re-walk a slice certified perfect in the last N days

--- a/.quests/config.yml
+++ b/.quests/config.yml
@@ -39,6 +39,12 @@ perfect:
   max_open_issues: 0           # zero open recommendations/issues remaining
   max_high_priority: 0         # zero high-priority recommendations remaining
   forbid_truncated: true       # a truncated run can never be perfect (M7)
+  coverage_days: 21            # cross-run coverage freshness: with the rotating window
+                               #   (budget.yml caps.max_quests_per_slice), a slice is walked
+                               #   a few quests at a time over several days; a quest's walk
+                               #   counts toward `perfect` only while it is this-fresh. Size it
+                               #   above one full sweep (ceil(total/window) days) + a fix cycle
+                               #   so a slow rotation still certifies. 0 = never expire.
   # --- RESERVED — enforced elsewhere, NOT read by ledger.py (documented here) ---
   require_executed: true       # RESERVED: verdict_obj.executed is MODEL-SUPPLIED, so the
                                #   predicate deliberately does NOT trust it (would be

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,9 +94,14 @@ map and setup.
   opens a **separate** content-only fix PR per granted slice that repairs only that
   walkthrough's *verified* issues (kept solely on a deterministic signal — tier-1
   score + brand lint + sandbox commands — never the model's own grade) →
-  auto-merges when green → repeats "until perfect". A committed ledger + generated
-  dashboard in `.quests/` are the source of truth; staged kill switches
-  `QUEST_PERFECTION_ENABLED` (orchestrator) and `QUEST_FIX_ENABLED` (write lane).
+  auto-merges when green → repeats "until perfect". Each slice walks a **rotating
+  window** of `caps.max_quests_per_slice` quests (`.quests/budget.yml`, default 5)
+  via `walkthrough_plan.py --window` — a level holds 20–30 quests and walking them
+  all in one run exhausts the OAuth token's rate limit; the ledger accumulates
+  per-quest coverage across runs and only certifies `perfect` once the whole level
+  is swept + passing. A committed ledger + generated dashboard in `.quests/` are
+  the source of truth; staged kill switches `QUEST_PERFECTION_ENABLED`
+  (orchestrator) and `QUEST_FIX_ENABLED` (write lane).
 - `agent-audit.yml` (weekly) — `agent-auditor` keeps the fleet accurate/least-privilege.
 
 **OFF by default.** Each workflow gates on a `*_ENABLED` repo variable **and** the

--- a/scripts/ai/README.md
+++ b/scripts/ai/README.md
@@ -93,6 +93,19 @@ level) slice is perfect. A daily orchestrator (`quest-perfection.yml`) fans out
 over all six character paths and, per path, picks the highest-priority
 not-yet-perfect slice from the committed ledger.
 
+**Rotating window (why a run stays bounded).** A level can hold 20–30 quests;
+walking them all in one run runs the engine for hours and exhausts the OAuth
+token's rate limit (the 2026-07-05 run auth-failed 5/6 slices doing exactly
+this). So the loop walks a **rotating window** of `caps.max_quests_per_slice`
+quests (`.quests/budget.yml`, default 5) per slice per run — `walkthrough_plan.py
+--window N`, rotated by date so following days sweep the rest. The ledger
+**accumulates per-quest coverage across runs** (`slice.coverage`, keyed by quest
+path) and certifies a slice `perfect` only once the *whole* level is covered,
+every quest execute-mode + passing, within a freshness window
+(`perfect.coverage_days`). A re-walk overwrites a quest's prior verdict, so a
+fix that flips fail→pass sticks; the circuit breaker only counts a fully-covered
+slice that stays imperfect (a mid-sweep run is progress, not a failed round).
+
 - **Walk arm** — the orchestrator's `slice` job plays each selected slice: a
   deterministic engine step mints sealed evidence, the `quest-walker` agent writes
   the session report, and a consolidated `report` job replays every slice into the

--- a/scripts/quest/ledger.py
+++ b/scripts/quest/ledger.py
@@ -205,6 +205,34 @@ def cfg_max_fix_rounds(config: dict) -> int:
     return int((config.get("fix") or {}).get("max_fix_rounds", 3) or 0)
 
 
+def cfg_coverage_days(config: dict) -> int:
+    """Freshness window (days) for cross-run per-quest coverage.
+
+    The loop walks a rotating WINDOW of a big slice each run, so a full sweep
+    takes ceil(total/window) days; a quest's walk only counts toward the slice's
+    `perfect` while it is this-fresh. Size it comfortably above one sweep + a fix
+    cycle so a slow-but-steady rotation still certifies. 0 = never expire.
+    """
+    return int(_perfect_cfg(config).get("coverage_days", 21) or 0)
+
+
+def _within_days(date_str: Optional[str], days: int) -> bool:
+    """True if `date_str` (YYYY-MM-DD) is within `days` of today (UTC).
+
+    days <= 0 means "no expiry" (always fresh). An unparseable/absent date is
+    treated as stale (False) so junk never counts as coverage.
+    """
+    if days <= 0:
+        return True
+    if not date_str:
+        return False
+    try:
+        d = datetime.strptime(str(date_str)[:10], "%Y-%m-%d").date()
+    except Exception:
+        return False
+    return (datetime.now(timezone.utc).date() - d).days <= days
+
+
 # --------------------------------------------------------------------------- #
 # Ledger I/O
 # --------------------------------------------------------------------------- #
@@ -368,6 +396,11 @@ def build_slice_entry(
             "total": 0,
             "scored": 0,
             "requested": _plan_quest_count(plan),
+            # The full slice size still matters (the ledger carries it forward so a
+            # no-evidence run doesn't erase the known denominator); this run just
+            # contributes no coverage.
+            "total_quests": _plan_total_quests(plan),
+            "per_quest": [],
             "errored": 0,
             "truncated": _plan_truncated(plan),
             "counts": {VERDICT_PASS: 0, VERDICT_WARN: 0, VERDICT_FAIL: 0},
@@ -450,12 +483,42 @@ def build_slice_entry(
             average, average_min, open_issues, max_open, high, max_high,
         )
 
+    # Per-quest coverage deltas — merge_slice folds these into slice.coverage so a
+    # ROTATED (windowed) sweep accumulates toward full-slice perfect across runs.
+    # An errored result carries no usable verdict, so it contributes no coverage
+    # (the quest must be re-walked); a passing/warn/fail result does.
+    per_quest = []
+    for r in results:
+        if "error" in r:
+            continue
+        q = r.get("quest") or {}
+        path = q.get("path") or q.get("rel_path")
+        v = r.get("verdict")
+        if not path or v not in (VERDICT_PASS, VERDICT_WARN, VERDICT_FAIL):
+            continue
+        r_open, r_high = _count_recommendations([r])
+        per_quest.append({
+            "path": path,
+            "verdict": v,
+            "average": r.get("overall"),
+            "open_issues": r_open,
+            "high": r_high,
+            "mode": mode,
+            "executed": bool((r.get("verdict_obj") or {}).get("executed")),
+        })
+
     entry.update({
         "verdict": verdict,
         "average": average,
         "total": total,
         "scored": scored,
         "requested": requested,
+        # Full slice size (the cross-run coverage denominator) + this run's per-quest
+        # coverage deltas. merge_slice is the AUTHORITY on slice `perfect` (over
+        # accumulated coverage); the `perfect` above is this single run's structural
+        # check, which merge overrides.
+        "total_quests": _plan_total_quests(plan) or requested,
+        "per_quest": per_quest,
         "errored": errored,
         "truncated": truncated,
         "counts": counts,
@@ -476,6 +539,18 @@ def _plan_quest_count(plan: Optional[dict]) -> int:
         return stats["count"]
     quests = plan.get("quests") or []
     return len(quests) if isinstance(quests, list) else 0
+
+
+def _plan_total_quests(plan: Optional[dict]) -> int:
+    """The FULL slice size (all quests in the level), the denominator for cross-run
+    coverage. A rotated plan carries `stats.total_quests`; a plan that predates the
+    field (or a first-N cap) falls back to its own quest count."""
+    if not isinstance(plan, dict):
+        return 0
+    stats = plan.get("stats") or {}
+    if isinstance(stats.get("total_quests"), int) and stats["total_quests"] > 0:
+        return stats["total_quests"]
+    return _plan_quest_count(plan)
 
 
 def _plan_truncated(plan: Optional[dict]) -> bool:
@@ -512,6 +587,112 @@ def _why_not_perfect(mode, require_mode, truncated, forbid_truncated,
     if high > max_high:
         bits.append(f"{high} high-priority")
     return "; ".join(bits) or "not perfect"
+
+
+# --------------------------------------------------------------------------- #
+# Cross-run coverage (rotating-window sweeps → whole-slice perfect)
+# --------------------------------------------------------------------------- #
+def _merge_coverage(prev_cov: Optional[dict], per_quest: Optional[list],
+                    coverage_days: int) -> dict:
+    """Fold this run's per-quest verdicts into the slice coverage map + prune stale.
+
+    Keyed by quest path: a re-walk OVERWRITES that quest's prior verdict (so a
+    fail→pass fix sticks). Entries older than `coverage_days` are dropped, so a
+    removed or long-unwalked quest stops counting as coverage.
+    """
+    cov = dict(prev_cov or {})
+    today = today_str()
+    for pq in (per_quest or []):
+        path = pq.get("path")
+        if not path:
+            continue
+        cov[path] = {
+            "verdict": pq.get("verdict"),
+            "average": pq.get("average"),
+            "open_issues": int(pq.get("open_issues") or 0),
+            "high": int(pq.get("high") or 0),
+            "mode": pq.get("mode"),
+            "executed": bool(pq.get("executed")),
+            "date": today,
+        }
+    return {p: c for p, c in cov.items()
+            if _within_days((c or {}).get("date"), coverage_days)}
+
+
+def _coverage_rollup(cov: dict, total_quests: int, config: dict) -> dict:
+    """Roll the coverage map up to a slice verdict + the `perfect` decision.
+
+    `perfect` requires the WHOLE slice covered (covered >= total_quests), every
+    covered quest walked in execute mode and passing, the mean score at/above the
+    bar, and issue counts within caps. Mirrors the single-run predicate's config
+    knobs, applied to accumulated coverage instead of one run.
+    """
+    entries = list(cov.values())
+    counts = {VERDICT_PASS: 0, VERDICT_WARN: 0, VERDICT_FAIL: 0}
+    for c in entries:
+        v = c.get("verdict")
+        if v in counts:
+            counts[v] += 1
+    covered = counts[VERDICT_PASS] + counts[VERDICT_WARN] + counts[VERDICT_FAIL]
+    avgs = [c["average"] for c in entries if isinstance(c.get("average"), (int, float))]
+    average = round(sum(avgs) / len(avgs), 1) if avgs else None
+    open_issues = sum(int(c.get("open_issues") or 0) for c in entries)
+    high = sum(int(c.get("high") or 0) for c in entries)
+    verdict = _worst_verdict([{"verdict": c.get("verdict")} for c in entries])
+    all_execute = bool(entries) and all(c.get("mode") == "execute" for c in entries)
+    fully_covered = total_quests > 0 and covered >= total_quests
+
+    average_min = cfg_average_min(config)
+    max_warn = cfg_max(config, "max_warn", 0)
+    max_fail = cfg_max(config, "max_fail", 0)
+    max_open = cfg_max(config, "max_open_issues", 0)
+    max_high = cfg_max(config, "max_high_priority", 0)
+
+    perfect = (
+        cfg_require_mode(config) == "execute"
+        and all_execute
+        and fully_covered
+        and counts[VERDICT_WARN] <= max_warn
+        and counts[VERDICT_FAIL] <= max_fail
+        and average is not None
+        and average >= average_min
+        and open_issues <= max_open
+        and high <= max_high
+    )
+
+    reason = ""
+    if not perfect:
+        bits: list[str] = []
+        if not all_execute and entries:
+            bits.append("coverage includes non-execute walks")
+        if not fully_covered:
+            bits.append(f"covered {covered}/{total_quests}")
+        if counts[VERDICT_FAIL] > max_fail:
+            bits.append(f"{counts[VERDICT_FAIL]} fail")
+        if counts[VERDICT_WARN] > max_warn:
+            bits.append(f"{counts[VERDICT_WARN]} warn")
+        if average is None:
+            bits.append("no average")
+        elif average < average_min:
+            bits.append(f"avg {average} < {average_min}")
+        if open_issues > max_open:
+            bits.append(f"{open_issues} open issue(s)")
+        if high > max_high:
+            bits.append(f"{high} high-priority")
+        reason = "; ".join(bits) or "not perfect"
+
+    return {
+        "covered": covered,
+        "counts": counts,
+        "average": average,
+        "open_issues": open_issues,
+        "high": high,
+        "verdict": verdict,
+        "all_execute": all_execute,
+        "fully_covered": fully_covered,
+        "perfect": perfect,
+        "reason": reason,
+    }
 
 
 # --------------------------------------------------------------------------- #
@@ -557,11 +738,27 @@ def merge_slice(
     last_fixed = prev.get("last_fixed")
     max_rounds = cfg_max_fix_rounds(config)
 
-    perfect = bool(entry.get("perfect"))
+    # ----- CROSS-RUN COVERAGE (the authority on slice `perfect`) --------------
+    # Fold this run's per-quest verdicts into the slice's coverage map, prune
+    # stale entries, then certify `perfect` over the WHOLE slice — not the single
+    # (possibly windowed) run. This is what lets a rotated sweep of a 26-quest
+    # level converge to perfect across days: each run advances coverage; a re-walk
+    # of a quest OVERWRITES its prior verdict (so a fix that flips fail→pass sticks).
+    # entry["perfect"] (build_slice_entry's single-run structural check) is NOT
+    # trusted here; slice perfect is recomputed from the accumulated map.
+    cov = _merge_coverage(prev.get("coverage"), entry.get("per_quest"),
+                          cfg_coverage_days(config))
+    total_quests = int(entry.get("total_quests") or prev.get("total_quests") or 0)
+    roll = _coverage_rollup(cov, total_quests, config)
+    perfect = roll["perfect"]
     perfect_since = prev.get("perfect_since")
-    # Only verdict-bearing walks (a real evaluation, not an empty/unparseable run)
-    # advance or reset the breaker — a no-evidence walk must not count as a round.
-    real_walk = event == "walk" and entry.get("verdict") is not None
+    # The circuit breaker only advances once the slice is FULLY COVERED but still
+    # imperfect — that is the "walk → fix → re-walk, still not perfect" loop it
+    # exists to break. A walk that merely advances an INCOMPLETE rotating sweep is
+    # progress, not a failed fix round, so it must not accrue toward `stuck`
+    # (otherwise a 26-quest slice would trip the breaker mid-first-sweep).
+    real_round = (event == "walk" and entry.get("verdict") is not None
+                  and roll["fully_covered"])
     if perfect:
         if not perfect_since:
             perfect_since = today_str()
@@ -570,14 +767,17 @@ def merge_slice(
         stuck_reason = None
     else:
         perfect_since = None
-        if real_walk and int(prev.get("runs", 0) or 0) > 0 and not prev.get("perfect"):
-            # A repeat imperfect walk: one more fix round elapsed without converging.
+        if real_round and int(prev.get("runs", 0) or 0) > 0 and not prev.get("perfect"):
+            # A repeat FULLY-COVERED imperfect walk: one more fix round without converging.
             fix_rounds += 1
             if max_rounds and fix_rounds >= max_rounds and not stuck:
                 stuck = True
                 stuck_reason = (f"still imperfect after {fix_rounds} walk→fix rounds "
                                 f"(max {max_rounds}); needs human review")
 
+    # Display fields report the SLICE's accumulated state (from coverage), not just
+    # the last window — so the dashboard/PR table show "the slice overall", with a
+    # covered N/total that makes an in-progress sweep legible.
     merged = {
         "slug": slug,
         "character": entry.get("character") or prev.get("character") or slug.split("/")[0],
@@ -585,20 +785,24 @@ def merge_slice(
         "theme": entry.get("theme") or prev.get("theme"),
         "tier": entry.get("tier") or prev.get("tier"),
         "mode": entry.get("mode"),
-        "verdict": entry.get("verdict"),
-        "average": entry.get("average"),
+        "verdict": roll["verdict"],
+        "average": roll["average"],
         "total": entry.get("total"),
-        "scored": entry.get("scored"),
-        "requested": entry.get("requested"),
+        # scored/requested reinterpreted at slice scope: covered-so-far / full size.
+        "scored": roll["covered"],
+        "requested": total_quests,
+        "total_quests": total_quests,
+        "covered": roll["covered"],
         "errored": entry.get("errored"),
         "truncated": entry.get("truncated"),
-        "counts": entry.get("counts"),
-        "open_issues": entry.get("open_issues"),
-        "high_priority_issues": entry.get("high_priority_issues"),
-        "executed": entry.get("executed"),
+        "counts": roll["counts"],
+        "open_issues": roll["open_issues"],
+        "high_priority_issues": roll["high"],
+        "executed": roll["all_execute"],
         "perfect": perfect,
         "perfect_since": perfect_since,
-        "reason": entry.get("reason"),
+        "reason": "" if perfect else roll["reason"],
+        "coverage": cov,
         "fix_rounds": fix_rounds,
         "stuck": stuck,
         "stuck_reason": stuck_reason,
@@ -747,8 +951,8 @@ def render_dashboard(ledger: dict) -> str:
     # ----- all slices, worst-first ------------------------------------------ #
     lines.append("## Slices (worst-first)")
     lines.append("")
-    lines.append("| Slice | Theme | Verdict | Avg | Open | Perfect | Stuck | Last run | Report |")
-    lines.append("| --- | --- | :-: | --: | --: | :-: | :-: | --- | --- |")
+    lines.append("| Slice | Theme | Verdict | Avg | Cov | Open | Perfect | Stuck | Last run | Report |")
+    lines.append("| --- | --- | :-: | --: | :-: | --: | :-: | :-: | --- | --- |")
 
     def row_sort(item):
         slug, slc = item
@@ -767,9 +971,12 @@ def render_dashboard(ledger: dict) -> str:
         run_url = slc.get("run_url")
         report = f"[run]({run_url})" if run_url else "—"
         theme = (slc.get("theme") or "").replace("|", "\\|")
+        tot_q = slc.get("total_quests")
+        cov_cell = (f"{slc.get('covered', 0)}/{tot_q}"
+                    if isinstance(tot_q, int) and tot_q > 0 else "—")
         lines.append(
             f"| `{slug}` | {theme} | {emoji} {verdict or '—'} | {avg_cell} | "
-            f"{slc.get('open_issues', 0)} | {perfect_cell} | {stuck_cell} | "
+            f"{cov_cell} | {slc.get('open_issues', 0)} | {perfect_cell} | {stuck_cell} | "
             f"{last} | {report} |"
         )
     lines.append("")
@@ -997,12 +1204,16 @@ def _agg(results: list[dict], **top) -> dict:
     return base
 
 
-def _result(level, verdict, overall, *, executed=True, recs=None, error=None):
+def _result(level, verdict, overall, *, qid="q", executed=True, recs=None, error=None):
+    # qid gives each synthetic quest a STABLE, distinct path — the ledger keys
+    # cross-run coverage by path, so a re-walk of the same qid overwrites (models a
+    # fix landing) and distinct qids accumulate as separate coverage.
+    path = f"pages/_quests/{level}/{qid}.md"
     if error:
-        return {"quest": {"path": f"q/{level}", "slug": "s", "level": level},
+        return {"quest": {"path": path, "slug": qid, "level": level},
                 "verdict": VERDICT_FAIL, "error": error}
     return {
-        "quest": {"path": f"q/{level}", "slug": "s", "level": level},
+        "quest": {"path": path, "slug": qid, "level": level},
         "verdict": verdict,
         "overall": overall,
         "verdict_obj": {
@@ -1014,13 +1225,16 @@ def _result(level, verdict, overall, *, executed=True, recs=None, error=None):
     }
 
 
-def _plan(char, level, count=1, truncated=False):
+def _plan(char, level, count=1, truncated=False, total=None):
+    # total (stats.total_quests) is the FULL slice size the ledger's cross-run
+    # coverage measures against; defaults to count (a full, non-windowed plan).
     return {
         "schema_version": "1.0.0",
         "character": {"key": char},
         "level": {"code": level, "theme": reg.theme_of(level), "tier": reg.tier_of(level)},
         "quests": [{"permalink": f"/quests/{level}/q{i}/"} for i in range(count)],
-        "stats": {"count": count, "truncated": truncated},
+        "stats": {"count": count, "total_quests": count if total is None else total,
+                  "truncated": truncated},
     }
 
 
@@ -1033,10 +1247,11 @@ def _selftest() -> int:  # noqa: C901 - exhaustive on purpose
             fails.append(msg)
 
     # 1) PERFECT: execute, non-truncated, fully scored, all pass, high avg, 0 issues.
+    # Two DISTINCT quests (qid a, b) so this doubles as a full-slice coverage input.
     plan = _plan("developer", "0001", count=2)
     agg = _agg([
-        _result("0001", VERDICT_PASS, 98),
-        _result("0001", VERDICT_PASS, 96),
+        _result("0001", VERDICT_PASS, 98, qid="a"),
+        _result("0001", VERDICT_PASS, 96, qid="b"),
     ])
     e = build_slice_entry(agg, plan, "execute", "http://run/1", cfg)
     check(e["perfect"] is True, f"perfect slice should be perfect: {e.get('reason')}")
@@ -1044,12 +1259,14 @@ def _selftest() -> int:  # noqa: C901 - exhaustive on purpose
     check(e["open_issues"] == 0, "perfect slice open_issues should be 0")
 
     # 2) WARN: a warn result can never be perfect; open_issues counts its recs.
+    # Full-slice {a pass, b warn} so re-walks overwrite the same quests in coverage.
     aggw = _agg([
-        _result("0001", VERDICT_WARN, 72,
+        _result("0001", VERDICT_PASS, 96, qid="a"),
+        _result("0001", VERDICT_WARN, 72, qid="b",
                 recs=[{"priority": "high", "area": "cmd", "suggestion": "fix"},
                       {"priority": "low", "area": "x", "suggestion": "y"}]),
     ])
-    ew = build_slice_entry(aggw, _plan("developer", "0001"), "execute", None, cfg)
+    ew = build_slice_entry(aggw, _plan("developer", "0001", count=2), "execute", None, cfg)
     check(ew["perfect"] is False, "warn slice must not be perfect")
     check(ew["verdict"] == VERDICT_WARN, "warn verdict")
     check(ew["open_issues"] == 2, f"warn open_issues should be 2, got {ew['open_issues']}")
@@ -1104,6 +1321,31 @@ def _selftest() -> int:  # noqa: C901 - exhaustive on purpose
     check(ledger["slices"]["developer/0001"]["perfect"] is False, "regressed not perfect")
     check(ledger["slices"]["developer/0001"]["perfect_since"] is None, "perfect_since cleared")
     check(ledger["slices"]["developer/0001"]["runs"] == 2, "runs bumped to 2")
+
+    # ---- WINDOWED coverage: a ROTATING sweep certifies perfect only once the WHOLE
+    # slice is covered (never on the first all-pass window), and a re-walk that flips
+    # a quest fail→pass completes it. total=3, one quest per run (window of 1).
+    lw = empty_ledger()
+
+    def _win(qid, verdict, overall=98, recs=None):
+        return build_slice_entry(
+            _agg([_result("0011", verdict, overall, qid=qid, recs=recs)]),
+            _plan("data-scientist", "0011", count=1, total=3), "execute", None, cfg)
+
+    mw = merge_slice(lw, "data-scientist/0011", _win("a", VERDICT_PASS), "walk", cfg)
+    check(mw["perfect"] is False and mw["covered"] == 1, "1/3 covered → not perfect yet")
+    check("1/3" in (mw["reason"] or ""), f"reason should show partial coverage: {mw['reason']}")
+    mw = merge_slice(lw, "data-scientist/0011", _win("b", VERDICT_PASS), "walk", cfg)
+    check(mw["perfect"] is False and mw["covered"] == 2, "2/3 covered → not perfect yet")
+    mw = merge_slice(lw, "data-scientist/0011", _win("c", VERDICT_FAIL, 30), "walk", cfg)
+    check(mw["perfect"] is False and mw["covered"] == 3, "3/3 covered but a fail → not perfect")
+    check("fail" in (mw["reason"] or ""), "coverage reason names the fail")
+    # Re-walk quest c after a 'fix' flips fail→pass; coverage OVERWRITES, slice completes.
+    mw = merge_slice(lw, "data-scientist/0011", _win("c", VERDICT_PASS), "walk", cfg)
+    check(mw["perfect"] is True, f"re-walk fixing the last quest → perfect: {mw.get('reason')}")
+    check(mw["covered"] == 3 and mw["requested"] == 3, "perfect slice covered 3/3")
+    check(lw["slices"]["data-scientist/0011"]["stuck"] is False,
+          "a normal multi-day sweep must NOT trip the circuit breaker")
 
     # ---- COLD START select: an unwalked slice outranks a walked non-perfect one ----
     ledger2 = empty_ledger()

--- a/scripts/quest/walkthrough_plan.py
+++ b/scripts/quest/walkthrough_plan.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import sys
 from datetime import date as _date
 from pathlib import Path
@@ -361,17 +362,46 @@ def _strongly_connected(ids: List[str], succ: Dict[str, set]) -> List[List[str]]
 
 
 def build_plan(character: dict, level: str, network: dict,
-               max_quests: int = 0) -> dict:
-    """Resolve the linked playthrough plan for one (character, level) slice."""
+               max_quests: int = 0, window: int = 0,
+               window_on: Optional[_date] = None) -> dict:
+    """Resolve the linked playthrough plan for one (character, level) slice.
+
+    Two independent ways to bound a big slice (a level can hold 20-30 quests):
+      * `max_quests` — a hard first-N cap (the standalone/manual arm). Flags
+        `stats.truncated`: the run only ever sees the first N quests.
+      * `window` — a date-ROTATED window of N quests (the perfection loop). Each
+        run walks a different contiguous slice, so over ceil(total/N) days the
+        whole level is covered. The ledger accumulates that per-quest coverage
+        across runs and only certifies `perfect` once the sweep is complete, so a
+        single window is NOT treated as the whole slice. `stats.total_quests`
+        always carries the full size for that cross-run accounting.
+    `window` wins if both are set.
+    """
     if not reg.is_valid_level(level):
         raise ValueError(f"invalid level '{level}' (expected a 4-bit code like 0001).")
 
     nodes = [n for n in network.get("nodes", [])
              if n.get("level") == level and n.get("type") in WALKABLE_TYPES]
     ordered = _order_links(nodes, network.get("edges", []))
+    total_quests = len(ordered)
 
     truncated = False
-    if max_quests and max_quests > 0 and len(ordered) > max_quests:
+    window_info: Optional[dict] = None
+    if window and window > 0:
+        # Date-rotated window: systematic daily sweep (index += 1 per day, wraps).
+        # An empty/small slice (total <= window) is one window covering everything.
+        num_windows = max(1, math.ceil(total_quests / window)) if total_quests else 1
+        on = window_on or _date.today()
+        index = on.toordinal() % num_windows
+        start = index * window
+        ordered = ordered[start:start + window]
+        window_info = {
+            "index": index,
+            "of": num_windows,
+            "size": window,
+            "offset": start,
+        }
+    elif max_quests and max_quests > 0 and len(ordered) > max_quests:
         ordered = ordered[:max_quests]
         truncated = True
 
@@ -411,7 +441,15 @@ def build_plan(character: dict, level: str, network: dict,
         "quests": quests,
         "stats": {
             "count": len(quests),
+            # The FULL slice size — the denominator the ledger's cross-run coverage
+            # + perfect predicate use. `count` is just this run's (possibly windowed)
+            # subset; `total_quests` is the whole level.
+            "total_quests": total_quests,
             "truncated": truncated,
+            # Present only for a rotated (loop) plan: which window of the sweep this
+            # run walks. Absent/None for a full or first-N-capped plan.
+            "windowed": window_info is not None,
+            "window": window_info,
             "by_type": _count(quests, "type"),
             "by_difficulty": _count(quests, "difficulty"),
         },
@@ -462,8 +500,16 @@ def render_text(plan: dict) -> str:
         diff = q["difficulty"] or "—"
         lines.append(f"   {i:>2}. [{q['type']}] {q['title']}")
         lines.append(f"       {diff}  ·  {q['permalink']}  ·  {q['path']}")
-    if plan["stats"]["truncated"]:
+    stats = plan["stats"]
+    if stats["truncated"]:
         lines.append("\n   (list truncated by --max-quests)")
+    w = stats.get("window")
+    if w:
+        lines.append(
+            f"\n   (rotated window {w['index'] + 1}/{w['of']} — quests "
+            f"{w['offset'] + 1}‑{w['offset'] + stats['count']} of "
+            f"{stats['total_quests']}; the ledger accumulates full-slice coverage "
+            f"across runs)")
     return "\n".join(lines)
 
 
@@ -535,6 +581,32 @@ def _selftest() -> int:
     if len(order) > 1:
         assert capped["stats"]["truncated"], "truncation not flagged"
 
+    # --- rotated window: bounds the run to N, carries the FULL size, and sweeps
+    # every quest over ceil(total/N) days without gap or overlap.
+    dev = resolve_character(paths, "developer")
+    full = build_plan(dev, "0001", network)["stats"]["total_quests"]
+    if full > 2:
+        N = 2
+        num_windows = math.ceil(full / N)
+        seen: list = []
+        for day in range(num_windows):
+            wp = build_plan(dev, "0001", network, window=N,
+                            window_on=_date.fromordinal(d.toordinal() + day))
+            ws = wp["stats"]
+            assert ws["count"] <= N, "window exceeded its size"
+            assert ws["total_quests"] == full, "window lost the full slice size"
+            assert ws["windowed"] and ws["window"], "window not flagged"
+            assert ws["window"]["of"] == num_windows, "window count drift"
+            seen += [q["permalink"] for q in wp["quests"]]
+        # num_windows consecutive days must cover every quest exactly once (the last
+        # window may be short, so it's a set-equality, not a multiset check).
+        allq = [q["permalink"] for q in build_plan(dev, "0001", network)["quests"]]
+        assert set(seen) == set(allq), \
+            f"rotation did not sweep the full slice ({len(set(seen))}/{len(allq)})"
+        # window wins over max_quests when both are set.
+        both = build_plan(dev, "0001", network, max_quests=1, window=N)["stats"]
+        assert both["windowed"] and both["count"] <= N, "window must win over max_quests"
+
     # --- ledger-aware SELECTION (offline): exercise --priority / --all-paths.
     # We point at a guaranteed-absent ledger path. Whatever ledger.py does with a
     # cold/missing file (cold-start selection if it's importable, or None if it
@@ -595,7 +667,13 @@ def main() -> int:
     p.add_argument("--level", help="Binary level code (e.g. 0001). Default: date-rotated.")
     p.add_argument("--date", help="ISO date (YYYY-MM-DD) used to rotate the slice. Default: today.")
     p.add_argument("--max-quests", type=int, default=0,
-                   help="Cap the chain to N quests (0 = no cap). Bounds a long walkthrough.")
+                   help="Hard first-N cap on the chain (0 = no cap). Bounds a long "
+                        "walkthrough; the run only ever sees the first N quests.")
+    p.add_argument("--window", type=int, default=0,
+                   help="Walk a date-ROTATED window of N quests instead of a first-N "
+                        "cap (the perfection loop). Over ceil(total/N) days the whole "
+                        "level is swept; the ledger accumulates coverage across runs. "
+                        "Rotated by --date. Takes precedence over --max-quests.")
     p.add_argument("--priority", action="store_true",
                    help="Ledger SELECTION: plan the worst/oldest not-perfect slice "
                         "(falls back to date-rotation if the ledger is absent/cold).")
@@ -644,7 +722,9 @@ def main() -> int:
         chosen: List[str] = []
         for slug in select_all_paths_slugs(paths, on, ledger_path):
             character, level = resolve_slug(paths, slug)
-            plan = build_plan(character, level, network, max_quests=args.max_quests)
+            plan = build_plan(character, level, network,
+                              max_quests=args.max_quests,
+                              window=args.window, window_on=on)
             print(render_text(plan), file=sys.stderr)
             if not plan["quests"]:
                 continue  # empty slice (sparse/all-codex level): nothing to walk
@@ -672,7 +752,8 @@ def main() -> int:
     else:
         character, level = rotate_slice(paths, on)
 
-    plan = build_plan(character, level, network, max_quests=args.max_quests)
+    plan = build_plan(character, level, network, max_quests=args.max_quests,
+                      window=args.window, window_on=on)
 
     print(render_text(plan), file=sys.stderr)
     if args.json:

--- a/test/quest-validator/agentic_validate.py
+++ b/test/quest-validator/agentic_validate.py
@@ -135,6 +135,7 @@ def main():
     results = []
     spent = 0.0
     truncated = False
+    auth_truncated = False
     for i, q in enumerate(quests, 1):
         if args.max_cost_usd and spent >= args.max_cost_usd:
             print(f"\n💰 Cost ceiling reached (${spent:.4f} ≥ ${args.max_cost_usd}); "
@@ -148,9 +149,18 @@ def main():
             results.append(res)
             spent += (res.get("meta", {}) or {}).get("cost_usd") or 0.0
         except runner.AuthError as e:
-            # Auth won't fix itself between quests — abort the whole batch.
-            print(f"\n❌ {e}", file=sys.stderr)
-            sys.exit(2)
+            # Auth won't recover between quests (throttle / expired token), so stop
+            # the batch — but DON'T discard the quests that already scored. We
+            # aggregate + write the partial evidence below (marked truncated), so a
+            # rate-limited run still contributes its completed quests as coverage
+            # rather than reddening the job and losing everything. A run that got
+            # ZERO quests still hard-fails (exit 2) at the end.
+            print(f"\n⚠️  {e}", file=sys.stderr)
+            print(f"⚠️  Auth failed after {len(results)}/{len(quests)} quest(s) — "
+                  f"stopping the batch and writing PARTIAL evidence.", file=sys.stderr)
+            truncated = True
+            auth_truncated = True
+            break
         except runner.RunnerError as e:
             results.append({"quest": q.to_meta(), "mode": args.mode, "meta": {},
                             "error": str(e), "overall": 0.0, "verdict": schema.VERDICT_FAIL,
@@ -158,14 +168,17 @@ def main():
 
     agg = report.aggregate(results)
     if truncated:
-        # Record partial coverage so a cost-truncated batch is never mistaken
-        # for full, clean coverage (by a human or the gate below).
+        # Record partial coverage so a truncated batch is never mistaken for full,
+        # clean coverage (by a human, the ledger, or the gate below).
         agg["truncated"] = True
         agg["evaluated"] = len(results)
         agg["requested"] = len(quests)
+        if auth_truncated:
+            agg["auth_truncated"] = True
     print("\n" + report.render_console(agg, verbose=args.verbose))
     if truncated:
-        print(f"\n⚠️  BATCH TRUNCATED by cost ceiling — evaluated {len(results)}/{len(quests)} quest(s). "
+        cause = "auth failure" if auth_truncated else "cost ceiling"
+        print(f"\n⚠️  BATCH TRUNCATED by {cause} — evaluated {len(results)}/{len(quests)} quest(s). "
               f"The score gate covers only the evaluated subset.", file=sys.stderr)
 
     if args.report:
@@ -190,8 +203,13 @@ def main():
                   f"{args.fail_threshold}% gate ({len(results)}/{len(quests)} evaluated).",
                   file=sys.stderr)
             sys.exit(1)
+    # Nothing scored is a hard failure regardless of cause — an auth throttle that
+    # let ZERO quests through is exit 2 (matching the pre-partial behavior), any
+    # other empty run is exit 1. A PARTIAL run that scored ≥1 quest exits 0: it
+    # wrote usable (truncated) evidence the ledger records as coverage, and the
+    # caller shouldn't red the whole slice job for an expected rate-limit.
     if agg["scored"] == 0:
-        sys.exit(1)
+        sys.exit(2 if auth_truncated else 1)
     sys.exit(0)
 
 


### PR DESCRIPTION
## ♾️ Quest perfection — daily walkthroughs + ledger

The loop walked one slice per character path. The agentic execute engine
gathered **sealed, workflow-minted evidence** per slice; the `quest-walker`
agent wrote each session report; the deterministic ledger replayed every
slice and re-rendered `.quests/DASHBOARD.md`.

| slice | walk | state | note |
|---|---|---|---|
| `data-scientist/0011` | ✅ evidenced | 🔁 not yet perfect | 1 fail; 2 warn; avg 58.7 < 95.0; 17 open issue(s); 6 high-priority |
| `developer/0001` | ⚠️ no evidence | 🔁 not yet perfect |  |
| `digital-artist/0001` | ⚠️ no evidence | 🔁 not yet perfect |  |
| `game-developer/0001` | ⚠️ no evidence | 🔁 not yet perfect |  |
| `security-specialist/0010` | ⚠️ no evidence | 🔁 not yet perfect |  |
| `system-engineer/0101` | ⚠️ no evidence | 🔁 not yet perfect |  |

This is the **read-only** arm — it changes **no quest content**. Content
fixes arrive as SEPARATE `auto:content` PRs from the fix lane. Per-slice
plan/evidence/report artifacts are attached to the run.

*Generated by the Quest Perfection Loop — [run](https://github.com/bamr87/it-journey/actions/runs/28739367908)*
