### PR TITLE
chore(theme): always track latest zer0-mistakes (unpin remote_theme)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,10 @@ source "https://rubygems.org"
 # Github Pages Gems - Use latest compatible version:
 gem 'github-pages'
 
-# Jekyll Theme — served via the pinned `remote_theme` in _config.yml (works with
-# the legacy GitHub Pages gh-pages build). jekyll-remote-theme ships with the
-# github-pages gem, so no theme gem is needed here.
+# Jekyll Theme — served via the unpinned `remote_theme` in _config.yml, which
+# always tracks the latest zer0-mistakes main (works with the legacy GitHub Pages
+# gh-pages build). jekyll-remote-theme ships with the github-pages gem, so no
+# theme gem is needed here.
 
 # If you have plugins enabled in the _config.yml, add them here too:
 group :jekyll_plugins do

--- a/_config.yml
+++ b/_config.yml
@@ -27,11 +27,13 @@
 # Site Settings ###################################################################
 
 founder                  : "Amr Abdel-Motaleb"
-# Theme: pinned `remote_theme` ref. Production deploys via legacy GitHub Pages
-# building Jekyll from the gh-pages branch, which can't use a gem theme (it never
-# runs `bundle install`) — so the theme is sourced and version-pinned here.
-# Bump the tag to upgrade; CI/dev use the same ref (see _config_dev.yml).
-remote_theme             : "bamr87/zer0-mistakes@v1.21.0"
+# Theme: unpinned `remote_theme` ref — always tracks the latest zer0-mistakes
+# default-branch (main) commit, so every build picks up upstream theme changes
+# automatically. Production deploys via legacy GitHub Pages building Jekyll from
+# the gh-pages branch, which can't use a gem theme (it never runs `bundle
+# install`) — so the theme is sourced here; CI/dev use the same ref (see
+# _config_dev.yml). To freeze a version, append a tag: `bamr87/zer0-mistakes@vX.Y.Z`.
+remote_theme             : "bamr87/zer0-mistakes"
 
 ## Github Information
 github_user              : &github_user "bamr87"

--- a/_config_ci.yml
+++ b/_config_ci.yml
@@ -1,6 +1,6 @@
 # CI smoke-build override — fast PR validation (skips the preview-image scan).
-# The theme is fetched via the pinned remote_theme in _config.yml, same as the
-# production gh-pages build.
+# The theme is fetched via the unpinned remote_theme in _config.yml (latest
+# main), same as the production gh-pages build.
 # Usage: bundle exec jekyll build --config _config.yml,_config_dev.yml,_config_ci.yml
 
 preview_images:

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,8 +1,9 @@
 # Dev config override — merged after _config.yml:
 #   bundle exec jekyll serve --config _config.yml,_config_dev.yml
 #
-# Theme: inherited from _config.yml (pinned remote_theme). jekyll-remote-theme
-# is in this file's plugins list below so the remote_theme loads in dev/CI too.
+# Theme: inherited from _config.yml (unpinned remote_theme — latest main).
+# jekyll-remote-theme is in this file's plugins list below so the remote_theme
+# loads in dev/CI too.
 
 # Allow future-dated posts to be rendered in development
 future: true


### PR DESCRIPTION
## What

Unpins the zer0-mistakes remote theme so the site **always builds against the latest theme `main`** instead of a frozen release tag.

`remote_theme` is resolved in one place — `_config.yml` — and dev/CI/prod all inherit it:

```diff
- remote_theme: "bamr87/zer0-mistakes@v1.21.0"
+ remote_theme: "bamr87/zer0-mistakes"
```

Rationale comments in `_config.yml`, `_config_dev.yml`, `_config_ci.yml`, and `Gemfile` are updated to match (each notes how to re-freeze via `@vX.Y.Z`).

## Why

The pin sat at **v1.21.0** while upstream had shipped through **v1.26.0** (+6 unreleased commits on `main`). This makes the site track the latest theme automatically — no more manual bumps.

## Trade-off (intentional)

- Builds are **no longer reproducible** — a given commit's rendering depends on theme `main` at build time.
- **Unreviewed** upstream theme changes ship straight to production.
- Fast rollback if `main` ever breaks the site: re-append a tag, e.g. `remote_theme: "bamr87/zer0-mistakes@v1.26.0"`.

## Validation

- `bamr87/zer0-mistakes` `main` is a well-formed Jekyll theme (`_layouts`, `_includes`, `_sass`, `assets`, gemspec present) and is **6 commits ahead of v1.26.0, 0 behind** — the moving ref resolves to real, current theme code.
- Full `bundle exec jekyll build` was not run locally (Docker unavailable in the authoring env); **`build-validation.yml` exercises the real build against the unpinned theme on this PR.**
- No content changed — config/comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)