### PR TITLE
🔧 Quest fix: security-specialist/1110

### DIFF
--- a/pages/_quests/1110/api-gateway-patterns.md
+++ b/pages/_quests/1110/api-gateway-patterns.md
@@ -137,6 +137,8 @@ This **🔴 Hard** quest expects:
 
 *The patterns are gateway-independent. The lab uses NGINX as a reverse proxy because it is everywhere; the same ideas apply to Kong, Traefik, Envoy, or a cloud gateway.*
 
+> **Before you run the container:** the `nginx.conf` you write in Chapter 2 proxies to `users` and `orders` upstreams, so NGINX exits immediately with `host not found in upstream` unless those services already exist on the same network. Start the whole lab — gateway plus two stub upstreams — with the Docker Compose file in **Chapter 2** rather than the bare `docker run` shown per-platform below (that standalone command only serves the default page until the upstreams are provisioned).
+
 ### 🍎 macOS Kingdom Path
 
 <details>
@@ -266,6 +268,37 @@ http {
 }
 ```
 
+### 🏗️ Provisioning the Upstreams
+
+The config above names `users` and `orders` upstreams by hostname, so those services must resolve on the same Docker network *before* NGINX will start — otherwise it crash-loops with `nginx: [emerg] host not found in upstream "users:8000"`. Bring the gateway and two trivial stub services up together with Docker Compose:
+
+```yaml
+# docker-compose.yml — the gateway plus two stub upstream services
+services:
+  users:
+    image: hashicorp/http-echo
+    command: ["-text=users service", "-listen=:8000"]
+  orders:
+    image: hashicorp/http-echo
+    command: ["-text=orders service", "-listen=:8000"]
+  gateway:
+    image: nginx:alpine
+    ports: ["8080:80"]
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on: [users, orders]
+```
+
+Put `docker-compose.yml` next to your `nginx.conf`, then start the whole lab with one command and watch the routes resolve:
+
+```bash
+docker compose up -d
+curl localhost:8080/users/     # -> users service
+curl localhost:8080/orders/    # -> orders service
+```
+
+Now the Novice Challenge's `curl localhost:8080/users/` is genuinely reachable.
+
 ### 🏗️ Authenticating at the Edge
 
 A common pattern: the gateway validates a JWT, then forwards the verified identity to the (now-simpler) services as a trusted header.
@@ -273,7 +306,8 @@ A common pattern: the gateway validates a JWT, then forwards the verified identi
 ```python
 # A tiny auth gateway in Python (FastAPI) — validate once, forward identity
 import jwt, httpx
