### PR TITLE
🔧 Quest fix: system-engineer/0101

### DIFF
--- a/pages/_quests/0101/testing-integration.md
+++ b/pages/_quests/0101/testing-integration.md
@@ -178,8 +178,11 @@ node --version
 <summary>Click to expand Linux instructions</summary>
 
 ```bash
-# Debian/Ubuntu
-sudo apt update && sudo apt install -y nodejs npm
+# Debian/Ubuntu — use NodeSource so you get Node 20+.
+# The default apt repo ships Node 18, which fails this quest's Node 20+ requirement.
+sudo apt update
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt install -y nodejs
 
 mkdir testing-quest && cd testing-quest
 npm init -y
@@ -264,6 +267,18 @@ test('total of an empty cart is zero', () => {
 - Separating tests into ordered CI stages
 - Gating: a failed stage blocks the next
 - Fail-fast ordering so trivial mistakes cost seconds, not minutes
+
+### 🏗️ Define the Three Test Scripts
+
+Before the pipeline can call them, create the three npm scripts every job below references. Each stage maps to the folder that holds its tests:
+
+```bash
+npm pkg set scripts.test:unit="node --test test/unit"
+npm pkg set scripts.test:integration="node --test test/integration"
+npm pkg set scripts.test:e2e="node --test test/e2e"
+```
+
+Now `npm run test:unit` (and its `test:integration` and `test:e2e` siblings) run locally exactly as the CI jobs invoke them - without this step, `npm run test:unit` fails with `Missing script: "test:unit"`.
 
 ### 🏗️ A Gated, Tiered Pipeline
 


### PR DESCRIPTION
## 🔧 Quest fix — `system-engineer/0101`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: system-engineer/0101

Evidence: execute-mode, non-truncated, all 5 results `executed==true`, `errored==0` (M7 gate passed). Only one non-pass quest: **testing-integration** (`warn`, overall 71). Fixed its two high-priority verified issues; the other four quests in the slice passed and were out of scope.

- **pages/_quests/0101/testing-integration.md** — fixed failed command `npm run test:unit -- --test-reporter=tap` (verified: `commands[].status=failed`, `Missing script: "test:unit"`) + high-priority recommendation (area: *Chapter 2 / package.json scripts*). Added an explicit Chapter 2 step (`npm pkg set scripts.test:unit=… scripts.test:integration=… scripts.test:e2e=…`) that creates the three scripts the CI YAML and checkpoints already assume exist. tier-1 score_pct 100.0 → 100.0 (held), brand clean. ✅ kept.
- **pages/_quests/0101/testing-integration.md** — addressed high-priority recommendation (area: *Linux Territory Path*): the Linux install used `sudo apt install -y nodejs npm`, which ships Node 18 on Ubuntu 24.04 and violates the quest's own Node 20+ requirement. Replaced it with the NodeSource `setup_20.x` path. tier-1 score_pct 100.0 → 100.0 (held), brand clean. ✅ kept.

_Left (out of scope for this HIGH-first pass, below the per-slice cap):_ two medium recommendations — *Secondary Objectives* (Test Sharding / Status Checks listed but not covered) and *Advanced Challenge* (no concrete flaky-test quarantine mechanism shown) — and one low recommendation (add `npm pkg set type=module` to avoid the MODULE_TYPELESS_PACKAGE_JSON warning). All are genuine but lower-priority; left for a future daily pass. No vendored quests encountered. No frontmatter changed, so no `_data/quests` regeneration required.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/29494904212)._
