### PR TITLE
🔧 Quest fix: security-specialist/1000

### DIFF
--- a/pages/_quests/1000/aws-essentials.md
+++ b/pages/_quests/1000/aws-essentials.md
@@ -305,22 +305,24 @@ aws ec2 terminate-instances --instance-ids <instance-id>
 S3 (Simple Storage Service) holds objects (files) inside buckets, with effectively unlimited capacity and 11 nines of durability.
 
 ```bash
-# Create a bucket (names are globally unique - add randomness)
-aws s3 mb s3://my-quest-bucket-$RANDOM
+# Create a bucket (names are globally unique - add randomness).
+# Store the generated name in a variable and reuse it in every command below.
+BUCKET=my-quest-bucket-$RANDOM
+aws s3 mb s3://$BUCKET
 
 # Upload and download an object
 echo "treasure" > loot.txt
-aws s3 cp loot.txt s3://my-quest-bucket-12345/
-aws s3 cp s3://my-quest-bucket-12345/loot.txt downloaded-loot.txt
+aws s3 cp loot.txt s3://$BUCKET/
+aws s3 cp s3://$BUCKET/loot.txt downloaded-loot.txt
 
 # Block ALL public access (the safe default for almost every bucket)
 aws s3api put-public-access-block \
-  --bucket my-quest-bucket-12345 \
+  --bucket $BUCKET \
   --public-access-block-configuration \
   BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
 
 # Clean up: empty and delete the bucket
-aws s3 rb s3://my-quest-bucket-12345 --force
+aws s3 rb s3://$BUCKET --force
 ```
 
 > The single most common cloud breach is a publicly readable S3 bucket. Block public access by default and open it deliberately, never accidentally.

--- a/pages/_quests/1000/azure-ascension-jekyll-deployment.md
+++ b/pages/_quests/1000/azure-ascension-jekyll-deployment.md
@@ -55,10 +55,20 @@ layout: quest
 ### 🛠️ System Requirements
 - [ ] Azure account with permissions to create Static Web Apps
 - [ ] GitHub account with repo access
+- [ ] [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) installed and authenticated (`az login`) — Chapter 2 depends on Azure authentication
+- [ ] Ruby ≥ 3.2 and Bundler installed (`gem install bundler`)
 
 ## 🧙‍♂️ Chapter 1: Prepare the Repository
 
-Ensure dependencies are installed:
+First, clone the IT-Journey repository and change into the Jekyll site root — every
+command below assumes this is your working directory (it is where the `Gemfile` lives):
+
+```bash
+git clone https://github.com/bamr87/it-journey.git
+cd it-journey
+```
+
+Ensure dependencies are installed (run from the `it-journey` repo root, next to the `Gemfile`):
 
 ```bash
 bundle install
@@ -72,18 +82,26 @@ bundle exec jekyll build
 
 ## ☁️ Chapter 2: Deploy with the Azure Helper Script
 
-Use the built-in deployment script:
+Use the built-in deployment script. Run it **from the `it-journey` repo root** (the same
+directory you cloned into in Chapter 1) using its repo-relative path:
 
 ```bash