-from fastapi import FastAPI, Request, HTTPException
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 
 app = FastAPI()
 SECRET, SERVICES = "change-me", {"users": "http://users:8000",
@@ -285,7 +319,10 @@ async def authenticate(request: Request, call_next):
     try:
         claims = jwt.decode(token, SECRET, algorithms=["HS256"])
     except jwt.PyJWTError:
-        raise HTTPException(status_code=401, detail="invalid token")
+        # Return the 401 directly. A raised HTTPException inside an
+        # @app.middleware("http") escapes FastAPI's exception handlers and
+        # surfaces as a 500 — so build the response here instead.
+        return JSONResponse({"detail": "invalid token"}, status_code=401)
     request.state.user_id = claims["sub"]   # services trust this, set only here
     return await call_next(request)
 ```

--- a/pages/_quests/1110/event-driven-design.md
+++ b/pages/_quests/1110/event-driven-design.md
@@ -237,6 +237,10 @@ consumer = KafkaConsumer(
     "user-events",
     bootstrap_servers="localhost:9092",
     group_id="welcome-emailer",                  # consumer groups enable scaling
+    auto_offset_reset="earliest",                # a brand-new group starts at the
+                                                 # log's beginning, so events published
+                                                 # before it connected still arrive
+    consumer_timeout_ms=10000,                   # stop blocking after 10s of silence
     value_deserializer=lambda b: json.loads(b.decode("utf-8")),
 )
 for message in consumer:
@@ -244,6 +248,8 @@ for message in consumer:
     if event["type"] == "UserRegistered":
         print(f"Sending welcome email to user {event['user_id']}")
 ```
+
+> **Heads-up:** without `auto_offset_reset="earliest"`, kafka-python defaults a fresh consumer group to `"latest"` — so if you run the producer *then* this consumer, the already-published event is skipped and the `for` loop blocks silently forever. The `consumer_timeout_ms` makes the loop exit cleanly once the backlog is drained; in production you would omit it and stop the long-running loop with Ctrl+C instead.
 
 ### 🔍 Knowledge Check: Events and Pub/Sub
 - [ ] Why is `UserRegistered` a better message than `SendWelcomeEmail`?
@@ -337,6 +343,21 @@ A non-idempotent consumer that "adds $100" on every delivery will double-credit 
 ### 🏗️ Designing for Stale Reads
 
 Because the read model lags, a user who places an order may not see it in their list for a few hundred milliseconds. Design around it: show an optimistic "processing" state, read-your-own-writes from the write side when freshness matters, and reserve strong consistency for the few operations that truly need it.
+
+### 🏗️ Ordering and Partitioning
+
+A broker guarantees order only *within a partition*, never across a whole topic. Kafka and Redpanda split a topic into partitions and hash each message's **key** to pick one — so every event sharing a key lands in the same partition and is delivered in the order it was produced. Events for *different* keys spread across partitions and may interleave.
+
+```python
+# Same key → same partition → per-entity ordering preserved
+producer.send("user-events", key=b"user-42",
+              value={"type": "EmailChanged",  "user_id": 42})
+producer.send("user-events", key=b"user-42",
+              value={"type": "EmailVerified", "user_id": 42})
+# Both user-42 events arrive in order; events for other users may interleave
+```
+
+Choose a key that matches the entity whose order matters (a `user_id`, an `order_id`). Send no key and events round-robin across partitions for maximum throughput — at the cost of any cross-event ordering guarantee.
 
 ### 🔍 Knowledge Check: Consistency
 - [ ] Why must an at-least-once consumer be idempotent?


### PR DESCRIPTION
## 🔧 Quest fix — `security-specialist/1110`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: security-specialist/1110

Honest-run gate passed: `mode==execute`, non-truncated, `errored==0`, every result
`executed==true`. Acted only on the two non-pass quests (`api-gateway-patterns` — fail;
`event-driven-design` — warn); the three `pass` quests were left untouched. Both edited
quests are first-party (no `source_repo`/`source_url`).

**Kept edits** (deterministic gate: tier-1 `score_pct` held-or-rose AND brand_lint clean):

- **pages/_quests/1110/api-gateway-patterns.md** — fixed the FastAPI auth middleware
  401-vs-500 bug (verified: `commands[].status=failed` — tokenless request returned HTTP
  500, not 401; high rec, area "Chapter 2 / auth middleware code"). The raised
  `HTTPException` inside `@app.middleware("http")` now returns a `JSONResponse(..., 401)`
  directly. tier-1 score_pct 100.0 → 100.0 (held), brand clean. ✅ kept.
- **pages/_quests/1110/api-gateway-patterns.md** — provisioned the `users`/`orders`
  upstreams so the lab starts (verified: `commands[].status=failed` — `docker run` +
  `nginx -t` crash-looped with `host not found in upstream "users:8000"`; high rec, area
  "Chapter 2 / lab setup"). Added a `docker-compose.yml` (gateway + two stub upstreams)
  plus a `docker compose up -d` / `curl` walkthrough in Chapter 2 and a pointer note in
  the platform section, making the Novice Challenge's `curl localhost:8080/users/`
  reachable. tier-1 score_pct 100.0 → 100.0 (held), brand clean. ✅ kept.
- **pages/_quests/1110/event-driven-design.md** — fixed the hanging consumer snippet
  (verified: `commands[].status=failed` — consumer hung forever with zero output, killed
  by `timeout` exit 124; high rec, area "Chapter 1 – Publish/Subscribe consumer snippet").
  Added `auto_offset_reset="earliest"` + `consumer_timeout_ms=10000` and a heads-up note
  explaining the default-`latest` offset trap and the Ctrl+C alternative. tier-1 score_pct
  100.0 → 100.0 (held), brand clean. ✅ kept.
- **pages/_quests/1110/event-driven-design.md** — added the missing "Ordering and
  Partitioning" content (verified high rec, area "Secondary Objective — Ordering and
  Partitioning": tracked learning objective with zero supporting content). Added a
  Chapter 3 subsection on per-partition ordering + message-key example. tier-1 score_pct
  100.0 → 100.0 (held), brand clean. ✅ kept.

_Left (out of small per-slice cap / lower priority, all first-party — no reverts, no
vendored skips):_ `api-gateway` medium recs for explicit `X-User-Id` downstream forwarding
and full Mastery-Challenge validation alignment (the compose + 401 fixes already restore
the failed-command paths); `event-driven` medium recs for a snapshot example and a
broker-level replay example; both quests' low recs (diagram static-inspection note;
kafka-python deserializer deprecation warning) are cosmetic. No frontmatter changed, so no
`_data/quests/**` regeneration was required.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/29329246935)._
