### PR TITLE
fix(deps): add darwin & windows platforms to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,9 @@ GEM
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
     ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x64-mingw-ucrt)
+    ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     ffi (1.17.4-x86_64-linux-musl)
     forwardable-extended (2.6.0)
@@ -242,6 +245,12 @@ GEM
       uri (>= 0.11.1)
     nokogiri (1.19.3-aarch64-linux-gnu)
       racc (~> 1.4)
+    nokogiri (1.19.3-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x64-mingw-ucrt)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-musl)
@@ -283,6 +292,9 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin
+  x64-mingw-ucrt
+  x86_64-darwin
   x86_64-linux
   x86_64-linux-musl
 


### PR DESCRIPTION
## Problem

The **Cross-Platform Validation** job (`macos-latest` / `windows-latest`) in `build-validation.yml` failed ([run 29445253567](https://github.com/bamr87/it-journey/actions/runs/29445253567/job/87454063273)) with:

```
Your bundle only supports platforms ["aarch64-linux", "x86_64-linux", "x86_64-linux-musl"]
Run `bundle lock --add-platform arm64-darwin-23` and try again.
```

`bundler-cache: true` runs `bundle install` in deployment/frozen mode, which requires the target platform to be present in `Gemfile.lock`. The lock only carried Linux platforms, so the native gems (`ffi`, `nokogiri`) had no darwin/windows specs to install.

## Fix

Ran `bundle lock --add-platform arm64-darwin x86_64-darwin x64-mingw-ucrt`, which adds:
- Platform tokens: `arm64-darwin`, `x86_64-darwin`, `x64-mingw-ucrt`
- Precompiled specs: `ffi` and `nokogiri` for each new platform

`BUNDLED WITH` kept pinned at **2.3.25**; no gem versions changed — additions only.

Covers all three matrix runners (ubuntu already worked; macOS + Windows now resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)