### PR TITLE
🔧 Quest fix: developer/0111

### DIFF
--- a/pages/_quests/0111/api-authentication.md
+++ b/pages/_quests/0111/api-authentication.md
@@ -139,6 +139,8 @@ This **🔴 Hard** quest expects:
 
 *Authentication concepts are universal. These setups give you tools to decode and forge tokens locally so you can see what is inside them.*
 
+> **Get a token first:** the GitHub API calls below read a personal access token from `$GITHUB_TOKEN`. See the **Novice Challenge: Authenticate for Real** near the end of this quest for how to create one (with the `read:user` scope), then export it before running the curl commands — `export GITHUB_TOKEN=ghp_your_token` (PowerShell: `$env:GITHUB_TOKEN="ghp_your_token"`). Without it, curl sends an empty header and the call is rejected.
+
 ### 🍎 macOS Kingdom Path
 
 <details>
@@ -324,6 +326,8 @@ curl -s -X POST https://auth.example.com/token \
 ```
 
 **Scopes** express least privilege: the client asks only for what it needs (`read:profile`, not `admin:everything`). The user sees and approves the exact scopes. A **refresh token** lets the client obtain a new short-lived access token when it expires, without bothering the user again. For mobile and single-page apps that cannot keep a secret, **PKCE** (Proof Key for Code Exchange) replaces the client secret with a per-request dynamic proof.
+
+**Where you keep a token is a security decision.** In a browser, a cookie marked `httpOnly`, `Secure`, and `SameSite` keeps the token out of reach of JavaScript so a cross-site scripting bug cannot steal it (at the cost of needing CSRF protection); storing a token in `localStorage` is convenient but readable by any script on the page, so one injected script leaks it. On mobile, use the platform secure store (iOS Keychain, Android Keystore), never plain app preferences. On a server, keep tokens and client secrets in environment variables or a secrets manager, never in source control. Everywhere the rule is the same: give the token the shortest lifetime and the smallest blast radius you can.
 
 ### 🔍 Knowledge Check: OAuth2
 - [ ] What is the one-time code exchanged for, and why does that happen server-to-server?

--- a/pages/_quests/0111/api-documentation.md
+++ b/pages/_quests/0111/api-documentation.md
@@ -137,6 +137,8 @@ This **🟡 Medium** quest expects:
 
 *OpenAPI is just a text file, so any platform works. These setups let you render and validate your spec.*
 
+> **Heads-up:** the `redocly lint` and `redocly build-docs` commands below act on an `openapi.yaml` file that you author in Chapters 1–2. Install the tooling now, but run the lint/render commands *after* the spec exists (or create an empty `openapi.yaml` placeholder first) — running them in an empty directory fails with `openapi.yaml does not exist`.
+
 ### 🍎 macOS Kingdom Path
 
 <details>
@@ -147,9 +149,9 @@ This **🟡 Medium** quest expects:
 brew install node
 npm install -g @redocly/cli
 
-# Validate a spec, then preview it as a docs site
+# Validate a spec, then render it as a docs site
 redocly lint openapi.yaml
-redocly preview-docs openapi.yaml   # opens an interactive preview
+redocly build-docs openapi.yaml -o docs.html   # static HTML (or: redocly preview for a live server)
 ```
 
 </details>
@@ -163,9 +165,9 @@ redocly preview-docs openapi.yaml   # opens an interactive preview
 winget install OpenJS.NodeJS
 npm install -g @redocly/cli
 
-# Lint and preview your OpenAPI document
+# Lint and render your OpenAPI document
 redocly lint openapi.yaml
-redocly preview-docs openapi.yaml
+redocly build-docs openapi.yaml -o docs.html   # or: redocly preview for a live server
 ```
 
 </details>
@@ -178,7 +180,7 @@ redocly preview-docs openapi.yaml
 ```bash
 sudo apt update && sudo apt install -y nodejs npm
 npm install -g @redocly/cli
