### PR TITLE
🔧 Quest fix: security-specialist/0010

### DIFF
--- a/pages/_quests/0010/side-quest-contribution-calendar.md
+++ b/pages/_quests/0010/side-quest-contribution-calendar.md
@@ -103,29 +103,32 @@ This quest turns that data into a visual heatmap — similar to GitHub's contrib
 
 Create `_includes/contributor/contribution_calendar.html`:
 
-```html
+> The `{% raw %}{% raw %}{% endraw %}` / `{% raw %}{% endraw %}{% endraw %}` lines below are display-only guards so this documentation page shows the Liquid literally. Copy only the inner markup (everything *between* those two lines) into the file.
 
-{% raw %}{% assign calendar = include.calendar %}{% endraw %}
-{% raw %}{% if calendar and calendar.size > 0 %}{% endraw %}
-<div class="contributor-calendar">
+```html
+{% raw %}
+{% assign calendar = include.calendar %}
+{% if calendar and calendar.size > 0 %}
+<div class="contributor-calendar" role="img"
+     aria-label="Contribution calendar heatmap: weekly commit activity over the past year">
   <h4>📆 Contribution History</h4>
   <div class="calendar-grid">
-    {% raw %}{% for week in calendar %}{% endraw %}
-      {% raw %}{% if week.commits == 0 %}{% endraw %}
-        {% raw %}{% assign intensity = "zero" %}{% endraw %}
-      {% raw %}{% elsif week.commits < 3 %}{% endraw %}
-        {% raw %}{% assign intensity = "low" %}{% endraw %}
-      {% raw %}{% elsif week.commits < 7 %}{% endraw %}
-        {% raw %}{% assign intensity = "medium" %}{% endraw %}
-      {% raw %}{% elsif week.commits < 15 %}{% endraw %}
-        {% raw %}{% assign intensity = "high" %}{% endraw %}
-      {% raw %}{% else %}{% endraw %}
-        {% raw %}{% assign intensity = "max" %}{% endraw %}
-      {% raw %}{% endif %}{% endraw %}
-      <div class="calendar-cell calendar-{% raw %}{{ intensity }}{% endraw %}"
-           title="{% raw %}{{ week.week }}{% endraw %}: {% raw %}{{ week.commits }}{% endraw %} commits">
+    {% for week in calendar %}
+      {% if week.commits == 0 %}
+        {% assign intensity = "zero" %}
+      {% elsif week.commits < 3 %}
+        {% assign intensity = "low" %}
+      {% elsif week.commits < 7 %}
+        {% assign intensity = "medium" %}
+      {% elsif week.commits < 15 %}
+        {% assign intensity = "high" %}
+      {% else %}
+        {% assign intensity = "max" %}
+      {% endif %}
+      <div class="calendar-cell calendar-{{ intensity }}"
+           title="{{ week.week }}: {{ week.commits }} commits">
       </div>
-    {% raw %}{% endfor %}{% endraw %}
+    {% endfor %}
   </div>
   <div class="calendar-legend">
     <span>Less</span>
@@ -137,8 +140,8 @@ Create `_includes/contributor/contribution_calendar.html`:
     <span>More</span>
   </div>
 </div>
-{% raw %}{% endif %}{% endraw %}
-
+{% endif %}
+{% endraw %}
 ```
 
 ### Step 2: Add CSS Styles
@@ -171,10 +174,10 @@ Add to `assets/css/contributor-profile.css`:
 .calendar-max    { background: var(--cal-max, #216e39); }
 
 /* Class-themed calendar colors */
-.contributor-card--wizard ~ .contributor-calendar .calendar-low    { background: #c4b5fd; }
-.contributor-card--wizard ~ .contributor-calendar .calendar-medium { background: #8b5cf6; }
-.contributor-card--wizard ~ .contributor-calendar .calendar-high   { background: #6d28d9; }
-.contributor-card--wizard ~ .contributor-calendar .calendar-max    { background: #4c1d95; }
+.contributor-card--wizard .contributor-calendar .calendar-low    { background: #c4b5fd; }
+.contributor-card--wizard .contributor-calendar .calendar-medium { background: #8b5cf6; }
+.contributor-card--wizard .contributor-calendar .calendar-high   { background: #6d28d9; }
+.contributor-card--wizard .contributor-calendar .calendar-max    { background: #4c1d95; }
 
 .calendar-legend {
   display: flex;
@@ -204,12 +207,14 @@ Add to `assets/css/contributor-profile.css`:
 Edit `_includes/contributor/character_sheet.html` and add after the stats panel or achievement wall:
 
 ```liquid
