### PR TITLE
🔧 Quest fix: security-specialist/1011

### DIFF
--- a/pages/_quests/1011/agentic-multi-agent-failure-recovery.md
+++ b/pages/_quests/1011/agentic-multi-agent-failure-recovery.md
@@ -303,13 +303,24 @@ if __name__ == "__main__":
 
 ## ✅ Quest Validation
 
+Validate your work with these standalone checks — run each from your quest
+workspace (no extra tooling required):
+
 ```bash
-python3 scripts/validate_quest.py --quest q16
-# ✅ Recovery workflow: orchestrator-with-recovery.yml present
-# ✅ Recovery coordinator: recovery_coordinator.py present
-# ✅ Compensation strategies: all 5 types documented
-# 🏆 Quest Q16 complete!
+# ✅ Recovery workflow present
+test -f orchestrator-with-recovery.yml && echo "orchestrator-with-recovery.yml present"
+# ✅ Recovery coordinator present
+test -f recovery_coordinator.py && echo "recovery_coordinator.py present"
+# ✅ Compensation strategies documented (expect a count of 5)
+grep -c -iE "retry|fallback|escalat|compensat|checkpoint" recovery_coordinator.py
 ```
+
+Manual completion checklist:
+
+- [ ] `orchestrator-with-recovery.yml` defines the recover-and-report job
+- [ ] `recovery_coordinator.py` implements the failure assessment logic
+- [ ] All 5 compensation strategy types are documented
+- [ ] 🏆 Quest Q16 complete!
 
 ## 🏆 Quest Rewards
 

--- a/pages/_quests/1011/ai-feature-pipeline-architect.md
+++ b/pages/_quests/1011/ai-feature-pipeline-architect.md
@@ -230,7 +230,13 @@ from mcp import ClientSession
 class RequirementProcessor:
     def __init__(self):
         # Read credentials from the environment — never hard-code API keys
-        self.llm = Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            raise SystemExit(
+                "ANTHROPIC_API_KEY is not set. Export it before running this agent, "
+                "e.g. `export ANTHROPIC_API_KEY=sk-...`."
+            )
+        self.llm = Anthropic(api_key=api_key)
         self.mcp_session: ClientSession | None = None  # opened via an MCP transport
 
     def process_user_request(self, raw_request: str):

--- a/pages/_quests/1011/secure-coding.md
+++ b/pages/_quests/1011/secure-coding.md
@@ -185,7 +185,8 @@ python3 --version
 
 ```bash
 # Any container or Codespace with Python works
-docker run --rm -it python:3.12-slim bash -lc \
+# (no -it: this runs non-interactively in scripts/CI without a TTY)
+docker run --rm python:3.12-slim bash -lc \
   "pip install bcrypt bandit pip-audit && python --version"
 ```
 


### PR DESCRIPTION
## 🔧 Quest fix — `security-specialist/1011`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: security-specialist/1011

Evidence gate (M7) passed: all 5 results `mode==execute`, `mock==false`, `executed==true`, non-truncated, 0 errored. Acted on the 3 non-pass quests (2 warn, 1 fail); the 2 `pass` quests were left untouched.

- **pages/_quests/1011/secure-coding.md** — fixed failed command `docker run --rm -it python:3.12-slim …` (verified: commands[].status=failed, `the input device is not a TTY`; matches high-priority rec "Cloud Realms Path (Docker snippet)"). Dropped the `-it` flags so the copy-pasted snippet runs non-interactively. tier-1 score_pct 100.0 → 100.0 (held), brand clean. ✅ kept.
- **pages/_quests/1011/ai-feature-pipeline-architect.md** — addressed failed command `… | python intake_agent.py` (verified: commands[].status=failed, raw `KeyError: 'ANTHROPIC_API_KEY'`; matches medium rec "intake_agent.py error handling"). Replaced `os.environ["ANTHROPIC_API_KEY"]` with an `os.environ.get(...)` check that raises an actionable message instead of a raw traceback. tier-1 score_pct 95.9 → 95.9 (held), brand clean. ✅ kept.
- **pages/_quests/1011/agentic-multi-agent-failure-recovery.md** — fixed failed command `python3 scripts/validate_quest.py --quest q16` (verified: commands[].status=failed, `No such file or directory`; matches medium rec "Quest Validation section"). Replaced the reference to a non-existent validator with standalone `test -f`/`grep -c` checks plus a manual completion checklist the learner can actually run. tier-1 score_pct 78.4 → 78.4 (held), brand clean. ✅ kept.

_Left (out of scope / not fixed this pass):_
- ai-feature-pipeline-architect (fail) remaining recommendations — two high-priority (flesh out Chapters 2–5 / add a working MCP session example) and several medium/low (stale `claude-3-5-sonnet-latest` model id, macOS `brew install --cask docker`, ADR template, concrete completion criteria) are larger authoring tasks beyond a smallest-edit fix pass; deferred to keep the PR small and reviewable.
- agentic-multi-agent-failure-recovery (warn) remaining recommendations — high-priority `needs.<job>.result` + missing referenced scripts (subtask.py, save_checkpoint.py, redelegate_tasks.py), plus medium/low (raw Jekyll `{% raw %}` tags, setup/prerequisites note) require substantial new content; deferred.
- secure-coding (warn) remaining medium/low recommendations (detect-secrets `--all-files`, SQL `%s` driver note, duplicate Flask endpoint naming, Node/XSS note) — not failed commands; deferred.
- No frontmatter changed, so no `_data/quests/**` regeneration was required. No vendored quests encountered (none carry `source_repo:`/`source_url:`).

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/29494904212)._
