### PR TITLE
fix: unbreak Pages deploy — orphan endraw in 0010 quest + the two CI holes that let it merge

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -117,16 +117,18 @@ jobs:
       with:
         fetch-depth: 1
 
-    # Fail FAST (before the slow Ruby build) on Liquid raw-guard bugs — nested
-    # {% raw %} or an unguarded GitHub Actions ${{ }}. The PR Jekyll build sets
-    # liquid.error_mode: warn (dev speed) and would let these through, but the
-    # production GitHub Pages build is strict and they take the live site down.
-    # Scoped to CHANGED pages on a PR (so pre-existing debt never blocks an
-    # unrelated change); full sweep on push/dispatch.
+    # Fail FAST (before the slow Ruby build) on Liquid raw-guard bugs — an
+    # orphan/nested {% raw %}/{% endraw %} or an unguarded GitHub Actions ${{ }}.
+    # These are fatal to every Jekyll build, production Pages included, and take
+    # the deploy down. Scoped to CHANGED pages on a PR (so pre-existing debt
+    # never blocks an unrelated change); full sweep on push/dispatch.
+    # pipefail: `checker | tee` must fail on the CHECKER's exit code, not tee's —
+    # without it this gate can never fail in PR mode (the PR #445 escape).
     - name: 🧪 Liquid raw-guard gate
       env:
         BASE: ${{ github.event.pull_request.base.sha }}
       run: |
+        set -o pipefail
         python3 scripts/validation/check_liquid_raw.py --selftest
         if [ "${{ github.event_name }}" = "pull_request" ]; then
           git fetch --no-tags --depth=1 origin "$BASE" 2>/dev/null || true
@@ -160,6 +162,8 @@ jobs:
 
     - name: 🔍 Check Configuration Validity
       run: |
+        # pipefail: `if cmd | tee` must test cmd's exit code, not tee's.
+        set -o pipefail
         echo "## ⚙️ Configuration Validation" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
 
@@ -175,6 +179,11 @@ jobs:
     - name: 🏗️ Test Jekyll Build Process
       id: jekyll_build
       run: |
+        # pipefail is load-bearing: GH Actions' default shell (`bash -e {0}`)
+        # does NOT set it, so `if jekyll build | tee log` tests tee's exit code
+        # (always 0) and a failed build reports ✅. That masking let the PR #445
+        # Liquid crash merge and break the production Pages deploy.
+        set -o pipefail
         echo "## 🏗️ Jekyll Build Test" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
 
@@ -252,6 +261,8 @@ jobs:
     - name: 🐳 Test Docker Build
       id: docker_build
       run: |
+        # pipefail: `if cmd | tee` must test cmd's exit code, not tee's.
+        set -o pipefail
         echo "## 🐳 Docker Build Test" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/dependency-checker.yml
+++ b/.github/workflows/dependency-checker.yml
@@ -62,6 +62,9 @@ jobs:
     - name: 🔍 Check Ruby Dependencies
       id: ruby_check
       run: |
+        # pipefail: `if bundle install | tee` must test bundle's exit code, not
+        # tee's — without it the failure branch below is unreachable.
+        set -o pipefail
         echo "## 💎 Ruby Dependency Analysis" >> dependency-check-results/summary.md
         echo "" >> dependency-check-results/summary.md
 

--- a/pages/_quests/0010/side-quest-contribution-calendar.md
+++ b/pages/_quests/0010/side-quest-contribution-calendar.md
@@ -103,7 +103,7 @@ This quest turns that data into a visual heatmap — similar to GitHub's contrib
 
 Create `_includes/contributor/contribution_calendar.html`:
 
