### PR TITLE
fix(ci): unbreak the auto-merge lanes — stop watching our own check (self-deadlock)

### DIFF
--- a/.github/workflows/content-auto-merge.yml
+++ b/.github/workflows/content-auto-merge.yml
@@ -62,16 +62,37 @@ jobs:
             exit 1
           fi
 
-      - name: Wait for checks, then squash-merge
+      - name: Wait for checks (excluding self), then squash-merge
+        env:
+          RUN_ID: ${{ github.run_id }}
         run: |
-          # Block until every check on the PR finishes; --fail-fast stops the moment
-          # one fails, so a build/frontmatter/brand failure never merges. Green here
-          # already implies on-brand (content-quality.yml is one of those checks).
-          if gh pr checks "$PR" --watch --fail-fast --interval 30; then
-            gh pr merge "$PR" --squash --delete-branch
-            echo "All checks green + content-only — merged ✅"
-          else
-            echo "A check failed — leaving PR #$PR open for review."
-            gh pr edit "$PR" --add-label ci-failed || true
-            exit 1
-          fi
+          set -euo pipefail
+          # `gh pr checks --watch` waits for EVERY check to finish — including THIS
+          # job's own check, which stays "pending" while it watches: a self-deadlock
+          # that never returns and hits timeout-minutes, leaving the PR unmerged.
+          # Poll instead, EXCLUDING our own run (its check link carries this run_id),
+          # so we wait only on checks that can actually finish. A build/frontmatter/
+          # brand failure still stops the merge; green here already implies on-brand
+          # (content-quality.yml is one of those checks).
+          deadline=$(( $(date +%s) + 25 * 60 ))
+          while :; do
+            rows=$(gh pr checks "$PR" --json bucket,link \
+                     --jq '.[] | [.bucket, .link] | @tsv' 2>/dev/null || true)
+            others=$(printf '%s\n' "$rows" | grep -v "/${RUN_ID}/" || true)
+            if [ -z "$others" ]; then
+              [ "$(date +%s)" -ge "$deadline" ] && { echo "::error::no non-self checks appeared before timeout."; exit 1; }
+              sleep 30; continue
+            fi
+            if printf '%s\n' "$others" | awk -F'\t' '$1=="fail"{f=1} END{exit !f}'; then
+              echo "A check failed — leaving PR #$PR open for review."
+              gh pr edit "$PR" --add-label ci-failed || true
+              exit 1
+            fi
+            if printf '%s\n' "$others" | awk -F'\t' '$1=="pending"{p=1} END{exit !p}'; then
+              [ "$(date +%s)" -ge "$deadline" ] && { echo "::error::timed out waiting for checks."; exit 1; }
+              sleep 30; continue
+            fi
+            break
+          done
+          gh pr merge "$PR" --squash --delete-branch
+          echo "All checks green + content-only — merged ✅"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -37,18 +37,40 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Wait for checks, then merge
+      - name: Wait for checks (excluding self), then merge
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+          RUN_ID: ${{ github.run_id }}
         run: |
-          # Block until every check on this PR finishes. --fail-fast exits non-zero
-          # the moment one fails, so a broken update is never merged.
-          if gh pr checks "$PR_URL" --watch --fail-fast --interval 30; then
-            gh pr merge "$PR_URL" --squash --delete-branch
-            echo "All checks green — merged ✅"
-          else
-            echo "A check failed — leaving the PR open for review."
-            gh pr edit "$PR_URL" --add-label "ci-failed" || true
-            exit 1
-          fi
+          set -euo pipefail
+          # `gh pr checks --watch` waits for EVERY check on the PR to finish —
+          # including THIS auto-merge job's own check, which stays "pending" for as
+          # long as it is doing the watching. That is a self-deadlock: the watch
+          # never returns, the job hits timeout-minutes (30), and the PR is left
+          # unmerged with a failed "auto-merge" check. Every Dependabot PR sat like
+          # this. Poll the checks ourselves and EXCLUDE our own run (its check link
+          # carries this run_id), so we wait only on the checks that can actually
+          # finish. A hard failure still stops the merge; only genuine greens merge.
+          deadline=$(( $(date +%s) + 25 * 60 ))
+          while :; do
+            rows=$(gh pr checks "$PR_URL" --json bucket,link \
+                     --jq '.[] | [.bucket, .link] | @tsv' 2>/dev/null || true)
+            others=$(printf '%s\n' "$rows" | grep -v "/${RUN_ID}/" || true)
+            if [ -z "$others" ]; then                 # only our own check so far
+              [ "$(date +%s)" -ge "$deadline" ] && { echo "::error::no non-self checks appeared before timeout."; exit 1; }
+              sleep 30; continue
+            fi
+            if printf '%s\n' "$others" | awk -F'\t' '$1=="fail"{f=1} END{exit !f}'; then
+              echo "A check failed — leaving the PR open for review."
+              gh pr edit "$PR_URL" --add-label "ci-failed" || true
+              exit 1
+            fi
+            if printf '%s\n' "$others" | awk -F'\t' '$1=="pending"{p=1} END{exit !p}'; then
+              [ "$(date +%s)" -ge "$deadline" ] && { echo "::error::timed out waiting for checks."; exit 1; }
+              sleep 30; continue
+            fi
+            break                                     # no fails, none pending → green
+          done
+          gh pr merge "$PR_URL" --squash --delete-branch
+          echo "All checks green — merged ✅"