-../../scripts/deployment/azure-jekyll-deploy.sh setup
-../../scripts/deployment/azure-jekyll-deploy.sh deploy --app-name <your-app-name> --github-repo <your-repo-url>
+# setup: verifies prerequisites and provisions the Azure Static Web App
+scripts/deployment/azure-jekyll-deploy.sh setup
+
+# deploy: pushes the build and wires up the GitHub Actions CI/CD workflow
+#   --app-name    the name for your Azure Static Web App (e.g. my-it-journey)
+#   --github-repo the HTTPS URL of your fork (e.g. https://github.com/<you>/it-journey)
+scripts/deployment/azure-jekyll-deploy.sh deploy --app-name <your-app-name> --github-repo <your-repo-url>
 ```
 
 Follow the prompts for Azure authentication and GitHub workflow setup.
 
 ## 🔐 Chapter 3: Secrets & Workflow Verification
 
-1. Confirm required GitHub secrets are set.
+1. Confirm the required GitHub secret is set: the Azure Static Web Apps deployment token,
+   stored as `AZURE_STATIC_WEB_APPS_API_TOKEN` under **Settings → Secrets and variables →
+   Actions** in your repo. The `deploy` step above prints this token; copy it into the secret.
 2. Open the generated workflow in `.github/workflows/`.
 3. Trigger a deploy by pushing a small change.
 
@@ -109,7 +127,7 @@ Follow the prompts for Azure authentication and GitHub workflow setup.
 
 *Structured wiki-links connect this quest to the IT-Journey knowledge graph. Open the [Obsidian Graph View](/notes/obsidian/graph/) to explore connections.*
 
-**Level hub:** [[Level 1001 (9) - Kubernetes Orchestration]]
+**Level hub:** [[Level 1000 (8) - Cloud Computing]]
 **Overworld:** [[🏰 Overworld - Master Quest Map]]
 **Obsidian docs:** [[Obsidian Knowledge Graph and Wiki Links]]
 

--- a/pages/_quests/1000/self-operating-website-03-the-war-machine.md
+++ b/pages/_quests/1000/self-operating-website-03-the-war-machine.md
@@ -112,7 +112,13 @@ The **OODA loop** gives us four named stages. *Observe* loads the world (the wor
 
 We rank with **RICE**: `score = (Reach × Impact × Confidence) / Effort`. Reach is how many pages or users a fix touches, Impact is how much it moves the needle, Confidence is how sure we are, and Effort is the cost. Dividing by effort means a cheap, broad, high-confidence win beats a heroic gamble every time.
 
+Save these pure functions as `scripts/decide_core.py` — `decide.py` below imports them
+with `from decide_core import Task, decide`, so the file must sit next to `decide.py` in
+`scripts/` (or be on your `PYTHONPATH`), otherwise you get `ModuleNotFoundError: No module
+named 'decide_core'`.
+
 ```python
+# scripts/decide_core.py — the pure OODA/RICE decision functions, imported by decide.py.
 from dataclasses import dataclass
 
 @dataclass(frozen=True)
@@ -145,7 +151,8 @@ The two helpers the dispatch script shells out to are thin. `build_backlog.py` i
 # Output shape (one object per candidate task), consumed by decide.py:
 #   [{"id": "fix-broken-link-42", "reach": 120, "impact": 2.0,
 #     "confidence": 0.9, "effort": 1.5}, ...]
-import json, sys
+import json
+import sys
 
 def build_backlog() -> list[dict]:
     # Replace this stub with a read of your Chapter-II worklist.
