### PR TITLE
🔧 Quest fix: system-engineer/1001

### DIFF
--- a/pages/_quests/1001/agentic-dev-environment-integration.md
+++ b/pages/_quests/1001/agentic-dev-environment-integration.md
@@ -117,7 +117,7 @@ Key sections an `AGENTS.md` must include:
 
 > **Exercise 6.1:** Create `AGENTS.md` in the root of your sandbox repository.
 
-```markdown
+````markdown
 # AGENTS.md — Agent Operating Guide
 
 This file provides operating instructions for AI agents (GitHub Copilot
@@ -168,7 +168,7 @@ npm test -- --coverage
 
 # Lint
 npm run lint
-```markdown
+```
 
 ## Build Commands
 
@@ -178,7 +178,7 @@ npm run build
 
 # Start development server
 npm run dev
-```bash
+```
 
 ## Commit Message Format
 
@@ -193,7 +193,7 @@ The following environment variables are set in the devcontainer:
 
 Do NOT use any other secrets. If your task requires a secret not listed
 here, STOP and report what you need.
-```
+````
 
 ---
 
@@ -256,10 +256,10 @@ check() {
     local cmd="$2"
     if eval "$cmd" &>/dev/null; then
         echo "✅ $name"
-        ((PASS++))
+        PASS=$((PASS+1))
     else
         echo "❌ $name"
-        ((FAIL++))
+        FAIL=$((FAIL+1))
     fi
 }
 

--- a/pages/_quests/1001/agentic-memory-strategies.md
+++ b/pages/_quests/1001/agentic-memory-strategies.md
@@ -132,6 +132,7 @@ Only then proceed to plan.
 
 > **Exercise 8.1:** Implement session memory using GitHub Actions artifacts.
 
+{% raw %}
 ```yaml
 # .github/workflows/agent-with-session-memory.yml
 name: Agent with Session Memory
@@ -151,9 +152,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .agent-memory/session.json
-          key: agent-session-${% raw %}{{ github.event.issue.number }}{% endraw %}
+          key: agent-session-${{ github.event.issue.number }}
           restore-keys: |
-            agent-session-${% raw %}{{ github.event.issue.number }}{% endraw %}
+            agent-session-${{ github.event.issue.number }}
 
       - name: Initialise session memory
         run: |
@@ -161,14 +162,14 @@ jobs:
           if [ ! -f .agent-memory/session.json ]; then
             cat > .agent-memory/session.json << 'EOF'
             {
-              "session_id": "${% raw %}{{ github.run_id }}{% endraw %}",
-              "issue_number": ${% raw %}{{ github.event.issue.number }}{% endraw %},
+              "session_id": "${{ github.run_id }}",
+              "issue_number": ${{ github.event.issue.number }},
               "started_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
               "completed_steps": [],
               "decisions": [],
               "files_modified": []
             }
-            EOF
+          EOF
           fi
 
       - name: Run agent task (reads and updates session memory)
@@ -199,10 +200,11 @@ jobs:
       - name: Save session memory
         uses: actions/upload-artifact@v4
         with:
-          name: agent-session-${% raw %}{{ github.event.issue.number }}{% endraw %}-${% raw %}{{ github.run_id }}{% endraw %}
+          name: agent-session-${{ github.event.issue.number }}-${{ github.run_id }}
           path: .agent-memory/session.json
           retention-days: 1
 ```
+{% endraw %}
 
 > **Why upload-artifact instead of `actions/cache/save`?** GitHub Actions caches are **immutable** — once a key is written, later writes for the same key are silently ignored, so the agent can restore stale session memory. For *mutable* same-run handoff, use upload/download artifacts (per-run). For *cross-run* mutable state, write to a repo file in a PR, or post the JSON as an issue comment and re-read it.
 

--- a/pages/_quests/1001/agentic-safe-execution-and-error-handling.md
+++ b/pages/_quests/1001/agentic-safe-execution-and-error-handling.md
@@ -115,6 +115,7 @@ Not all failures are equal. Before building retry logic, classify what can and c
 
 > **Exercise 7.1:** Add retry configuration to your agent workflow.
 
+{% raw %}
 ```yaml
 # .github/workflows/agent-with-retries.yml
 name: Agent with Resilient Execution
@@ -142,7 +143,7 @@ jobs:
             echo "=== Attempt $attempt of $RETRY_MAX ==="
             
             if python3 work/gh-600/scripts/run_agent_task.py \
-                --issue "${% raw %}{{ github.event.issue.number }}{% endraw %}" \
+                --issue "${{ github.event.issue.number }}" \
                 --output agent-result.json; then
               echo "✅ Agent task succeeded on attempt $attempt"
               echo "succeeded=true" >> "$GITHUB_OUTPUT"
@@ -174,8 +175,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const errorCode = '${% raw %}{{ steps.agent_task.outputs.error_code }}{% endraw %}' || 'unknown';
-            const runUrl = `https://github.com/${% raw %}{{ github.repository }}{% endraw %}/actions/runs/${% raw %}{{ github.run_id }}{% endraw %}`;
+            const errorCode = '${{ steps.agent_task.outputs.error_code }}' || 'unknown';
+            const runUrl = `https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
             
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -190,6 +191,7 @@ jobs:
                 `with an updated body.`
             });
 ```