--- a/.github/workflows/issue-pr-auto-merge.yml
+++ b/.github/workflows/issue-pr-auto-merge.yml
@@ -77,16 +77,37 @@ jobs:
             exit 1
           fi
 
-      - name: Wait for checks, then squash-merge
+      - name: Wait for checks (excluding self), then squash-merge
+        env:
+          RUN_ID: ${{ github.run_id }}
         run: |
-          # Block until every check finishes; --fail-fast stops the moment one
-          # fails, so a build/frontmatter/brand failure never merges. Merging
-          # closes the linked issues via the PR body's `Closes #N` lines.
-          if gh pr checks "$PR" --watch --fail-fast --interval 30; then
-            gh pr merge "$PR" --squash --delete-branch
-            echo "All checks green + content-only — merged ✅ (linked issues closed)"
-          else
-            echo "A check failed — leaving PR #$PR open for review."
-            gh pr edit "$PR" --add-label ci-failed || true
-            exit 1
-          fi
+          set -euo pipefail
+          # `gh pr checks --watch` waits for EVERY check to finish — including THIS
+          # job's own check, which stays "pending" while it watches: a self-deadlock
+          # that never returns and hits timeout-minutes, leaving the PR unmerged.
+          # Poll instead, EXCLUDING our own run (its check link carries this run_id),
+          # so we wait only on checks that can actually finish. A build/frontmatter/
+          # brand failure still stops the merge. Merging closes the linked issues via
+          # the PR body's `Closes #N` lines.
+          deadline=$(( $(date +%s) + 25 * 60 ))
+          while :; do
+            rows=$(gh pr checks "$PR" --json bucket,link \
+                     --jq '.[] | [.bucket, .link] | @tsv' 2>/dev/null || true)
+            others=$(printf '%s\n' "$rows" | grep -v "/${RUN_ID}/" || true)
+            if [ -z "$others" ]; then
+              [ "$(date +%s)" -ge "$deadline" ] && { echo "::error::no non-self checks appeared before timeout."; exit 1; }
+              sleep 30; continue
+            fi
+            if printf '%s\n' "$others" | awk -F'\t' '$1=="fail"{f=1} END{exit !f}'; then
+              echo "A check failed — leaving PR #$PR open for review."
+              gh pr edit "$PR" --add-label ci-failed || true
+              exit 1
+            fi
+            if printf '%s\n' "$others" | awk -F'\t' '$1=="pending"{p=1} END{exit !p}'; then
+              [ "$(date +%s)" -ge "$deadline" ] && { echo "::error::timed out waiting for checks."; exit 1; }
+              sleep 30; continue
+            fi
+            break
+          done
+          gh pr merge "$PR" --squash --delete-branch
+          echo "All checks green + content-only — merged ✅ (linked issues closed)"


### PR DESCRIPTION
## The bug

All three auto-merge workflows — `dependabot-auto-merge.yml`, `content-auto-merge.yml`, `issue-pr-auto-merge.yml` — waited for CI with:

```bash
gh pr checks "$PR" --watch --fail-fast --interval 30
```

`--watch` blocks until **every** check on the PR reaches a terminal state — but the auto-merge job's **own check** stays `pending` for exactly as long as it is doing the watching. That's a **self-deadlock**: the watch never returns, the job hits `timeout-minutes: 30`, and the PR is left unmerged with a failed `auto-merge` check.

The run log for #413 shows it exactly — every functional check green while the job waits on itself:
```
Analyze (python)  pass
CodeQL            pass
auto-merge        pending  0   ← this run, 28727796262, watching itself
actionlint        pass
...
##[error]The operation was canceled.   ← 30-min timeout
```

Every open Dependabot PR (#373, #374, #412, #413) sat unmerged this way. And the **content lane has the same latent bug** — which matters because it's the one meant to squash-merge the quest-perfection **fix PRs**, so the loop can't actually auto-merge its own fixes until this is fixed.

## The fix

Replace `--watch` with a poll loop that **excludes our own run** (its check link carries `$GITHUB_RUN_ID`), so it waits only on checks that can actually finish:

- a **hard failure** → stop, label `ci-failed`, leave open (unchanged behavior);
- **pending** (non-self) → keep waiting to the deadline;
- **all green** → squash-merge;
- **only our own check so far** → wait rather than merge unchecked.

Same 20-line loop in all three lanes; each keeps its own upstream gating (the content/issue smuggle-guards run before it, untouched).

## Validation

- **actionlint** clean on all three, **including shellcheck** (the CI gate disables shellcheck; I ran it anyway to vet the new bash).
- **Decision logic unit-tested** against #413's real check data (self excluded → `pass ×5 + skipping ×2` → **MERGE**) and synthetic rows for every branch: real-fail → BLOCK, non-self-pending → WAIT, all-green → MERGE, only-self → WAIT.

Note: these are `pull_request_target` workflows, which always run the **base branch's** copy — so the fix can't be exercised from a PR branch; it takes effect once merged to `main`. After merge, the open Dependabot PRs should auto-merge on their next `synchronize` (or a re-trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)