@@ -163,7 +170,8 @@ if __name__ == "__main__":
 
 ```python
 # scripts/decide.py — Orient + Decide: read backlog JSON on stdin, print one id.
-import json, sys
+import json
+import sys
 from decide_core import Task, decide   # the pure functions defined above
 
 def main() -> None:
@@ -228,8 +236,17 @@ TASK_ID="$1"
 
 LEASE_REF="refs/leases/${TASK_ID}"
 
-# Point the lease at the current commit; the *name* is the lock.
-git update-ref "$LEASE_REF" HEAD
+# Point the lease at a UNIQUE per-runner commit — NOT at HEAD.
+# If two runners share the same HEAD SHA, pushing HEAD to the lease ref is
+# byte-identical for both, so git reports "Everything up-to-date" (exit 0) for
+# the second runner too and BOTH would believe they won. A per-attempt nonce
+# commit makes the two pushes differ, so the create-only CAS below correctly
+# rejects the loser with a stale-info error.
+NONCE="${GITHUB_RUN_ID:-$$}-${RANDOM}-$(date +%s%N)"
+LEASE_SHA="$(GIT_AUTHOR_NAME=war-machine GIT_AUTHOR_EMAIL=war-machine@ci \
+  GIT_COMMITTER_NAME=war-machine GIT_COMMITTER_EMAIL=war-machine@ci \
+  git commit-tree 'HEAD^{tree}' -p HEAD -m "lease ${TASK_ID} ${NONCE}")"
+git update-ref "$LEASE_REF" "$LEASE_SHA"
 
 # The push IS the compare-and-swap. An EMPTY expected value
 # (the part after the trailing ':') asserts the ref must NOT already


### PR DESCRIPTION
## 🔧 Quest fix — `security-specialist/1000`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: security-specialist/1000

Evidence: `walk-evidence.json` — `mode=execute`, non-truncated, all 4 results
`executed=true`, `errored=0` → M7 honest-run gate passes. Acted on the 3 non-pass quests
(1 `warn`, 2 `fail`); skipped the 1 `pass` quest. None are vendored. All kept edits held
tier-1 structural score (M1: holds-or-rises) with brand_lint clean; no quest frontmatter
was touched.

- **pages/_quests/1000/aws-essentials.md** (`warn`) — fixed the failed S3 command
  (`verdict_obj.commands[].status=failed` + high rec, area *Chapter 2: Storing Objects in
  S3*): the bucket is created with a `$RANDOM` suffix but four later commands hardcoded
  `my-quest-bucket-12345`. Stored the generated name in a `BUCKET=` variable and reused
  `$BUCKET` in every `cp`/`put-public-access-block`/`rb` call. tier-1 score_pct 100.0 →
  100.0 (held), brand clean. ✅ kept.

- **pages/_quests/1000/azure-ascension-jekyll-deployment.md** (`fail`) — addressed the
  failed commands + high/medium recs:
  - failed `bundle install` / `bundle exec jekyll build` (no Gemfile — repo never cloned)
    + high rec *Chapter 1 prerequisites*: added an explicit `git clone` + `cd it-journey`
    step and Ruby ≥3.2 / Bundler note before the build.
  - high rec *System requirements*: added Azure CLI install + `az login` and Ruby/Bundler
    to System Requirements.
  - failed `../../scripts/deployment/azure-jekyll-deploy.sh …` (script not found at that
    relative path) + high rec *Chapter 2 deploy script*: corrected the path to the
    repo-root-relative `scripts/deployment/azure-jekyll-deploy.sh` (the script exists
    there), stated the working directory, and documented `setup` vs `deploy` and the
    `--app-name` / `--github-repo` flags.
  - medium rec *Chapter 3 secrets*: named the required secret
    `AZURE_STATIC_WEB_APPS_API_TOKEN` and where to set it.
  - medium rec *Knowledge Graph*: fixed the mismatched Level-hub wiki-link from
    `Level 1001 (9) - Kubernetes Orchestration` to `Level 1000 (8) - Cloud Computing`.

  tier-1 score_pct 74.3 → 74.3 (held), brand clean. ✅ kept.

- **pages/_quests/1000/self-operating-website-03-the-war-machine.md** (`fail`) —
  addressed the failed commands + high/medium recs:
  - failed `scripts/decide.py` (`ModuleNotFoundError: No module named 'decide_core'`) +
    medium rec *Chapter 1 — decide_core.py placement*: added a `# scripts/decide_core.py`
    header and an instruction to save the pure Task/rice_score/decide snippet next to
    `decide.py` (or on `PYTHONPATH`).
  - high rec *CI tiered pipeline / lint tier* (`ruff check` E401 on the quest's own code):
    split `import json, sys` into separate `import json` / `import sys` lines in both
    `build_backlog.py` and `decide.py`.
  - failed `lease.sh` concurrent same-HEAD race + high rec *Chapter 2 — git-ref CAS
    leasing*: the lease pointed at `HEAD`, so two runners on an identical HEAD SHA pushed
    byte-identical values and both got `Everything up-to-date` (exit 0) — both "won".
    Changed the lease to point at a unique per-attempt nonce commit
    (`git commit-tree` with a `GITHUB_RUN_ID`/`RANDOM`/timestamp nonce) so the two pushes
    differ and the create-only `--force-with-lease` CAS correctly rejects the loser.

  tier-1 score_pct 94.6 → 94.6 (held), brand clean. ✅ kept.

_Left (not fixed this pass):_
- **war-machine, high rec *CI unit tier*** (`pytest tests/unit` collects no tests) — a
  faithful fix requires authoring the missing `decide()`/RICE unit-test content
  (substantive), and removing the tier would weaken the quest to move nothing; left for a
  dedicated pass to keep this PR small and reviewable.
- **war-machine, medium rec** *Mastery Challenge "prove the test has teeth"* (add a
  `time.sleep` to make the sabotaged race observable) — deferred with the unit-tier work
  above.
- **aws-essentials** medium/low recs (SSH example; 2024 Free Tier credit-model note; Linux
  install-path caveat) and **azure** low recs (Azure cost/cleanup note; Quest Rewards/XP
  section) — out of the small per-slice edit cap; deferred to a future pass.
- **pages/_quests/1000/infrastructure-as-code.md** — `verdict=pass`; out of scope (fix
  lane acts only on `warn`/`fail` quests), so its 2 failed commands were not touched here.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/28939589301)._
