### PR TITLE
🔧 Quest fix: developer/0100

### DIFF
--- a/pages/_quests/0100/side-quest-profile-themes.md
+++ b/pages/_quests/0100/side-quest-profile-themes.md
@@ -207,6 +207,8 @@ profile:
 
 Update `_includes/contributor/character_sheet.html` to apply the theme class:
 
+> ⚠️ **Strip the Liquid `raw`/`endraw` wrapper tags before pasting.** They only exist here so this quest page can *display* the Liquid tags instead of running them. Copy the code into the real `.html` file **without** the `raw`/`endraw` lines — otherwise Jekyll renders the literal `{% raw %}{% if %}{% endraw %}`/`{% raw %}{{ theme_class }}{% endraw %}` markup as visible text instead of applying your theme.
+
 ```liquid
 
 {% raw %}{% if contributor.profile.theme %}{% endraw %}
@@ -219,6 +221,8 @@ Update `_includes/contributor/character_sheet.html` to apply the theme class:
 ### Step 6: Load the Theme CSS
 
 In your profile page (or in `character_sheet.html`):
+
+> ⚠️ **Same as Step 5 — remove the Liquid `raw`/`endraw` wrapper tags before pasting.** Paste only the Liquid between them; leaving the `raw`/`endraw` lines in produces a broken literal `<link>` tag (with visible `{% raw %}{{ ... }}{% endraw %}` markup) instead of loading your theme's stylesheet.
 
 ```liquid
 

--- a/pages/_quests/0100/sourcery-code-methods.md
+++ b/pages/_quests/0100/sourcery-code-methods.md
@@ -88,6 +88,14 @@ You'll know you've truly mastered this quest when you can:
 - [ ] Design and implement professional development workflows for teams
 - [ ] Troubleshoot version control issues and guide others through solutions
 
+## 🗺️ Quest Prerequisites
+
+Before you begin, make sure your realm is stocked with the tools this quest assumes:
+
+- **A GitHub account** — Chapter 1 pushes to a remote repository and later chapters wire up GitHub Actions. Sign up at [github.com](https://github.com/) if you don't have one.
+- **Git installed and configured** — the "Choose Your Adventure Platform" section below installs Git for your OS.
+- **Node.js installed** — the Chapter 4 GitHub Actions workflow runs `npm` scripts (test, lint, coverage), so a working Node.js/npm toolchain is required to follow that chapter against a real project. Grab it from [nodejs.org](https://nodejs.org/).
+
 ## 🌍 Choose Your Adventure Platform
 
 *Different platforms offer unique advantages for mastering source control sorcery. Choose the path that best fits your current realm and magical setup.*
@@ -174,6 +182,7 @@ Every source control journey begins with understanding the three mystical realms
 mkdir my-first-quest
 cd my-first-quest
 git init  # Initialize the repository with Git magic
+git branch -M main  # Name the default branch 'main' now, so it matches GitHub's default and the output below
 
 # Check the status of your realm
 git status  # Shows which files are tracked, modified, or staged
@@ -191,10 +200,19 @@ This marks the beginning of my source control journey.
 Created initial documentation for the project."
 
 # Connect to a remote GitHub repository
+# ⚠️ First create an EMPTY repo on GitHub (web UI, or `gh repo create my-first-quest --public`),
+# then swap `yourusername`/repo name below for your own — this URL is only a placeholder.
 git remote add origin https://github.com/yourusername/my-first-quest.git
-git branch -M main
 git push -u origin main
 ```
+
+> 🔑 **Heads-up — the push needs a real repo and authentication.** `git push` only
+> succeeds once `origin` points at a repository you actually created on GitHub **and**
+> you're signed in (a browser/credential-manager prompt, or a
+> [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)).
+> Against the placeholder URL above it fails with
+> `fatal: could not read Username for 'https://github.com'` — that's expected until you
+> substitute your own repo and credentials.
 
 **Expected Output**:
 ```text


### PR DESCRIPTION
## 🔧 Quest fix — `developer/0100`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: developer/0100

Evidence gate (M7) passed: all 3 results `mode==execute`, `mock==false`,
`executed==true`, non-truncated, 0 errored. Acted on the 2 `warn` quests only
(the `pass` quest `self-operating-website-02-the-proving-grounds` was skipped).
No quest was vendored (`source_repo`/`source_url` absent). No frontmatter changed.

**Kept edits**

- **pages/_quests/0100/sourcery-code-methods.md** — fixed two failed sandbox commands
  in Chapter 1: (a) the `Expected Output` block showed `[main (root-commit) …]` while the
  real run produced `[master …]` (`commands[].status=failed`), and (b) `git push -u origin main`
  failed with `fatal: could not read Username for 'https://github.com'`
  (`commands[].status=failed`). Moved `git branch -M main` to right after `git init` so the
  shown `main` output now matches reality (high rec: *Chapter 1 Expected Output block*), and
  added a heads-up that the push requires a real, pre-created GitHub repo + authentication /
  PAT with a username substitution (high rec: *Chapter 1 remote push step*).
  tier-1 **68/74 → 71/74** (also added a `## 🗺️ Quest Prerequisites` section covering
  GitHub account + Git + Node.js, addressing the low rec *Prerequisites*). brand clean. ✅ kept.

- **pages/_quests/0100/side-quest-profile-themes.md** — fixed two failed Liquid commands:
  Steps 5 & 6 rendered literal `{% raw %}{% if %}{% endraw %}`/`{% raw %}{{ }}{% endraw %}`
  text because the copy-paste blocks kept their `{% raw %}` wrappers
  (`commands[].status=failed` for both steps). Added an explicit callout to each step telling
  the learner to strip the `raw`/`endraw` wrapper tags before pasting into the real
  `.html` file (high rec: *Steps 5 & 6 Liquid code blocks*). The page's own display wrappers
  were left intact (verified the notes keep all raw/endraw tags balanced so the build renders).
  tier-1 **63/74 → 63/74** (held). brand clean. ✅ kept.

**Left (out of small-cap scope or not deterministically improvable)**

- sourcery — medium rec *Chapter 4 GitHub Actions workflow* (scaffold package.json): only
  partially covered by the new Node.js prerequisite note; full scaffolding left for a
  focused authoring pass.
- sourcery — medium rec *Advanced Git Techniques* (worked rebase/cherry-pick/merge-conflict
  example) and low rec *AI-Enhanced Workflows objective*: larger authoring, deferred.
- profile-themes — medium recs *Step 2 contrast pairs* (arctic/sunset) and *Step 1↔3
  `--xp-bar-fill` reconcile*, plus low recs *Step 7 preview URL* and *Step 1 CSS selector
  context*: deferred to keep the PR small; can be picked up on the next daily sweep.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/29091248315)._