-
-{% raw %}{% include contributor/contribution_calendar.html calendar=contributor.stats.contribution_calendar %}{% endraw %}
-
+{% raw %}
+{% include contributor/contribution_calendar.html calendar=contributor.stats.contribution_calendar %}
+{% endraw %}
 ```
 
 ### Step 4: Verify
+
+> **Prerequisite:** This step needs the working Jekyll project and `Gemfile` you set up in the [Forge Your Character](/quests/0001/forge-your-character/) quest. Run this from that project's root — without it, `bundle exec jekyll serve` will fail with a missing bundler/Gemfile error.
 
 ```bash
 bundle exec jekyll serve


### PR DESCRIPTION
## 🔧 Quest fix — `security-specialist/0010`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: security-specialist/0010

Slice evidence: 1 quest, verdict `warn` (execute-mode, non-truncated, `executed==true`). All edits confined to `pages/_quests/0010/side-quest-contribution-calendar.md` (not vendored — no `source_repo:`/`source_url:`). Tier-1 numbers read straight from `quest_validator.py --summary`.

- **pages/_quests/0010/side-quest-contribution-calendar.md** — fixed failed command `HTML/Liquid: _includes/contributor/contribution_calendar.html (Step 1)` (verified: `commands[].status==failed`) and the matching **high**-priority recommendation (area: *Step 1 & Step 3 code fences*). Replaced the per-tag `{% raw %}…{% endraw %}` wrapping — which rendered inert, unexecuted tag text when copy-pasted — with a single block-level `{% raw %}`/`{% endraw %}` guard around clean Liquid, plus a one-line note telling learners to copy only the inner markup. tier-1 score 58/74 (78.4%) → 58/74 (78.4%) held, brand clean. ✅ kept.
- **pages/_quests/0010/side-quest-contribution-calendar.md** — fixed failed command `Liquid: {% include contributor/contribution_calendar.html … %} (Step 3)` (verified: `commands[].status==failed`; same high recommendation). Applied the identical single-wrapper fix to the Step 3 include snippet. tier-1 held 78.4%, brand clean. ✅ kept.
- **pages/_quests/0010/side-quest-contribution-calendar.md** — addressed **medium** recommendation (area: *Step 2 CSS — wizard theme selectors*). Changed `.contributor-card--wizard ~ .contributor-calendar …` to the descendant selector `.contributor-card--wizard .contributor-calendar …`, since Step 3 nests the calendar inside the card (the sibling `~` form was verified dead in that DOM). tier-1 held 78.4%, brand clean. ✅ kept.
- **pages/_quests/0010/side-quest-contribution-calendar.md** — addressed **medium** recommendation (area: *Accessibility*). Added `role="img"` and an `aria-label` to the `.contributor-calendar` container (grid was built from unlabeled `<div>`s relying only on hover `title`). Folded into the Step 1 corrected block. tier-1 held 78.4%, brand clean. ✅ kept.
- **pages/_quests/0010/side-quest-contribution-calendar.md** — addressed **low** recommendation (area: *Step 4 prerequisites*). Added an inline prerequisite note before `bundle exec jekyll serve` pointing to the Forge Your Character project/Gemfile, so learners don't run it cold. tier-1 held 78.4%, brand clean. ✅ kept.

_Left:_ The skipped Step 4 command (`bundle exec jekyll serve`, `status==skipped` — no Gemfile in the isolated sandbox) is not an actionable defect (expected side-quest isolation limitation), so no edit was made against it beyond the prerequisite note above. No vendored quests in this slice. No edits reverted — tier-1 structural score held at 78.4% and brand lint stayed clean for every edit; no frontmatter changed (no `_data/quests` regeneration required).

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/28791022929)._
