### PR TITLE
🔧 Quest fix: developer/0100

### DIFF
--- a/pages/_quests/0100/self-operating-website-02-the-proving-grounds.md
+++ b/pages/_quests/0100/self-operating-website-02-the-proving-grounds.md
@@ -171,7 +171,13 @@ def check_frontmatter(md_path, text):
         out.append(finding(md_path, "fm-missing", "error", "no front matter block"))
         return out
     block = text.split("---", 2)[1]
-    data = yaml.safe_load(block) or {}
+    try:
+        data = yaml.safe_load(block) or {}
+    except yaml.YAMLError as e:
+        # A malformed block (e.g. an unquoted colon in a value) must degrade to
+        # a clean finding, never crash the harness — the gate stays deterministic.
+        out.append(finding(md_path, "fm-invalid", "error", f"invalid front matter: {e}"))
+        return out
     for key in sorted(REQUIRED_KEYS - set(data)):
         out.append(finding(md_path, "fm-required-key", "error", f"missing key: {key}"))
     return out
@@ -225,7 +231,13 @@ def check_frontmatter(md_path, text):
         out.append(finding(md_path, "fm-missing", "error", "no front matter block"))
         return out
     block = text.split("---", 2)[1]
-    data = yaml.safe_load(block) or {}
+    try:
+        data = yaml.safe_load(block) or {}
+    except yaml.YAMLError as e:
+        # A malformed block (e.g. an unquoted colon in a value) must degrade to
+        # a clean finding, never crash the harness — the gate stays deterministic.
+        out.append(finding(md_path, "fm-invalid", "error", f"invalid front matter: {e}"))
+        return out
     for key in sorted(REQUIRED_KEYS - set(data)):
         out.append(finding(md_path, "fm-required-key", "error", f"missing key: {key}"))
     return out

--- a/pages/_quests/0100/side-quest-profile-themes.md
+++ b/pages/_quests/0100/side-quest-profile-themes.md
@@ -137,6 +137,8 @@ Choose a theme concept. Examples:
 | `sunset` | Warm gradients | `#ff6b35` | `#fff3e0` |
 | `terminal` | Green on black | `#33ff33` | `#1a1a1a` |
 
+> ⚠️ **Accent color ≠ text color.** These accent/background pairs are design *concepts*, not guaranteed-accessible text colors. The light pairings — `arctic` (`#00bcd4` on `#e3f2fd` ≈ 2.0:1) and `sunset` (`#ff6b35` on `#fff3e0` ≈ 2.6:1) — fall short of the 3:1 minimum you'll enforce in Step 4. When a themed accent is used for text or interactive elements, pair it with a separate, darker text-safe variant of that hue so it clears the contrast bar. Always validate your final colors against the Step 4 table before opening a PR.
+
 ### Step 3: Create the Theme CSS
 
 Create `assets/css/themes/contributor-theme-YOUR_THEME.css`:

--- a/pages/_quests/0100/sourcery-code-methods.md
+++ b/pages/_quests/0100/sourcery-code-methods.md
@@ -366,6 +366,29 @@ Screenshots will be added in a future update (UI artifacts in progress).
 
 ### 🏗️ Creating Your First GitHub Action
 
+Before the workflow can pass, your repo needs a project the pipeline can act on. The steps below reference `npm ci`, `npm test`, `npm run lint`, and `npm run coverage`, so scaffold a minimal `package.json` first — then run `npm install` once to generate the `package-lock.json` that `npm ci` requires:
+
+```json
+// package.json — minimal scaffold so the workflow's npm steps resolve
+{
+  "name": "my-first-quest",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "echo \"no tests yet\" && exit 0",
+    "lint": "echo \"no linter configured yet\" && exit 0",
+    "coverage": "echo \"no coverage configured yet\" && exit 0"
+  }
+}
+```
+
+```bash
+npm install   # generates package-lock.json so `npm ci` works in CI
+git add package.json package-lock.json
+git commit -m "chore: scaffold package.json for CI pipeline"
+```
+
+With those no-op scripts committed, the pipeline runs green end to end; swap each `echo` for a real test/lint/coverage tool as your project grows.
+
 Automation is the highest form of development magic:
 
 ```yaml
@@ -389,7 +412,7 @@ jobs:
     - name: 🧙‍♂️ Setup Node.js Magic
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
         
     - name: ⚡ Install Dependencies


### PR DESCRIPTION
## 🔧 Quest fix — `developer/0100`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: developer/0100

Evidence honest-run gate (M7) passed: `mode==execute`, non-truncated, `errored==0`, every result `verdict_obj.executed==true`. All three quests verdict `warn`. Fixed the highest-priority verified issues under the deterministic keep gate (tier-1 `quest_validator.py` holds-or-rises + `brand_lint` clean).

- **pages/_quests/0100/self-operating-website-02-the-proving-grounds.md** — fixed the failed command `python scripts/ci/verify.py (complete assembled harness)` (verified: `commands[].status==failed`) and the paired high-priority recommendation (area: `check_frontmatter()`). Wrapped `yaml.safe_load(block)` in `try/except yaml.YAMLError`, emitting a clean `fm-invalid` finding instead of crashing on an unquoted colon in front matter (applied to both the partial and the "copy end to end" assembled block). tier-1 score 70/74 (94.6%) → 70/74 (94.6%) held, brand clean. ✅ kept.
- **pages/_quests/0100/side-quest-profile-themes.md** — addressed high-priority recommendation (area: Step 2 theme concept table). Added a caveat note that the `arctic` (~2.0:1) and `sunset` (~2.6:1) accent/background pairs fall short of Step 4's own 3:1 minimum and need a darker text-safe variant. tier-1 score 63/74 (85.1%) → 63/74 (85.1%) held, brand clean. ✅ kept.
- **pages/_quests/0100/sourcery-code-methods.md** — addressed high-priority recommendation (area: Chapter 4 workflow): added a minimal `package.json` scaffold + `npm install` step before the workflow YAML so `npm ci`/`test`/`lint`/`coverage` resolve instead of failing on a missing lockfile/scripts. tier-1 score 71/74 (95.9%) → 71/74 (95.9%) held, brand clean. ✅ kept.
- **pages/_quests/0100/sourcery-code-methods.md** — addressed medium recommendation (area: Chapter 4 `node-version`): bumped `node-version: '18'` → `'20'` (Node 18 reached EOL April 2025). tier-1 score 71/74 (95.9%) held, brand clean. ✅ kept.

_Left (out of scope for a small PR / lower priority):_
- Quest 1: medium (`main()` broad try/except for unreadable files), medium (reorder "copy end to end" callout ahead of the partial fragments), low (YAML `on:`→bool footnote) — the witnessed failed command is already resolved by the `check_frontmatter` guard; left the rest to keep the PR minimal.
- Quest 2: medium (add a merge-conflict/branch-protection walkthrough for Challenge 2), low (`gh pr create` CLI equivalent) — larger pedagogical additions, left for a future pass.
- Quest 3: medium (merge `theme:` into existing `profile:` block), medium (reconcile Step 1 vs Step 3 variable narrative), low (combined Liquid fragment placement), low (`bundle install` reminder) — left to keep the PR small.

_No vendored quests (no `source_repo:`/`source_url:`). No aborts. No frontmatter changed, so no `_data/quests` regeneration needed. No edits reverted._

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/29494904212)._
