### PR TITLE
ci(quest-perfection): isolate slice failures so a partial sweep still counts

### DIFF
--- a/.github/workflows/quest-perfection.yml
+++ b/.github/workflows/quest-perfection.yml
@@ -134,6 +134,9 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
+          # Wheel-cache pip installs across runs (keyed on the repo's committed
+          # requirements files; the jobs themselves only `pip install pyyaml`).
+          cache: pip
 
       - name: Install Python tooling
         run: pip install pyyaml
@@ -378,12 +381,30 @@ jobs:
   # ---------------------------------------------------------------------------
   # slice — one (character, level) slice per matrix entry, IN SERIES
   # (max-parallel: 1) so ledger writes serialize and the human reviewer is never
-  # flooded. fail-fast: false so one bad slice doesn't abort the sweep.
+  # flooded. fail-fast: false so one bad slice doesn't abort the sweep, and
+  # continue-on-error so one bad slice doesn't fail the RUN either (see below).
   # ---------------------------------------------------------------------------
   slice:
     needs: plan
     if: ${{ needs.plan.outputs.count != '0' && needs.plan.outputs.matrix != '' }}
     runs-on: ubuntu-latest
+    # FAILURE ISOLATION — one flaky leg must not convert the whole multi-hour
+    # sweep into a "failed" run. fail-fast: false already lets sibling slices
+    # finish, but a single failed leg still set the workflow conclusion to
+    # `failure`, booking every productive minute of a 5/6-good sweep as waste
+    # (observed: a transient GitHub "Set up job" action-resolution 500 killed
+    # one leg at minute 0 and wrote off a 140-minute run). continue-on-error
+    # lifts the leg's failure out of the run conclusion — and, being job-level,
+    # it also covers "Set up job" infra failures that no in-job retry step can
+    # reach. Failures stay visible, never masked: the leg still shows red in
+    # the run UI, and the report job surfaces every undelivered slice (and
+    # hard-fails the run on a sweep-wide wipeout).
+    continue-on-error: true
+    # Bound each leg: a stuck agentic engine must not run toward the 6h job
+    # ceiling. The engine walks a bounded quest window (13-30 min observed) plus
+    # the walker agent, so 45 minutes is generous headroom per leg; a timed-out
+    # leg soft-fails (continue-on-error) and retries next run.
+    timeout-minutes: 45
     # Read-only over GitHub: this job walks + uploads an artifact. All git writes
     # (the consolidated report PR) happen in the `report` job; the fix PR in the
     # called quest-fix.yml.
@@ -417,6 +438,9 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
+          # Wheel-cache pip installs across runs (keyed on the repo's committed
+          # requirements files; the jobs themselves only `pip install pyyaml`).
+          cache: pip
 
       - name: Install Python tooling
         run: pip install pyyaml
@@ -641,6 +665,9 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
+          # Wheel-cache pip installs across runs (keyed on the repo's committed
+          # requirements files; the jobs themselves only `pip install pyyaml`).
+          cache: pip
 
       - name: Install Python tooling
         run: pip install pyyaml
@@ -653,6 +680,43 @@ jobs:
         with:
           pattern: quest-perfection-*
           path: slices