+{% endraw %}
 
 ---
 
@@ -239,8 +241,8 @@ Level 4 — Timeout:              Hard stop + comment + disable agent label
 > **Exercise 7.3:** Create a test that deliberately causes each failure type and verify the escalation path.
 
 ```bash
-# work/gh-600/scripts/test_failure_scenarios.sh
 #!/usr/bin/env bash
+# work/gh-600/scripts/test_failure_scenarios.sh
 set -euo pipefail
 
 echo "=== Testing Agent Failure Scenarios ==="


### PR DESCRIPTION
## 🔧 Quest fix — `system-engineer/1001`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: system-engineer/1001

Evidence: execute-mode, non-truncated, all results `executed==true` (M7 satisfied).
Acted on the 3 non-pass quests (`fail`); the 2 `pass` quests were left untouched.
All kept edits held-or-rose on the tier-1 structural score and stayed brand-clean
(numbers read straight from `quest_validator.py --json`). None are vendored. No
frontmatter changed, so no `_data/quests/**` regeneration was needed.

**`pages/_quests/1001/agentic-dev-environment-integration.md`** — tier-1 score_pct 85.1 → 85.1 (held), brand clean. ✅ kept.
- Fixed failed command `check_agent_env.sh` (Exercise 6.3, `commands[].status=failed`;
  high rec): replaced `((PASS++))`/`((FAIL++))` with `PASS=$((PASS+1))`/`FAIL=$((FAIL+1))`
  so the script no longer dies on the first check under `set -euo pipefail`.
- Fixed failed command `AGENTS.md content block` (Exercise 6.1, `commands[].status=failed`;
  high rec): de-nested the corrupted fences — outer fence → 4 backticks, inner Test/Build
  Commands fences closed with bare ``` ``` ``` instead of ` ```markdown `/` ```bash `, so the
  block no longer collapses and a copied `AGENTS.md` renders correctly.

**`pages/_quests/1001/agentic-safe-execution-and-error-handling.md`** — tier-1 score_pct 85.1 → 85.1 (held), brand clean. ✅ kept.
- Fixed failed command `agent-with-retries.yml` (Exercise 7.1, `commands[].status=failed`;
  high rec): stripped the leaked inline `{% raw %}…{% endraw %}` tags that broke the `${{ }}`
  syntax (bash "bad substitution" / JS SyntaxError) and wrapped the whole block in a single
  `{% raw %}`/`{% endraw %}` pair on their own lines, so the code shows clean GitHub Actions
  `${{ … }}` while Jekyll rendering stays protected.
- Fixed failed command `test_failure_scenarios.sh` (Exercise 7.3, `commands[].status=failed`;
  high rec): moved `#!/usr/bin/env bash` to line 1 (path comment now follows it) so the
  shebang is honoured instead of the file being mis-run as `Unicode text`.

**`pages/_quests/1001/agentic-memory-strategies.md`** — tier-1 score_pct 78.4 → 78.4 (held), brand clean. ✅ kept.
- Fixed failed command `agent-with-session-memory.yml` (Exercise 8.1, `commands[].status=failed`;
  two high recs): left-aligned the first heredoc's closing `EOF` to the `run:` block base
  indent (bash column 0) so the JSON heredoc terminates instead of swallowing the rest of
  the script; and stripped the leaked inline `{% raw %}…{% endraw %}` tags, wrapping the
  block in one `{% raw %}`/`{% endraw %}` pair so learners see real `${{ … }}` syntax.

_Left (verified but out of this small, reviewable pass):_
- The shared `scripts/validate_quest.py` "Quest Validation" command fails in all three
  quests (medium recs) — the script is never shipped/scaffolded. This is one cross-cutting
  authoring decision (ship/link the script vs. relabel as platform-side CI) best made
  deliberately, not guessed; deferred.
- `agentic-dev-environment-integration.md`: high rec to add-or-remove the
  `.github/copilot-instructions.md` check (needs a whole new exercise or a validation-step
  removal — larger authoring); plus medium (devcontainer `up` step) and low (Node 18 EOL,
  cold-start placeholder notes) recs.
- `agentic-safe-execution-and-error-handling.md`: remainder of the 7.3 high rec (implement
  real mocking/assertions in the test script); low recs (7.2 step-placement wording,
  `permissions: issues: write` note).
- `agentic-memory-strategies.md`: medium (runnable context-injection demo) and low
  (`restore-keys` clarification) recs.

_No edits were reverted; every attempted edit passed the deterministic gate._

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/29248386306)._