-redocly lint openapi.yaml && redocly preview-docs openapi.yaml
+redocly lint openapi.yaml && redocly build-docs openapi.yaml -o docs.html
 ```
 
 </details>
@@ -254,6 +256,9 @@ Contract-first flow:
 Here is `GET /books/{id}` and `POST /books`, with a reusable `Book` schema and examples:
 
 ```yaml
+# Declare an empty default security requirement so redocly's
+# security-defined rule is satisfied (these demo endpoints need no auth)
+security: []
 paths:
   /books/{id}:
     get:
@@ -304,7 +309,9 @@ components:
 The `$ref` keyword is the key to DRY documentation: define `Book` once and reference it from every place a book appears. **Examples** make the docs come alive - a developer can copy a realistic payload instead of guessing. Validate the document with tooling before you trust it:
 
 ```bash
-# Lint the spec; a clean run means tools can rely on it
+# Lint the spec; zero errors means tools can rely on it.
+# redocly may still print advisory *warnings* (e.g. a missing license,
+# an example.com server, or a missing operationId) — those do not fail the run.
 redocly lint openapi.yaml
 ```
 


### PR DESCRIPTION
## 🔧 Quest fix — `developer/0111`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: developer/0111

Evidence honest-run gate passed: all 5 results `mode==execute`, `executed==true`, none truncated, `errored==0`. Acted on the two non-pass quests only (api-authentication = warn, api-documentation = fail). Both are non-vendored (no `source_repo:`/`source_url:`). Both already scored tier-1 100% (74/74), so every kept edit had to **hold** 100% and keep brand lint clean.

**pages/_quests/0111/api-documentation.md** (verdict: fail)

- Fixed failed command `redocly preview-docs openapi.yaml` (verified: `commands[].status=failed` — "Unknown arguments: preview-docs" in @redocly/cli v2.39.0), across the macOS/Windows/Linux platform blocks → replaced with `redocly build-docs openapi.yaml -o docs.html` (+ `redocly preview` pointer). tier-1 score_pct 100 → 100 (held), brand clean. ✅ kept.
- Addressed high-priority recommendation (area: *Chapter 2 validate example*) — the flagship YAML failed `redocly lint` with 2 security-defined errors despite the text promising "a clean run." Added root-level `security: []` and reworded the lint note to set expectations for advisory warnings. tier-1 100 → 100 (held), brand clean. ✅ kept.
- Addressed medium recommendation (area: *platform section ordering*) — verified `redocly lint`/build fail with "openapi.yaml does not exist" when run top-to-bottom before the file exists. Added a heads-up note that the commands act on the spec authored in Chapters 1–2. tier-1 100 → 100 (held), brand clean. ✅ kept.

**pages/_quests/0111/api-authentication.md** (verdict: warn)

- Addressed high-priority recommendation (area: *GITHUB_TOKEN ordering*) — learners were told to run curl with `$GITHUB_TOKEN` before being shown how to obtain one (only in the Novice Challenge). Added a pointer + `export`/`$env:` example in the platform section. tier-1 score_pct 100 → 100 (held), brand clean. ✅ kept.
- Addressed medium recommendation (area: *secondary objective Token Storage*) — the objective is listed/checked but never taught. Added a short paragraph in Chapter 3 covering httpOnly cookies vs localStorage, mobile keystores, and server secrets. tier-1 100 → 100 (held), brand clean. ✅ kept.

_Left (out of scope / low priority, no witnessed defect):_
- api-authentication: two `low` recs (base64url-padding caveat on the decode snippet; ≥32-byte secret to avoid PyJWT's InsecureKeyLengthWarning) — advisory polish, not learner-blocking; the snippets executed as documented.
- api-documentation: two `low` recs (make Chapter 1→2 file-continuity explicit; add a runnable contract-tests example for the bonus objective) — enhancements, not confirmed failures.
- Nothing reverted; no command regressed. No frontmatter changed, so no `_data/quests/**` regeneration was needed.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/29329246935)._
