### PR TITLE
🔧 Quest fix: developer/1110

### DIFF
--- a/pages/_quests/1110/404-hunting.md
+++ b/pages/_quests/1110/404-hunting.md
@@ -140,6 +140,7 @@ plugins:
 
 Create an inviting `404.html`:
 
+{% raw %}
 ```html
 ---
 permalink: /404.html
@@ -148,19 +149,20 @@ permalink: /404.html
   <h1>🧭 Lost in the Linkwood</h1>
   <p>The path you sought fades into mist. Try these routes:</p>
   <ul>
-    <li><a href="{% raw %}{{ site.baseurl }}{% endraw %}/">Return to camp (home)</a></li>
-    <li><a href="{% raw %}{{ site.baseurl }}{% endraw %}/sitemap.xml">Consult the star map (sitemap)</a></li>
+    <li><a href="{{ site.baseurl }}/">Return to camp (home)</a></li>
+    <li><a href="{{ site.baseurl }}/sitemap.xml">Consult the star map (sitemap)</a></li>
   </ul>
   <h2>Recent beacons</h2>
   <ul>
-    {% raw %}{% for post in site.posts limit:5 %}{% endraw %}
-      <li><a href="{% raw %}{{ post.url | relative_url }}{% endraw %}">{% raw %}{{ post.title }}{% endraw %}</a></li>
-    {% raw %}{% endfor %}{% endraw %}
+    {% for post in site.posts limit:5 %}
+      <li><a href="{{ post.url | relative_url }}">{{ post.title }}</a></li>
+    {% endfor %}
   </ul>
-  <p>If this seems wrong, please <a href="https://github.com/{% raw %}{{ site.github.repository_nwo }}{% endraw %}/issues/new?title=404:%20{% raw %}{{ page.url }}{% endraw %}">open a scroll (issue)</a>.</p>
+  <p>If this seems wrong, please <a href="https://github.com/{{ site.github.repository_nwo }}/issues/new?title=404:%20{{ page.url }}">open a scroll (issue)</a>.</p>
   <style>.not-found{max-width:720px;margin:3rem auto;padding:0 1rem}</style>
 </main>
 ```
+{% endraw %}
 
 ### 🔍 Knowledge Check: Paths
 
@@ -221,6 +223,7 @@ permalink: /legacy-path/
 
 Lychee (quick, generous):
 
+{% raw %}
 ```yaml
 name: Hyperlink Guardian
 on:
@@ -244,8 +247,9 @@ jobs:
             --timeout 20
             **/*.md **/*.html
         env:
-          GITHUB_TOKEN: ${% raw %}{{ secrets.GITHUB_TOKEN }}{% endraw %}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
+{% endraw %}
 
 HTMLProofer (strict, post-build):
 
@@ -263,18 +267,19 @@ jobs:
           bundler-cache: true
       - name: Build Jekyll
         run: |
-          bundle install --path vendor/bundle
+          bundle config set --local path vendor/bundle
+          bundle install
           bundle exec jekyll build --trace
       - name: HTMLProofer
         run: |
-          gem install html-proofer
+          gem install html-proofer -v 5.2.1
           htmlproofer ./_site \
             --assume-extension \
             --check-external-hash \
             --enforce-https \
-            --typhoeus-config 'timeout:20' \
-            --url-ignore "^https://localhost,https://127.0.0.1" \
-            --http-status-ignore '0,429'
+            --typhoeus '{"timeout":20}' \
+            --ignore-urls "^https://localhost,https://127.0.0.1" \
+            --ignore-status-codes '0,429'
 ```
 
 ### 🔍 Knowledge Check: Guardians

--- a/pages/_quests/1110/domain-driven-design.md
+++ b/pages/_quests/1110/domain-driven-design.md
@@ -255,7 +255,7 @@ class Customer:                    # entity: identity persists through change
     def rename(self, new_name: str) -> None:
         self.name = new_name       # still the same customer afterwards
 
-print(Money(500, "USD") + Money(250, "USD"))   # Money(750, 'USD')
+print(Money(500, "USD") + Money(250, "USD"))   # Money(amount=750, currency='USD')
 ```
 
 ### 🏗️ Aggregates - The Consistency Boundary
@@ -295,6 +295,35 @@ class OrderRepository(ABC):        # domain-shaped persistence seam
     @abstractmethod
     def save(self, order: Order) -> None: ...
 ```
+
+### 🏗️ Domain Events - Capturing What Happened
+
+A **domain event** records a meaningful business occurrence as a first-class,
+immutable object — named in the past tense because it describes something that
+*already happened*. Aggregates raise events when they enforce an invariant, and
+other parts of the system (or other bounded contexts) react to them without the
+aggregate needing to know who is listening.
+
+```python
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+@dataclass(frozen=True)            # events are immutable facts about the past
+class OrderConfirmed:
+    order_id: str
+    confirmed_at: datetime
+
+# The aggregate root raises the event as part of enforcing its invariant.
+class Order:                       # (extends the aggregate root above)
+    def confirm(self) -> "OrderConfirmed":
+        if self.line_count == 0:
+            raise ValueError("Cannot confirm an empty order")
+        return OrderConfirmed(self.id, datetime.now(timezone.utc))
+```
+
+Domain events are the seam that lets you evolve toward event-driven design: the
+same `OrderConfirmed` fact can trigger an email, update a read model, or flow to
+another bounded context — each reacting independently.
 
 ### 🔍 Knowledge Check: Tactical Patterns
 - [ ] Is an `Address` usually an entity or a value object? Why?

