### PR TITLE
🔧 Quest fix: developer/0110

### DIFF
--- a/pages/_quests/0110/database-fundamentals.md
+++ b/pages/_quests/0110/database-fundamentals.md
@@ -303,7 +303,17 @@ The foreign key guarantees a loan can never reference a member who does not exis
 | **Isolation** | Concurrent transactions don't corrupt each other | Two librarians issuing loans don't reuse a loan_id |
 | **Durability** | Once committed, data survives a crash | A power cut after `COMMIT` does not lose the loan |
 
-Watch atomicity protect a transfer between two accounts:
+First, create the `accounts` table and seed two rows so the example runs as written. The `CHECK` constraint refuses any update that would drive a balance negative - a `CHECK` guards a rule *inside* a single row, the way a foreign key guards a rule *between* tables:
+
+```sql
+CREATE TABLE accounts (
+    id      INTEGER PRIMARY KEY,
+    balance NUMERIC NOT NULL CHECK (balance >= 0)   -- CHECK: no account may go negative
+);
+INSERT INTO accounts (id, balance) VALUES (1, 100), (2, 100);
+```
+
+Now watch atomicity protect a transfer between those two accounts:
 
 ```sql
 BEGIN;                                              -- start the transaction

--- a/pages/_quests/0110/database-migrations.md
+++ b/pages/_quests/0110/database-migrations.md
@@ -168,9 +168,12 @@ pip install alembic psycopg2-binary
 <summary>Click to expand Linux instructions</summary>
 
 ```bash
-sudo apt update && sudo apt install -y postgresql python3-pip
+sudo apt update && sudo apt install -y postgresql python3-pip python3-venv
 sudo systemctl enable --now postgresql
 sudo -u postgres createdb living_schema
+# Ubuntu 23.04+/Debian 12+ mark the system Python "externally managed" (PEP 668),
+# so install into a virtualenv rather than pip-installing globally:
+python3 -m venv .venv && source .venv/bin/activate
 pip install alembic psycopg2-binary
 ```
 
@@ -182,9 +185,13 @@ pip install alembic psycopg2-binary
 <summary>Click to expand Cloud/Container instructions</summary>
 
 ```bash
-docker run --name living-schema -e POSTGRES_PASSWORD=quest -p 5432:5432 -d postgres:16
-# Flyway via Docker - no local install needed:
-docker run --rm flyway/flyway -url=jdbc:postgresql://host.docker.internal/living_schema info
+# POSTGRES_DB creates the living_schema database on first boot:
+docker run --name living-schema -e POSTGRES_PASSWORD=quest -e POSTGRES_DB=living_schema -p 5432:5432 -d postgres:16
+# Flyway via Docker - no local install needed.
+# --add-host is required on native Linux Docker: host.docker.internal resolves
+# automatically only on Docker Desktop (Mac/Windows). Pass -user/-password too:
+docker run --rm --add-host=host.docker.internal:host-gateway flyway/flyway \
+  -url=jdbc:postgresql://host.docker.internal/living_schema -user=postgres -password=quest info
 ```
 
 </details>


### PR DESCRIPTION
## 🔧 Quest fix — `developer/0110`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: developer/0110

Honest run confirmed: execute-mode, non-truncated, all 5 results `executed==true`, 0 errored. Acted on the 2 `warn` quests only (3 `pass` quests out of scope). Neither target is vendored.

- **pages/_quests/0110/database-fundamentals.md** — fixed the failed flagship ACID command `BEGIN; UPDATE accounts ...` (verified: `commands[].status=failed` — `relation "accounts" does not exist`) and its high-priority rec (area: *Chapter 3 - ACID example*) by adding the missing `CREATE TABLE accounts (... CHECK (balance >= 0))` + `INSERT` seed rows before the transaction block. The `CHECK` constraint added there also demonstrates the medium rec (area: *Secondary Objective - Constraints (CHECK)*), previously listed but never shown. tier-1 score 74/74 (100.0%) → 74/74 (100.0%) (held), brand clean. ✅ kept.
- **pages/_quests/0110/database-migrations.md** — fixed the failed command `docker run ... flyway/flyway ... info` (verified: `commands[].status=failed` — `UnknownHostException: host.docker.internal`, missing credentials, DB never created) and its high-priority rec (area: *Cloud Realms Path / Chapter 1 Docker snippet*): added `-e POSTGRES_DB=living_schema`, `-user=postgres -password=quest`, and `--add-host=host.docker.internal:host-gateway` for native Linux Docker. Also addressed the medium rec (area: *Linux Territory Path pip install*, PEP 668) by adding `python3-venv` + a venv activation before `pip install`. tier-1 score 74/74 (100.0%) → 74/74 (100.0%) (held), brand clean. ✅ kept.

_Left (out of scope for this small pass, valid for a future run):_ fundamentals — medium *Indexes (preview)* rec and low *Platform setup snippets* re-verify rec. migrations — medium *Liquibase claims* rec, low *Flyway worked example* rec. All deferred to keep the PR small and reviewable; none reverted. No edits touched frontmatter, so `_data/quests/**` regeneration was not required.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/29248386306)._