-> The `{% raw %}{% raw %}{% endraw %}` / `{% raw %}{% endraw %}{% endraw %}` lines below are display-only guards so this documentation page shows the Liquid literally. Copy only the inner markup (everything *between* those two lines) into the file.
+> The opening and closing Liquid `raw` / `endraw` guard lines inside the code block below are display-only — they stop Jekyll from executing the example so this page can show the Liquid literally. Copy only the markup *between* those two guard lines into the file.
 
 ```html
 {% raw %}

--- a/scripts/validation/check_liquid_raw.py
+++ b/scripts/validation/check_liquid_raw.py
@@ -4,19 +4,33 @@ check_liquid_raw.py — deterministic Liquid raw-guard gate for content markdown
 
 WHY THIS EXISTS. Jekyll runs Liquid BEFORE Markdown, so code fences and backticks
 do NOT protect `{{ … }}` / `{% … %}` / GitHub Actions `${{ … }}`. Pages must wrap
-such snippets in a `{% raw %}` … `{% endraw %}` block. Two mistakes ship a page
-that builds locally (the dev/CI config sets `liquid.error_mode: warn`, which
-DOWNGRADES Liquid parse errors to warnings) yet FAILS the production GitHub Pages
-build (strict), taking the live site down:
+such snippets in a `{% raw %}` … `{% endraw %}` block. The raw block does not
+nest and cannot contain a literal `{% endraw %}` — Liquid always pairs an opening
+`{% raw %}` with the NEXT `{% endraw %}` it sees, so any leftover `{% endraw %}`
+is an orphan and every Jekyll build (dev, CI, and production GitHub Pages alike)
+dies at parse time with "Unknown tag 'endraw'", taking the deploy down.
 
-  1. NESTED raw — a `{% raw %}` block wrapped around code that already contains an
-     inline `{% raw %}…{% endraw %}` guard. raw does not nest, so the inner
-     `{% endraw %}` closes the block early and the outer one is an orphan
-     ("Unknown tag 'endraw'"). FATAL.
-  2. UNGUARDED expression — a `{{`/`${{`/`{%` left outside any raw block.
+This gate models Liquid's actual sequential raw-block pairing and fails BEFORE
+the slow Jekyll build, with a precise file:line. It flags:
 
-This gate models Liquid's raw-block parsing and fails the build BEFORE Jekyll, with
-a precise file:line, so the bug is caught in CI instead of in production.
+  1. ORPHAN `{% endraw %}` — an endraw with no raw block open. The classic cause
+     is trying to display raw/endraw tags literally inline, e.g.
+     `{% raw %}{% endraw %}{% endraw %}`: Liquid closes the block at the FIRST
+     endraw and the second is an orphan. FATAL in every build.
+  2. NESTED `{% raw %}` — a raw tag inside an already-open raw block. Liquid
+     treats it as literal text, so the inner guard's endraw closes the OUTER
+     block early and a later endraw becomes an orphan. Flagged at the cause line.
+  3. UNCLOSED `{% raw %}` at end of file. FATAL.
+  4. UNGUARDED GitHub Actions `${{ … }}` outside any raw region — not valid
+     Jekyll Liquid, so it is always a code example that must be raw-guarded (it
+     renders to `$` at best, or throws on `||`/`==` at worst). Bare `{{`/`{%`
+     are LEGITIMATE Liquid templating (e.g. pages/stats.md) and are not flagged.
+
+Escaped early once already: the display-only guard note that shipped in PR #445
+(`{% raw %}{% endraw %}{% endraw %}` inline) passed the old line-based checker —
+it only modeled full-line raw blocks and scrubbed balanced inline spans — and
+broke the production Pages build. Tags are now paired sequentially across the
+whole file, exactly like Liquid's parser.
 
 Usage:
     python3 scripts/validation/check_liquid_raw.py [paths-or-dirs ...]   # default: pages
@@ -30,46 +44,48 @@ from pathlib import Path
 # Tags, tolerant of Liquid whitespace-trim hyphens: {%- raw -%}, {% raw %}, etc.
 RAW_T = r"\{%-?\s*raw\s*-?%\}"
 ENDRAW_T = r"\{%-?\s*endraw\s*-?%\}"
-OPEN_RE = re.compile(rf"^\s*{RAW_T}\s*$")
-CLOSE_RE = re.compile(rf"^\s*{ENDRAW_T}\s*$")
-ANY_RAW_RE = re.compile(rf"{RAW_T}|{ENDRAW_T}")
-INLINE_SPAN = re.compile(rf"{RAW_T}.*?{ENDRAW_T}")          # a balanced inline guard is fine
-
-
-def _is_open(s: str) -> bool:  return bool(OPEN_RE.match(s))
-def _is_close(s: str) -> bool: return bool(CLOSE_RE.match(s))
+TAG_RE = re.compile(rf"(?P<raw>{RAW_T})|(?P<endraw>{ENDRAW_T})")
 
 
 def check_text(text: str):
-    """Yield (line_no, problem) for one file's text."""
-    depth = 0
-    for i, raw_line in enumerate(text.split("\n"), 1):
-        s = raw_line
-        if _is_open(s):
-            if depth:
-                yield (i, "nested {% raw %} (raw blocks do not nest)")
-            depth = 1
-            continue
-        if _is_close(s):
-            if depth == 0:
-                yield (i, "{% endraw %} with no open {% raw %} block")
-            depth = 0
-            continue
-        if depth:
-            # Inside a raw block everything is literal — but an inline raw/endraw
-            # here is exactly the nesting trap that breaks the production build.
-            if ANY_RAW_RE.search(s):
-                yield (i, f"inline raw tag inside a {{% raw %}} block → nesting: {s.strip()[:60]}")
-            continue
-        # Outside a raw block, only flag GitHub Actions `${{ … }}` — it is NOT valid
-        # Jekyll Liquid, so it is always a code example that must be raw-guarded (it
-        # renders to `$` at best, or throws on `||`/`==` at worst). Bare `{{`/`{%`
-        # are LEGITIMATE Liquid templating (e.g. pages/stats.md) and must not be flagged.
-        scrubbed = INLINE_SPAN.sub("", s)            # genuine inline guards are safe
-        if "${{" in scrubbed:
-            yield (i, f"unguarded GitHub Actions ${{{{ outside {{% raw %}}: {s.strip()[:60]}")
-    if depth:
-        yield (0, "unclosed {% raw %} block at end of file")
+    """Yield (line_no, problem) for one file's text.
+
+    Walks raw/endraw tags in document order, mirroring Liquid's parser: an
+    opening raw pairs with the NEXT endraw, unconditionally. Everything between
+    a pair is a guarded region; `${{` is only legal inside one.
+    """
+    def line_of(pos: int) -> int:
+        return text.count("\n", 0, pos) + 1
+
+    raw_spans = []          # (start, end) offsets of guarded regions
+    open_at = None          # offset of the currently open {% raw %}, or None
+    for m in TAG_RE.finditer(text):
+        if m.lastgroup == "raw":
+            if open_at is None:
+                open_at = m.start()
+            else:
+                # Literal to Liquid, but a trap for authors: the next endraw
+                # closes the OUTER block, orphaning the one after it.
+                yield (line_of(m.start()),
+                       "{% raw %} inside an open raw block → nesting "
+                       "(raw does not nest; the next {% endraw %} closes the outer block)")
+        else:  # endraw
+            if open_at is None:
+                yield (line_of(m.start()),
+                       "orphan {% endraw %} with no open {% raw %} block "
+                       "(fatal: Liquid 'Unknown tag endraw')")
+            else:
+                raw_spans.append((open_at, m.end()))
+                open_at = None
+    if open_at is not None:
+        yield (line_of(open_at), "unclosed {% raw %} block at end of file")
+        raw_spans.append((open_at, len(text)))  # treat rest as guarded: avoid double-reporting
+
+    for m in re.finditer(r"\$\{\{", text):
+        if not any(s <= m.start() < e for s, e in raw_spans):
+            line = text.split("\n")[line_of(m.start()) - 1]
+            yield (line_of(m.start()),
+                   f"unguarded GitHub Actions ${{{{ outside {{% raw %}}: {line.strip()[:60]}")
 
 
 def iter_files(paths):
@@ -82,14 +98,33 @@ def iter_files(paths):
             yield pp
 
 
-_GOOD = "intro\n{% raw %}\n```yaml\nx: ${{ y }}\n```\n{% endraw %}\ninline `a{% raw %}${{ z }}{% endraw %}b` ok\n"
-_BAD = "{% raw %}\n```yaml\nif: {% raw %}${{ always() }}{% endraw %}\n```\n{% endraw %}\n"
+_GOOD = (
+    "intro\n{% raw %}\n```yaml\nx: ${{ y }}\n```\n{% endraw %}\n"
+    "inline `a{% raw %}${{ z }}{% endraw %}b` ok\n"
+    "mid-line open {% raw %}\n${{ spans_lines }}\n{% endraw %} mid-line close\n"
+)
+_BAD_NESTED = "{% raw %}\n```yaml\nif: {% raw %}${{ always() }}{% endraw %}\n```\n{% endraw %}\n"
+# The exact inline pattern that took down the Pages build (PR #445):
+_BAD_ORPHAN = ("> The `{% raw %}{% raw %}{% endraw %}` / `{% raw %}{% endraw %}{% endraw %}` "
+               "lines below are display-only guards.\n")
+_BAD_BARE_ORPHAN = "close it with `{% endraw %}` when done\n"
+_BAD_UNCLOSED = "{% raw %}\n${{ never_closed }}\n"
+_BAD_UNGUARDED = "run: echo ${{ github.sha }}\n"
 
 
 def _selftest() -> int:
     assert list(check_text(_GOOD)) == [], list(check_text(_GOOD))
-    bad = list(check_text(_BAD))
-    assert any("nesting" in p for _, p in bad), bad
+    nested = list(check_text(_BAD_NESTED))
+    assert any("nesting" in p for _, p in nested), nested
+    assert any("orphan" in p for _, p in nested), nested  # the outer endraw is orphaned
+    orphan = list(check_text(_BAD_ORPHAN))
+    assert any("orphan" in p for _, p in orphan), orphan
+    bare = list(check_text(_BAD_BARE_ORPHAN))
+    assert any("orphan" in p for _, p in bare), bare
+    unclosed = list(check_text(_BAD_UNCLOSED))
+    assert [p for _, p in unclosed] == ["unclosed {% raw %} block at end of file"], unclosed
+    unguarded = list(check_text(_BAD_UNGUARDED))
+    assert any("unguarded" in p for _, p in unguarded), unguarded
     print("check_liquid_raw selftest: OK")
     return 0
 
@@ -115,7 +150,7 @@ def main(argv=None) -> int:
             total += 1
     if total:
         print(f"\n❌ {total} Liquid raw-guard problem(s) in {len(files)} file(s) — "
-              f"these build locally (error_mode: warn) but FAIL production Pages.", file=sys.stderr)
+              f"fatal to EVERY Jekyll build (dev, CI, and production Pages).", file=sys.stderr)
         return 1
     if not args.quiet:
         print(f"✅ Liquid raw-guards clean across {len(files)} file(s).")


### PR DESCRIPTION
## What broke

The production Pages deploy ([run 28816005239](https://github.com/bamr87/it-journey/actions/runs/28816005239)) died with:

```
Liquid Exception: Liquid syntax error (line 37): Unknown tag 'endraw'
  in pages/_quests/0010/side-quest-contribution-calendar.md
```

#445 added a note *explaining* raw-guards whose inline examples were themselves fatal Liquid: in `{% raw %}{% endraw %}{% endraw %}`, Liquid pairs the **first** `endraw` with the opening `raw`, leaving an orphan `{% endraw %}` — a parse-time crash in every Jekyll build. The live site is stale (deploy skipped), and every 6-hour `sync-gh-pages` run will keep failing until this merges.

## How it escaped four layers of CI

1. **🧪 Liquid raw-guard gate** — `check_liquid_raw.py` ran on this exact file and passed it. Outside full-line raw blocks it scrubbed *balanced* inline `{% raw %}…{% endraw %}` spans and only grepped the remainder for `${{`; a leftover orphan `{% endraw %}` was never flagged.
2. **🏗️ Jekyll Build Test** — the build **did crash with the exact production error** (it's in the PR run's `jekyll-build-logs` artifact), but the step is `if jekyll build | tee log; then … else exit 1; fi`. GH Actions' default shell (`bash -e {0}`) has **no pipefail**, so the `if` tests `tee`'s exit code — always 0. The failure branch was unreachable; the fatal exception was filed under "⚠️ Build completed with warnings". The gate step's own `checker | tee` pipeline had the same hole, so even a detecting checker couldn't have failed the step.
3. **content-auto-merge** — saw all required checks green and squash-merged.
4. **sync-gh-pages** — auto-merge pushes with `GITHUB_TOKEN` trigger no push workflows, so nothing re-validated main; the green-gate found no failing check-runs and synced the broken tree to `gh-pages`, where the Pages build (the first process in the chain that honors the build's real exit code) failed.

Side effect of (2): both #445's and #447's PR builds died at this file's parse, so everything after it — including all of #447's codex quests — had **never been through a complete Jekyll build** until now.

## Fixes (one commit each)

- **`fix(quests)`** — rewrite the note to describe the guard lines in words; zero Liquid tags emitted.
- **`fix(validation)`** — `check_liquid_raw.py` now walks raw/endraw tags in document order exactly like Liquid's parser: flags orphan `{% endraw %}` (fatal), nested `{% raw %}` at the cause line, unclosed raw, and unguarded `${{` outside raw regions. The exact #445 line is now a selftest regression case.
- **`fix(ci)`** — `set -o pipefail` on the raw-guard gate, `jekyll doctor`, Jekyll build, and Docker build steps in `build-validation.yml`, and the `bundle install` check in `dependency-checker.yml`; corrected the comment that misattributed earlier escapes to `liquid.error_mode: warn` (unknown-tag errors are fatal in every error mode — the real hole was the unchecked pipe status).

## Validation

- `check_liquid_raw.py --selftest` ✅; on the pre-fix file: **2 findings at line 106, exit 1** (regression proof); full `pages/` sweep: **275 files clean**
- `actionlint -shellcheck=` (CI-parity flags) on both edited workflows: clean
- `make content-audit` ✅ · `make quest-audit` ✅ (freshness in sync)
- **Full CI-parity Jekyll build in Docker** (`make docker-build-ci`, same config triple as CI): `done in 37.123 seconds` — first complete parse of the tree since #445; the fixed page and all #447 codex pages render.

## After merge

The next scheduled `sync-gh-pages` run (every 6 h at :20) deploys this; to restore the live site immediately, dispatch it manually:

```
gh workflow run sync-gh-pages.yml --repo bamr87/it-journey
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