+
+      # FAILED-SLICE VISIBILITY — the slice legs run continue-on-error so one
+      # flaky leg can't fail the whole sweep, which means the run conclusion no
+      # longer tells you a leg died. This step does: compare the planned matrix
+      # against the artifacts that actually arrived, warn (annotation + step
+      # summary) for every slice that failed or delivered nothing, and hard-fail
+      # the run ONLY when every planned slice is missing — a sweep-wide wipeout
+      # is a real problem (infra/auth), not a flaky leg.
+      - name: Surface failed slices (planned vs delivered)
+        env:
+          PLAN_MATRIX: ${{ needs.plan.outputs.matrix }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, os, sys
+          from pathlib import Path
+          entries = (json.loads(os.environ.get("PLAN_MATRIX") or "{}") or {}).get("include", [])
+          missing = [e["slug"] for e in entries
+                     if not (Path("slices") / f"quest-perfection-{e['branch_slug']}"
+                             / "walk-plan.json").is_file()]
+          delivered = len(entries) - len(missing)
+          line = f"**Slices delivered:** {delivered}/{len(entries)}"
+          if missing:
+              line += " — failed/undelivered: " + ", ".join(f"`{s}`" for s in missing)
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as fh:
+              fh.write(line + "\n")
+          print(line)
+          for slug in missing:
+              print(f"::warning::slice {slug} failed or uploaded no artifact — the other "
+                    f"slices' work still counts; this slice stays in the queue and is "
+                    f"retried on the next run.")
+          if entries and delivered == 0:
+              print("::error::every planned slice failed to deliver an artifact — "
+                    "sweep-wide failure (runner infra or Claude auth), not a flaky leg. "
+                    "Failing the run loudly.")
+              sys.exit(1)
+          PY
 
       - name: Replay ledger updates + collect the session reports
         run: |


### PR DESCRIPTION
Addresses bamr87/bamr87#23 — *"Actions: it-journey/quest-perfection — one failed slice wastes the whole multi-hour daily run"*.

## Root cause

The daily Quest Perfection sweep fans a matrix of per-character `slice` legs, each running the agentic engine for 13–30 min. `fail-fast: false` was already set, so sibling legs finished — but **a single failed leg still set the workflow conclusion to `failure`**, converting an otherwise-productive multi-hour run into 100% "wasted" minutes in the Actions analytics (36.9% effective, 727.6m/14d booked as waste). Two observed modes:

- a transient GitHub **"Set up job" action-resolution 500** killing one leg at minute 0 (run [29248386306](https://github.com/bamr87/it-journey/actions/runs/29248386306) — 5/6 slices succeeded, 140m written off);
- a genuine one-leg failure in `Gather sandboxed evidence` (runs [29190829265](https://github.com/bamr87/it-journey/actions/runs/29190829265), [29150921861](https://github.com/bamr87/it-journey/actions/runs/29150921861)).

Layered on top: no per-leg `timeout-minutes` (p95 run 171m ⇒ occasional runaways toward the 6h ceiling) and no dependency caching.

## Fix (`.github/workflows/quest-perfection.yml`)

1. **`continue-on-error: true` on the `slice` job** — a failed leg no longer sets the run conclusion. Job-level (not step-level) deliberately: the "Set up job" ISE fires *before any step runs*, so no in-job retry step can reach it — job-level isolation is the only lever that covers both failure modes. The `report` and `fix` jobs already ran on `!cancelled()` and tolerate missing artifacts, so downstream behavior is unchanged.
2. **Failures stay visible, never masked** — the leg still shows red in the run UI, and a new report-job step **"Surface failed slices (planned vs delivered)"** diffs the planned matrix against the artifacts that actually arrived: per-missing-slice `::warning::` annotations + a `Slices delivered: N/M` step-summary line, and a **hard failure of the run when *every* planned slice is missing** (a sweep-wide wipeout is infra/auth breakage, not a flaky leg). This complements the existing zero-productive-slices guard, which can't fire when no artifacts arrive at all.
3. **`timeout-minutes: 45` on the `slice` job** — bounds each leg (engine 13–30 min observed + walker agent) so a stuck engine soft-fails and retries next run instead of running toward 6h.
4. **`cache: pip`** on the three `setup-python` steps (plan/slice/report).

Deliberately **not** included: a `nick-fields/retry` wrapper (the observed ISE precedes all steps — (1) is the issue's own fallback for it); `setup-node` npm caching (no root lockfile — it would hard-fail the job); and staggering character paths across days (issue item 5 — a budget/planner policy change, better done in `.quests/budget.yml` as a follow-up, and the rotating quest window already bounds per-slice work).

## Expected impact

A 5/6-good sweep now concludes `success`, reclaiming the ~700m/14d currently booked as waste; effectiveness should rise from ~37% toward 80%+. Real problems stay loud: red legs, warnings, the delivered-count summary, the wipeout hard-fail, and the whole-sweep zero-score guard are all untouched or strengthened.

Validated with `actionlint` (clean) and a YAML parse; the embedded Python of the new step was compile- and smoke-tested (partial failure → warn + exit 0; wipeout → exit 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
