### PR TITLE
🔧 Quest fix: security-specialist/1011

### DIFF
--- a/pages/_quests/1011/agentic-behavior-tuning.md
+++ b/pages/_quests/1011/agentic-behavior-tuning.md
@@ -97,6 +97,12 @@ Before tuning, you need a benchmark. Run three representative tasks and record o
 
 > **Exercise 13.1:** Create the baseline measurement script.
 
+**Prerequisites** (the script reads real workflow history, so it needs a repo with agent activity):
+>
+> - `gh auth login` completed, or `GH_TOKEN` exported, so the GitHub CLI is authenticated
+> - an `agent-task.yml` workflow already committed to the repo
+> - at least one prior agent run/PR for tasks 1–3 to measure
+
 ```bash
 # work/gh-600/scripts/measure_agent_baseline.sh
 #!/usr/bin/env bash
@@ -117,8 +123,12 @@ echo "=== Agent Behaviour Baseline Measurement ==="
 for TASK_NUM in 1 2 3; do
     echo "Measuring task $TASK_NUM..."
     
-    # Get the latest agent run for this task
-    RUN_ID=$(gh run list --workflow=agent-task.yml --limit=1 --json databaseId -q '.[0].databaseId')
+    # Get the latest agent run for this task (degrade gracefully if none exists yet)
+    RUN_ID=$(gh run list --workflow=agent-task.yml --limit=1 --json databaseId -q '.[0].databaseId' 2>/dev/null || true)
+    if [ -z "$RUN_ID" ]; then
+        echo "⚠️  No agent-task.yml run found for task $TASK_NUM — run the agent workflow at least once, then re-run this script."
+        continue
+    fi
     
     PR_OPENED=$(gh pr list --state all --search "is:pr in:title issue-$TASK_NUM" --json number -q 'length')
     TESTS_PASSED=$(gh run view "$RUN_ID" --json conclusion -q '.conclusion')
@@ -213,12 +223,17 @@ Format: Date | File | Change | Reason | Outcome
 
 ## ✅ Quest Validation
 
+Run this manual self-check from your repo root — it verifies your Q13 deliverables directly, so you don't need any external validator script:
+
 ```bash
