### PR TITLE
🔧 Quest fix: system-engineer/0101

### DIFF
--- a/pages/_quests/0101/docker-mastery-example.md
+++ b/pages/_quests/0101/docker-mastery-example.md
@@ -169,15 +169,31 @@ Follow these step-by-step instructions to build your foundation:
 3. **First Implementation** - Create your first working example using hands-on techniques
 4. **Validation** - Verify your setup and understanding through practical exercises
 
-```docker
-# Docker example code will go here
-# This example demonstrates fundamental concepts
-# Expected output: [Describe what users should see]
+Create a file named `Dockerfile` (no extension) with the minimal, runnable image below.
+Every Dockerfile needs at least a `FROM` base image and an instruction to run:
 
-# Step-by-step implementation
-# 1. [First step explanation]
-# 2. [Second step explanation]
-# 3. [Third step explanation]
+```dockerfile
+# Dockerfile — a minimal, runnable image
+FROM alpine:3.20
+
+# Print a greeting when a container starts from this image
+CMD ["echo", "Hello from your first Docker container!"]
+```
+
+Build the image and run a container from it, in the same folder as the `Dockerfile`:
+
+```bash
+# Build an image tagged "my-first-image" from the current directory (.)
+docker build -t my-first-image .
+
+# Run a throwaway container from that image
+docker run --rm my-first-image
+```
+
+Expected output from the `docker run` command:
+
+```text
+Hello from your first Docker container!
 ```
 
 ### 🔍 Knowledge Check: Docker Fundamentals

--- a/pages/_quests/0101/the-lazytex-of-building-a-curriculum-vitae.md
+++ b/pages/_quests/0101/the-lazytex-of-building-a-curriculum-vitae.md
@@ -193,6 +193,7 @@ starter below as `cv/cv.tex`. It is self‑contained—it uses only base TeX Liv
 and defines the custom commands (`\resumeSubheading`, `\resumeItem`, and the list helpers)
 that you will use in Chapter 3, so it compiles cleanly with a stock LaTeX install.
 
+{% raw %}
 ```latex
 \documentclass[letterpaper,11pt]{article}
 