--- a/pages/_quests/1110/self-operating-website-09-the-chronicle.md
+++ b/pages/_quests/1110/self-operating-website-09-the-chronicle.md
@@ -236,7 +236,10 @@ Now the curse. It is tempting to load the ledger with a YAML library, append a r
 ```ruby
 # THE CURSE — never do this to a file with a comment header:
 require "yaml"
-data = YAML.load_file("ledger.yml")     # comments are dropped here, invisibly
+require "time"  # needed for Time#iso8601
+# Psych 4 (default since Ruby 3.1) safe-loads: permit Time or the ledger's
+# bare ISO8601 timestamps raise Psych::DisallowedClass before you get here.
+data = YAML.load_file("ledger.yml", permitted_classes: [Time])  # comments are dropped here, invisibly
 data["sessions"] << { "ts" => Time.now.utc.iso8601, "cost_usd" => 0.12 }
 File.write("ledger.yml", data.to_yaml)  # writes valid YAML with NO header
 ```


### PR DESCRIPTION
## 🔧 Quest fix — `developer/1110`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: developer/1110

Evidence honest-run gate passed (M7): all 5 results `mode==execute`, `executed==true`,
run non-truncated, 0 errored. Acted on the 3 non-pass quests only (1 fail, 2 warn);
the 2 `pass` quests were left untouched. No frontmatter changed, so no `_data/quests`
regeneration was required.

**Kept edits (deterministic gate: tier-1 held/rose AND brand_lint clean):**

- **pages/_quests/1110/404-hunting.md** — fixed the `404.html` snippet that built broken
  (failed command; high rec "404.html snippet Ch.1"): replaced the per-expression
  `{% raw %}`/`{% endraw %}` wrappers with a single raw block around the whole fence, so
  the copyable content is plain `{{ site.baseurl }}` / `{% for post ... %}` etc. tier-1
  score 68/74 (91.9%) → 68/74 (91.9%) held, brand clean. ✅ kept.
- **pages/_quests/1110/404-hunting.md** — fixed `GITHUB_TOKEN` in the lychee workflow
  (failed command; high rec "Lychee workflow Ch.3"): the leaked raw-tag markup
  `${% raw %}{{ secrets.GITHUB_TOKEN }}{% endraw %}` is now plain
  `${{ secrets.GITHUB_TOKEN }}` inside a single raw-wrapped fence. tier-1 68/74 held,
  brand clean. ✅ kept.
- **pages/_quests/1110/404-hunting.md** — fixed the HTMLProofer workflow (failed command;
  high recs "HTMLProofer workflow" + "HTMLProofer CLI flags"): `bundle install --path
  vendor/bundle` (removed flag, exit 15) → `bundle config set --local path vendor/bundle
  && bundle install`; updated html-proofer 5.x flags `--typhoeus-config 'timeout:20'` →
  `--typhoeus '{"timeout":20}'`, `--url-ignore` → `--ignore-urls`, `--http-status-ignore`
  → `--ignore-status-codes`; pinned `gem install html-proofer -v 5.2.1`. tier-1 68/74
  held, brand clean. ✅ kept.
- **pages/_quests/1110/self-operating-website-09-the-chronicle.md** — fixed the Ruby
  "THE CURSE" snippet (failed command; high rec "Ch.2 Ruby snippet"): added `require
  "time"` (for `Time#iso8601`) and `YAML.load_file(path, permitted_classes: [Time])` so
  Psych 4's safe-load (default since Ruby 3.1) no longer throws `Psych::DisallowedClass`
  before the learner reaches the comment-loss lesson. tier-1 70/74 (94.6%) → 70/74
  (94.6%) held, brand clean. ✅ kept.
- **pages/_quests/1110/domain-driven-design.md** — added a Domain Events subsection
  (high rec "Completeness / Chapter coverage"): a short explanation + an `OrderConfirmed`
  event dataclass and an `Order.confirm()` raiser, since Domain Events was a Secondary
  Objective and in the completion checklist but never explained. tier-1 74/74 (100%) →
  74/74 (100%) held, brand clean. ✅ kept.
- **pages/_quests/1110/domain-driven-design.md** — fixed the misleading output comment on
  the Money snippet (low rec "Ch.2 Money snippet output"): `# Money(750, 'USD')` →
  `# Money(amount=750, currency='USD')` to match the actual `@dataclass` repr. tier-1
  74/74 held, brand clean. ✅ kept.

_Left (out of scope for this pass / kept PR small & focused on witnessed failures):_
404-hunting — medium rec (redirect-loop before/after example) and low recs (centralized
`_data/redirects.yml` map, mermaid QA note) left for a focused authoring pass.
chronicle — medium rec (empty-stdin guard in `chronicle.sh`) and low recs (run-from-root
note, mermaid) left. domain-driven-design — low recs (illustrative-naming note on the
Ch.1 vocabulary snippet, `InMemoryOrderRepository` concrete impl) left. No vendored quest
was encountered; the 2 `pass` quests (design-patterns, microservices-architecture) had no
in-scope verified issues.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/29412020762)._