-python3 scripts/validate_quest.py --quest q13
-# ✅ Baseline measurement: baseline-results.jsonl present
-# ✅ Iteration log: iteration records in docs/agent-instructions/
-# ✅ Instruction changelog: CHANGELOG.md present
-# 🏆 Quest Q13 complete!
+# Manual self-check — confirm your Q13 deliverables exist
+test -f work/gh-600/baseline-results.jsonl \
+  && echo "✅ Baseline measurement: baseline-results.jsonl present"
+ls docs/agent-instructions/*.md >/dev/null 2>&1 \
+  && echo "✅ Iteration log: iteration records in docs/agent-instructions/"
+test -f docs/agent-instructions/CHANGELOG.md \
+  && echo "✅ Instruction changelog: CHANGELOG.md present"
+# 🏆 Quest Q13 complete when all three checks print ✅
 ```
 
 ## 🏆 Quest Rewards

--- a/pages/_quests/1011/agentic-codex-05-multi-agent-coordination.md
+++ b/pages/_quests/1011/agentic-codex-05-multi-agent-coordination.md
@@ -205,10 +205,10 @@ On GitHub Actions the correlation ID is born in the orchestrator and travels as 
     steps:
       - name: Run agent and emit a traced log line
         run: |
-          echo "{\"cid\":\"$CORRELATION_ID\",\"agent\":\"backend\",\"event\":\"start\"}" \
+          echo "{\"ts\":\"$(date -u +%s.%N)\",\"cid\":\"$CORRELATION_ID\",\"agent\":\"backend\",\"event\":\"start\"}" \
             | tee -a "trace-$CORRELATION_ID.jsonl"
           # ... agent work ...
-          echo "{\"cid\":\"$CORRELATION_ID\",\"agent\":\"backend\",\"event\":\"done\"}" \
+          echo "{\"ts\":\"$(date -u +%s.%N)\",\"cid\":\"$CORRELATION_ID\",\"agent\":\"backend\",\"event\":\"done\"}" \
             | tee -a "trace-$CORRELATION_ID.jsonl"
       - name: Write to the run summary
         run: echo "### backend agent — run \`$CORRELATION_ID\`" >> "$GITHUB_STEP_SUMMARY"
@@ -219,7 +219,7 @@ On GitHub Actions the correlation ID is born in the orchestrator and travels as 
 ```
 {% endraw %}
 
-Because every agent stamps the same `cid`, the `collect` job can download all the trace artifacts, concatenate them, and sort by event order to produce one human-readable narrative of the whole council's work: who started, what each handed off, where the chain broke. That artifact is the **audit record** — Domain 5 explicitly asks you to "document key decisions, handoffs, and outcomes across agents" and to enable "post-hoc analysis." A correlation-ID trace is how you satisfy both. The exam's classic stem — *"a trace excerpt is shown; which agent introduced the fault?"* — is answerable only because the trace is unified; without the shared ID you can name the agent that *crashed* but never the one that *caused* it.
+Because every agent stamps the same `cid` **and a monotonic `ts` timestamp**, the `collect` job can download all the trace artifacts, concatenate them, and sort by `ts` to reconstruct true chronological order — producing one human-readable narrative of the whole council's work: who started, what each handed off, where the chain broke. (Sorting by `event` name alone would sort alphabetically — `done` before `start` — and scramble the timeline, which is why an explicit ordering field is required.) That artifact is the **audit record** — Domain 5 explicitly asks you to "document key decisions, handoffs, and outcomes across agents" and to enable "post-hoc analysis." A correlation-ID trace is how you satisfy both. The exam's classic stem — *"a trace excerpt is shown; which agent introduced the fault?"* — is answerable only because the trace is unified; without the shared ID you can name the agent that *crashed* but never the one that *caused* it.
 
 You can collapse all three agents' artifacts in the orchestrator with the Models API or a small script, but the primitive is the same: shared ID in, unified trace out.
 
@@ -227,7 +227,7 @@ You can collapse all three agents' artifacts in the orchestrator with the Models
 # collect step — stitch every agent's trace into one ordered narrative
 cid="$1"                                  # the run's correlation ID
 cat trace-*-"$cid"/*.jsonl 2>/dev/null \
-  | jq -s 'sort_by(.event) | .[] | "\(.cid) \(.agent) \(.event)"' -r \
+  | jq -s 'sort_by(.ts) | .[] | "\(.ts) \(.agent) \(.event)"' -r \
   > "council-trace-$cid.md"
 echo "Wrote council-trace-$cid.md"
 ```

--- a/pages/_quests/1011/agentic-multi-agent-observability.md
+++ b/pages/_quests/1011/agentic-multi-agent-observability.md
@@ -130,12 +130,12 @@ jobs:
           python3 work/gh-600/scripts/traced_subtask.py \
             --correlation-id "$CORRELATION_ID" \
             --subtask "analysis" \
-            --output "trace-analysis-$CORRELATION_ID.json"
+            --output "trace-analysis-$CORRELATION_ID.jsonl"
 
       - uses: actions/upload-artifact@v4
         with:
           name: trace-${% raw %}{{ env.CORRELATION_ID }}{% endraw %}-analysis
-          path: "trace-analysis-${% raw %}{{ env.CORRELATION_ID }}{% endraw %}.json"
+          path: "trace-analysis-${% raw %}{{ env.CORRELATION_ID }}{% endraw %}.jsonl"
 ```
 
 ---

--- a/pages/_quests/1011/agentic-multi-agent-orchestration-patterns.md
+++ b/pages/_quests/1011/agentic-multi-agent-orchestration-patterns.md
@@ -263,10 +263,9 @@ jobs:
 
 ### Chapter 4 — Sub-Agent Contracts
 
-Every sub-agent in a multi-agent system needs a well-defined contract — standard inputs and outputs:
+Every sub-agent in a multi-agent system needs a well-defined contract — standard inputs and outputs. Save this as `work/gh-600/schemas/sub-agent-contract.json` (plain `.json` files can't contain `//` comments, so the path lives here in prose rather than inside the block):
 
 ```json
-// work/gh-600/schemas/sub-agent-contract.json
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "SubAgentContract",
@@ -305,12 +304,18 @@ Every sub-agent in a multi-agent system needs a well-defined contract — standa
 
 ## ✅ Quest Validation
 
+Run this manual self-check from your repo root — it verifies your Q14 deliverables directly, so you don't need any external validator script:
+
 ```bash
-python3 scripts/validate_quest.py --quest q14
-# ✅ Fan-out workflow: orchestrator-fan-out.yml present
-# ✅ Chain workflow: orchestrator-chain.yml present
-# ✅ Sub-agent contract: sub-agent-contract.json present
-# 🏆 Quest Q14 complete!
+# Manual self-check — confirm your Q14 deliverables exist
+test -f .github/workflows/orchestrator-fan-out.yml \
+  && echo "✅ Fan-out workflow: orchestrator-fan-out.yml present"
+test -f .github/workflows/orchestrator-chain.yml \
+  && echo "✅ Chain workflow: orchestrator-chain.yml present"
+test -f work/gh-600/schemas/sub-agent-contract.json \
+  && python3 -m json.tool work/gh-600/schemas/sub-agent-contract.json >/dev/null \
+  && echo "✅ Sub-agent contract: sub-agent-contract.json present and valid JSON"
+# 🏆 Quest Q14 complete when all three checks print ✅
 ```
 
 ## 🏆 Quest Rewards


### PR DESCRIPTION
## 🔧 Quest fix — `security-specialist/1011`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: security-specialist/1011

Evidence gate ✅ — `walk-evidence.json` is execute-mode, non-mock, non-truncated, `errored=0`, every result `executed==true` (M7 satisfied). No vendored quests in the slice (no `source_repo:`/`source_url:`). Acted only on `warn`/`fail` quests; all before→after numbers read straight from `quest_validator.py`.

**Kept edits (deterministic gate: tier-1 score held-or-rose AND brand_lint clean/unchanged):**

- **pages/_quests/1011/agentic-behavior-tuning.md** — fixed failed command
  `python3 scripts/validate_quest.py --quest q13` (verified: commands[].status=failed, "No such file"; high rec "Quest Validation"). Replaced the non-existent validator with a runnable manual self-check that tests the actual Q13 deliverables. tier-1 score_pct 78.4 → 78.4 (held). ✅ kept.
- **pages/_quests/1011/agentic-behavior-tuning.md** — fixed failed command
  `measure_agent_baseline.sh` (verified: commands[].status=failed, `gh` unauthenticated aborts via `set -e`; high rec "Exercise 13.1 baseline script"). Added explicit prerequisites (`gh auth login`, existing `agent-task.yml`, prior runs) and error handling (`|| true` + empty-`RUN_ID` guard with `continue`) so it degrades gracefully. tier-1 score_pct 78.4 → 78.4 (held). ✅ kept.
- **pages/_quests/1011/agentic-multi-agent-orchestration-patterns.md** — fixed failed command
  `json: sub-agent-contract.json` (verified: commands[].status=failed, `json.load` "Expecting value" from a leading `//` comment; medium rec "Chapter 4 JSON block"). Moved the file-path hint into prose above the fence; block now parses (`json.loads` OK). tier-1 score_pct 78.4 → 78.4 (held). ✅ kept.
- **pages/_quests/1011/agentic-multi-agent-orchestration-patterns.md** — fixed failed command
  `python3 scripts/validate_quest.py --quest q14` (verified: commands[].status=failed; high rec "Quest Validation section"). Replaced with a runnable manual self-check of the Q14 deliverables (incl. `json.tool` validity check). tier-1 score_pct 78.4 → 78.4 (held). ✅ kept.
- **pages/_quests/1011/agentic-codex-05-multi-agent-coordination.md** — fixed failed command
  Chapter 2 collect-step (verified: commands[].status=failed; `sort_by(.event)` sorts alphabetically, `done` before `start`; high rec "Chapter 2 collect-step bash snippet"). Added a monotonic `ts` field to the emitted trace lines and switched the collect `jq` to `sort_by(.ts)`, matching the Hands-On Lab's `seq` approach. tier-1 score_pct 95.9 → 95.9 (held). ✅ kept.
- **pages/_quests/1011/agentic-multi-agent-observability.md** — fixed failed command
  aggregator glob vs Chapter 1 output (verified: commands[].status=failed; aggregator `rglob("*.jsonl")` found 0 files against the workflow's `.json` output; high rec "Chapter 1 / Chapter 3 integration"). Aligned the Chapter 1 workflow `--output`/artifact path to `.jsonl` (the file is line-delimited JSONL everywhere else), so the pipeline connects. tier-1 score_pct 78.4 → 78.4 (held). ✅ kept.

_No frontmatter was touched, so no `_data/quests/**` regeneration is required._

**Left (out of scope or too substantive for a smallest-edit fix):**

- **security-fundamentals.md** — verdict `pass`; its one failed command is out of scope (only `warn`/`fail` quests are eligible). Skipped.
- **Leaked `{% raw %}`/`{% endraw %}` inside `${{ }}` YAML** (orchestration-patterns Ch.2/Ch.3, observability Ch.1) — left deliberately. The `${% raw %}{{ … }}{% endraw %}` pattern renders on the published page to the correct `${{ … }}`; the engine's `yaml.safe_load` ran on the raw markdown source, not the rendered page a learner copies from. Rewriting every occurrence is high-churn with no learner-facing benefit and risks the deterministic gate — flagged for human review.
- **Missing referenced scripts** (`partition_task.py`, `run_subtask.py`, `aggregate_results.py`, `traced_subtask.py`; high recs) — left; authoring full implementations/scaffolds is a substantive task beyond a single smallest-edit failed-command fix.
- **Remaining medium/low recommendations** (event-driven pattern chapter, `permissions: issues: write`, missing `download-artifact` step, GH-600 exam-ID verification, iteration-log path comment, objectives 2 & 4 exercises, canonical `copilot-instructions.md` path, mastery-challenge/validation-script checks) — left as substantive authoring or external-verification work, not evidence-grounded failed commands.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/29412020762)._