@@ -249,6 +250,7 @@ that you will use in Chapter 3, so it compiles cleanly with a stock LaTeX instal
 
 \end{document}
 ```
+{% endraw %}
 
 Once saved, compile it from a terminal in the `cv/` folder to confirm the toolchain works:
 

--- a/pages/_quests/0101/the-lazytex-of-building-a-curriculum-vitae.md
+++ b/pages/_quests/0101/the-lazytex-of-building-a-curriculum-vitae.md
@@ -171,6 +171,9 @@ This quest focuses on local VS Code mastery.
 
 ### 🔧 Implementation: Verify the Forge
 
+Don't have `cv.tex` yet? Create it first from the self‑contained starter in
+[Chapter 2](#-chapter-2-summon-the-template-create-cvtex), then return here.
+
 Open VS Code → open the `cv/` folder → open `cv.tex`. Use the TeX sidebar (TeX icon) and run
 “Build LaTeX project”. If the build fails with missing packages, install them via your TeX package
 manager (`tlmgr` on macOS BasicTeX/TeX Live, MiKTeX on Windows).
@@ -183,14 +186,84 @@ latexmk -pdf cv.tex
 
 ---
 
-## 🧙‍♂️ Chapter 2: Summon the Template (Link to cv.tex)
+## 🧙‍♂️ Chapter 2: Summon the Template (Create cv.tex)
 
-Your core artifact lives at: `cv/cv.tex`. It already includes:
+Your core artifact is `cv.tex`. Create it now: make a `cv/` folder, then save the
+starter below as `cv/cv.tex`. It is self‑contained—it uses only base TeX Live packages
+and defines the custom commands (`\resumeSubheading`, `\resumeItem`, and the list helpers)
+that you will use in Chapter 3, so it compiles cleanly with a stock LaTeX install.
 
-- Packages: `fontawesome5`, `CormorantGaramond`, `hyperref`, `multicol`, `titlesec`, `tabularx`,
-  `graphicx`, and ATS aid `\\pdfgentounicode=1`
-- Custom commands: `\\resumeSubheading`, `\\resumeItem`, lists, and section scaffolds
-- Optional headshot: `\\includegraphics[width=0.15\\linewidth]{Amr-Headshot_v3.jpg}`
+```latex
+\documentclass[letterpaper,11pt]{article}
+
+\usepackage[margin=1in]{geometry}
+\usepackage{enumitem}
+\usepackage{titlesec}
+\usepackage[hidelinks]{hyperref}
+
+% ATS aid: map glyphs to Unicode so PDF text stays selectable and searchable
+\pdfgentounicode=1
+
+% --- Custom commands used throughout this CV ---------------------------------
+\titleformat{\section}{\large\bfseries}{}{0em}{}[\titlerule]
+
+\newcommand{\resumeSubheading}[4]{%
+  \vspace{2pt}\noindent
+  \textbf{#1}\hfill\textit{#2}\\
+  \textit{#3}\hfill\textit{#4}\par
+}
+
+\newlist{resumeItems}{itemize}{1}
+\setlist[resumeItems]{leftmargin=1.5em,label=\textbullet,topsep=2pt}
+\newcommand{\resumeItem}[1]{\item #1}
+\newcommand{\resumeItemListStart}{\begin{resumeItems}}
+\newcommand{\resumeItemListEnd}{\end{resumeItems}}
+
+\begin{document}
+
+\begin{center}
+  {\LARGE\textbf{Your Name}}\\[2pt]
+  \href{mailto:you@example.com}{you@example.com} \textbar{}
+  \href{https://www.linkedin.com/in/yourhandle}{LinkedIn} \textbar{}
+  \href{https://github.com/yourhandle}{GitHub}
+\end{center}
+
+\section{Education}
+\resumeSubheading{Your Institution}{2019 -- 2023}{B.S. in Your Field}{City, ST}
+\resumeItemListStart
+  \resumeItem{GPA, honors, or relevant coursework}
+\resumeItemListEnd
+
+\section{Professional Experience}
+\resumeSubheading{Your Company}{Jan 2023 -- Present}{Your Title}{City, ST}
+\resumeItemListStart
+  \resumeItem{Delivered X by doing Y, resulting in Z\% improvement}
+  \resumeItem{Built A using B and C; reduced cost or time by N}
+\resumeItemListEnd
+
+\section{Skills}
+\resumeItemListStart
+  \resumeItem{Languages: \ldots}
+  \resumeItem{Tools: \ldots}
+\resumeItemListEnd
+
+\end{document}
+```
+
+Once saved, compile it from a terminal in the `cv/` folder to confirm the toolchain works:
+
+```bash
+cd cv
+latexmk -pdf cv.tex
+```
+
+This produces `cv.pdf`. With the artifact in place, return to Chapter 1's build step—the
+VS Code "Build LaTeX project" button runs the same `latexmk -pdf` recipe on this file.
+
+> **Optional upgrades:** once the base template compiles, you can add richer packages such
+> as `fontawesome5` (icons), `CormorantGaramond` (typeface), `multicol`, or a headshot via
+> `\includegraphics[width=0.15\linewidth]{headshot.jpg}`. Install any missing package with
+> your TeX manager (e.g., `tlmgr install fontawesome5 cormorantgaramond`) before using it.
 
 ### 🔧 Implementation: Prepare Assets
 
@@ -206,12 +279,12 @@ Use the template’s custom commands to populate your story.
 
 ### Education
 
-Fill each school with `\\resumeSubheading{Institution}{Dates}{Degree}{Location}` and a nested bullet list for GPA/Emphasis.
+Fill each school with `\resumeSubheading{Institution}{Dates}{Degree}{Location}` and a nested bullet list for GPA/Emphasis.
 
 ### Professional Experience
 
-For each role, use `\\resumeSubheading{Company}{Dates}{Title}{Location}` and add quantified bullets
-with `\\resumeItem{...}`. Keep 3–5 bullets per role.
+For each role, use `\resumeSubheading{Company}{Dates}{Title}{Location}` and add quantified bullets
+with `\resumeItem{...}`. Keep 3–5 bullets per role.
 
 ### Projects / Skills / Strengths
 
@@ -220,14 +293,14 @@ Populate as provided in the template. Add new items using the same list patterns
 Example snippet (structure only):
 
 ```tex
-\\resumeSubheading{Your Company}{Jan 2023 -- Present}{Your Title}{City, ST}
-  \\resumeItemListStart
-    \\resumeItem{Delivered X by doing Y, resulting in Z% improvement}
-    \\resumeItem{Built A using B and C; reduced cost/time by N}
-  \\resumeItemListEnd
+\resumeSubheading{Your Company}{Jan 2023 -- Present}{Your Title}{City, ST}
+  \resumeItemListStart
+    \resumeItem{Delivered X by doing Y, resulting in Z% improvement}
+    \resumeItem{Built A using B and C; reduced cost/time by N}
+  \resumeItemListEnd
 ```
 
-ATS Tip: Keep graphics minimal, keep text selectable, and ensure links use `\\href{}`. The
+ATS Tip: Keep graphics minimal, keep text selectable, and ensure links use `\href{}`. The
 template already activates Unicode mapping.
 
 ---
@@ -390,7 +463,7 @@ graph TD
 Before you depart, ensure you can:
 
 - Explain how `latexmk` drives the build and where the PDF is produced
-- Add a new role using `\\resumeSubheading` and `\\resumeItem`
+- Add a new role using `\resumeSubheading` and `\resumeItem`
 - Fix a missing package by installing it via your TeX distribution
 
 ---


### PR DESCRIPTION
## 🔧 Quest fix — `system-engineer/0101`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: system-engineer/0101

Evidence: execute-mode, non-truncated, all results `executed==true` (M7 gate passed).
Acted only on the two non-pass quests (`fail`); the 3 `pass`-verdict quests were left
untouched even where they carried a failed command (out of scope per fix-lane rules).
No frontmatter changed, so no `_data/quests/**` regeneration was needed.

**pages/_quests/0101/the-lazytex-of-building-a-curriculum-vitae.md** (verdict: fail)

- Fixed the pervasive **doubled-backslash** LaTeX typo (`\\resumeSubheading`,
  `\\resumeItem`, `\\resumeItemListStart/End`, `\\href`, `\\includegraphics`,
  `\\linewidth`, `\\pdfgentounicode`) → single backslash throughout.
  _Verified:_ `commands[].status=failed` (Chapter 3 tex example doubled-backslash) +
  high recommendation "LaTeX code examples throughout". tier-1 score_pct **91.9 → 91.9**
  (held), brand clean. ✅ kept.
- Provided the missing **`cv.tex` artifact**: embedded a self-contained, compilable
  minimal starter (base TeX Live packages only; defines the `\resumeSubheading` /
  `\resumeItem` / list custom commands used later) plus the `latexmk -pdf cv.tex`
  build commands. No `cv.tex` exists anywhere in the repo, so embedding is the honest
  fix rather than a dead link. _Verified:_ `commands[].status=failed` (`latexmk -pdf
  cv.tex` → file not found / exit 127) + high recommendation "Chapter 2 — provide the
  actual cv.tex starter". tier-1 score_pct **91.9 → 91.9** (held), brand clean. ✅ kept.
- Added a one-line Chapter 1 forward pointer to create `cv.tex` from the Chapter 2
  starter before building. _Verified:_ medium recommendation "Chapter 1 — add a fallback
  path for learners who don't already have cv/cv.tex". tier-1 score_pct **91.9 → 91.9**
  (held), brand clean. ✅ kept.

**pages/_quests/0101/docker-mastery-example.md** (verdict: fail)

- Replaced the Chapter 1 placeholder `docker` code block (comment-only, which
  `docker build` rejected as "file with no instructions") with a **real minimal
  Dockerfile** (`FROM alpine:3.20` + `CMD`), the `docker build`/`docker run` commands,
  and the actual expected output. _Verified:_ `commands[].status=failed` (docker block
  builds with no instructions) + high recommendation "Chapter 1 docker code block —
  replace placeholder comments with an actual minimal Dockerfile + real build/run".
  tier-1 score_pct **95.9 → 95.9** (held), brand clean. ✅ kept.

_Left (not fixed this pass):_

- **docker** — the remaining high/medium/low recommendations (whole document is an
  unpopulated template: author full tutorial prose, add a Docker Compose section, a
  cloud-deployment walkthrough, and real Additional-Resources URLs) are large authoring
  jobs beyond a smallest-edit pass; left for a follow-up so this PR stays small and
  reviewable. Not reverted — never attempted.
- **lazytex** — medium rec (verify the exact CTAN/tlmgr name for Cormorant Garamond)
  and low rec (flag `texlive-full` download size) are non-blocking polish; largely
  mitigated because the new starter no longer requires that package. Left out of scope.
- **3 pass-verdict quests** (`cicd-fundamentals`, `github-actions-basics`,
  `ouroboros-loop-02-the-wardens-gate`) each recorded a failed command but hold a
  `pass` verdict → out of scope (fix-lane acts only on `warn`/`fail` quests).

No vendored quests were present in this slice. No git run.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/29412020762)._
