### PR TITLE
🔧 Quest fix: security-specialist/1011

### DIFF
--- a/pages/_quests/1011/agentic-multi-agent-failure-recovery.md
+++ b/pages/_quests/1011/agentic-multi-agent-failure-recovery.md
@@ -227,7 +227,9 @@ def assess_and_recover(
     results = {}
     for result_file in Path(results_dir).rglob("*.json"):
         with open(result_file) as f:
-            results[result_file.stem] = json.load(f)
+            # Key by the artifact directory (e.g. "subtask1-result"), which
+            # matches the upload-artifact name used in the workflow above.
+            results[result_file.parent.name] = json.load(f)
     
     failed_agents = [k for k, v in agent_statuses.items() if v == "failure"]
     succeeded_agents = [k for k, v in agent_statuses.items() if v == "success"]
@@ -241,8 +243,12 @@ def assess_and_recover(
     }
     
     for agent_id in failed_agents:
-        # Determine recovery strategy based on what's available
-        agent_result = results.get(f"{agent_id}-result")
+        # Determine recovery strategy based on what's available.
+        # Map the orchestrator agent id (e.g. "sub-agent-1") to the artifact
+        # naming used by the workflow (e.g. "subtask1-result") so checkpoint
+        # detection actually finds the preserved partial results.
+        subtask_name = agent_id.replace("sub-agent-", "subtask")
+        agent_result = results.get(f"{subtask_name}-result")
         
         if agent_result and agent_result.get("checkpoint_available"):
             recovery_plan["recovery_actions"].append({
@@ -263,12 +269,16 @@ def assess_and_recover(
     print(f"Recovery plan: {len(failed_agents)} failed, {len(succeeded_agents)} succeeded")
     print(f"Recovery actions: {len(recovery_plan['recovery_actions'])}")
     
-    # Set GitHub Actions outputs
+    # Set GitHub Actions outputs via $GITHUB_OUTPUT (the `::set-output`
+    # workflow command was deprecated and no longer works on hosted runners).
     needs_redelegation = any(
         a["strategy"] == "redelegate"
         for a in recovery_plan["recovery_actions"]
     )
-    print(f"::set-output name=needs_redelegation::{str(needs_redelegation).lower()}")
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a") as gh_out:
+            gh_out.write(f"needs_redelegation={str(needs_redelegation).lower()}\n")
     
     return recovery_plan
 

--- a/pages/_quests/1011/ai-feature-pipeline-architect.md
+++ b/pages/_quests/1011/ai-feature-pipeline-architect.md
@@ -219,25 +219,35 @@ const aiPipeline = {
 
 ```python
 # Install the AI orchestration framework
-pip install langchain anthropic openai mcp-client
+# (the Model Context Protocol package on PyPI is `mcp`, not `mcp-client`)
+pip install langchain anthropic openai mcp
 
 # Create your first AI agent for requirement processing
-from langchain.agents import Agent
-from mcp import MCPClient
+import os
+from anthropic import Anthropic
+from mcp import ClientSession
 
 class RequirementProcessor:
     def __init__(self):
-        self.llm = Anthropic(api_key="your-key")
-        self.mcp_client = MCPClient()
-    
-    async def process_user_request(self, raw_request: str):
+        # Read credentials from the environment — never hard-code API keys
+        self.llm = Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+        self.mcp_session: ClientSession | None = None  # opened via an MCP transport
+
+    def process_user_request(self, raw_request: str):
         """Transform natural language into structured requirements"""
         # AI processes the request and generates structured output
-        structured_req = await self.llm.agenerate({
-            "prompt": f"Convert this feature request into structured format: {raw_request}",
-            "schema": "user_story_schema.json"
-        })
-        return structured_req
+        response = self.llm.messages.create(
+            model="claude-3-5-sonnet-latest",
+            max_tokens=1024,
+            messages=[{
+                "role": "user",
+                "content": (
+                    "Convert this feature request into structured JSON "
+                    f"matching user_story_schema.json: {raw_request}"
+                ),
+            }],
+        )
+        return response.content[0].text
 ```
 
 **Why this matters**: The intake stage is critical because unclear requirements lead to failed projects. AI excels at parsing natural language and asking clarifying questions that humans might miss.
@@ -259,6 +269,22 @@ class RequirementProcessor:
 ```
 
 **Step 3: Test your intake pipeline**
+
+First save the `RequirementProcessor` class above into `intake_agent.py` and add a
+`__main__` entry point that reads the request from stdin, so the module is runnable
+from the command line:
+
+```python
+# intake_agent.py (append below the RequirementProcessor class)
+import sys
+
+if __name__ == "__main__":
+    raw_request = sys.stdin.read().strip()
+    processor = RequirementProcessor()
+    print(processor.process_user_request(raw_request))
+```
+
+Then run it (make sure `ANTHROPIC_API_KEY` is exported in your environment):
 
 ```bash
 # Test the requirement processor


### PR DESCRIPTION
## 🔧 Quest fix — `security-specialist/1011`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: security-specialist/1011

Evidence gate (M7) passed: `mode==execute`, not truncated, `errored==0`, every result
`executed==true`. Acted only on the two `fail` quests' verified issues (highest priority
first). All kept edits are content-only; no frontmatter changed, so no `_data/quests`
regeneration was needed. Every before→after number is read straight from
`quest_validator.py` (tier-1 `score_pct`).

**Kept edits**

- **pages/_quests/1011/agentic-multi-agent-failure-recovery.md** — fixed failed command
  `python: recovery_coordinator.py …` (verified: `commands[].status=failed`) + high rec
  (*Chapter 3 — recovery_coordinator.py*): the results-dict lookup key `sub-agent-1-result`
  never matched the workflow's artifact naming. Now keys results by artifact directory
  (`subtask1-result`) and maps `sub-agent-N → subtaskN`, so checkpoint detection returns
  `retry_from_checkpoint` instead of `redelegate`/`unknown` (reproduced the walker's fixture
  to confirm). tier-1 score_pct 78.4 → 78.4 (held), brand clean. ✅ kept.
- **pages/_quests/1011/agentic-multi-agent-failure-recovery.md** — addressed high rec
  (*Chapter 3 — output mechanism*): replaced deprecated
  `print("::set-output name=needs_redelegation::…")` with a write to `$GITHUB_OUTPUT`
  (confirmed it now writes `needs_redelegation=…`). tier-1 score_pct 78.4 → 78.4 (held),
  brand clean. ✅ kept.
- **pages/_quests/1011/ai-feature-pipeline-architect.md** — fixed failed command
  `pip install … mcp-client` / `from mcp import MCPClient` / `from langchain.agents import Agent`
  (verified: `commands[].status=failed`) + high rec (*Chapter 1 Step 1 imports*): corrected
  the package to `mcp`, imports to `from anthropic import Anthropic` + `from mcp import ClientSession`,
  dropped the non-existent `langchain.agents.Agent` import, moved the hardcoded `api_key="your-key"`
  to `os.environ["ANTHROPIC_API_KEY"]` (also the medium security-framing rec), and replaced the
  nonexistent `self.llm.agenerate(...)` call with the real `Anthropic().messages.create(...)` API.
  tier-1 score_pct 95.9 → 95.9 (held), brand clean. ✅ kept.
- **pages/_quests/1011/ai-feature-pipeline-architect.md** — fixed failed command
  `echo … | python intake_agent.py` → *No such file or directory* (verified:
  `commands[].status=failed`) + high rec (*Chapter 1 Step 3 test command*): added a small
  runnable `intake_agent.py` `__main__`/stdin entry point wrapping `RequirementProcessor`
  before the test command, so the "Expected output" claim is now reachable. tier-1 score_pct
  95.9 → 95.9 (held), brand clean. ✅ kept.

**Left (and why)**

- _agentic-multi-agent-failure-recovery.md — high rec/failed command "strip the `{% raw %}…{% endraw %}`
  tags from the YAML":_ **left as a false positive.** That `${% raw %}{{ … }}{% endraw %}` form is the
  repo-standard Jekyll idiom (used 94× across 19 quests) and renders to correct `${{ … }}`; the page has
  no `render_with_liquid: false`. The engine flagged the raw markdown source, not the rendered page —
  stripping the tags as suggested would break Jekyll rendering (a regression), so no edit made.
- _agentic — medium/low recs (provide `subtask.py`/`save_checkpoint.py`/`redelegate_tasks.py`; note
  `scripts/validate_quest.py` location):_ substantive new authoring, out of smallest-edit scope.
- _ai-feature-pipeline-architect.md — remaining high/medium recs (rewrite the Chapter 2–5 stub
  orchestrator classes into runnable code / bring chapters to Chapter-1 depth) and low recs
  (`brew install --cask github-copilot-cli`, `docker-compose`→`docker compose`):_ large rewrites /
  low priority — out of scope for a minimal, reviewable fix this pass.
- _ouroboros-loop-04-the-sealed-evidence.md (`warn`):_ no failed commands; only medium/low **additive**
  recommendations (optional local lab, credential-scrub citation wording, ledger example snippet,
  knowledge-check hints). No minimal defect a learner hits as a failure — additive authoring, left.
- _secure-coding.md and threat-modeling.md (`pass`):_ out of scope — the skill acts only on `warn`/`fail`
  quests (secure-coding's 2 failed commands are on a `pass` verdict).

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/29248386306)._
