### PR TITLE
🔧 Quest fix: system-engineer/1001

### DIFF
--- a/pages/_quests/1001/agentic-dev-environment-integration.md
+++ b/pages/_quests/1001/agentic-dev-environment-integration.md
@@ -239,7 +239,28 @@ here, STOP and report what you need.
 
 ### Chapter 4 — Validating Environment Parity
 
-> **Exercise 6.3:** Run this parity check script to confirm the environment is correctly configured.
+> **Exercise 6.3:** First create the agent instruction file the check requires, then run the parity check to confirm the environment is correctly configured.
+
+The check below verifies `.github/copilot-instructions.md` — the repo-scoped guide GitHub Copilot loads automatically. Create it before running the check, or the check will always report a failure:
+
+```bash
+mkdir -p .github
+cat > .github/copilot-instructions.md << 'EOF'
+# Copilot Instructions
+
+Read `AGENTS.md` before taking any action, and operate only within the
+allowed/forbidden operation lists it defines. Prefer small, reviewable
+changes and never touch restricted areas.
+EOF
+```
+
+The check also requires `GITHUB_TOKEN` to be set — export a real token first (see Chapter 5) so the token check passes:
+
+```bash
+export GITHUB_TOKEN=your_real_token   # a valid PAT, not a placeholder
+```
+
+Now run the parity check script:
 
 ```bash
 #!/usr/bin/env bash

--- a/pages/_quests/1001/agentic-memory-strategies.md
+++ b/pages/_quests/1001/agentic-memory-strategies.md
@@ -160,7 +160,7 @@ jobs:
         run: |
           mkdir -p .agent-memory
           if [ ! -f .agent-memory/session.json ]; then
-            cat > .agent-memory/session.json << 'EOF'
+            cat > .agent-memory/session.json << EOF
             {
               "session_id": "${{ github.run_id }}",
               "issue_number": ${{ github.event.issue.number }},
@@ -278,12 +278,14 @@ from previous agent runs that should inform future decisions.
 
 ## ✅ Quest Validation
 
+Run this self-contained check (no external script needed) from your sandbox repo root:
+
 ```bash
-python3 scripts/validate_quest.py --quest q8
-# ✅ Session memory: agent-with-session-memory.yml present
-# ✅ Persistent memory: docs/agent-memory/ directory with .md files
-# ✅ Context injection: copilot-instructions.md has memory loading protocol
-# 🏆 Quest Q8 complete!
+WF=.github/workflows/agent-with-session-memory.yml
+test -f "$WF"                    && echo "✅ Session memory: agent-with-session-memory.yml present" || echo "❌ Workflow missing"
+test -d docs/agent-memory        && echo "✅ Persistent memory: docs/agent-memory/ directory with .md files" || echo "❌ No persistent memory dir"
+grep -q 'Memory Loading Protocol' .github/copilot-instructions.md 2>/dev/null && echo "✅ Context injection: copilot-instructions.md has memory loading protocol" || echo "ℹ️  Context injection: add the protocol from Chapter 5 to .github/copilot-instructions.md"
+# 🏆 All green → Quest Q8 complete!
 ```
 
 ## 🏆 Quest Rewards

--- a/pages/_quests/1001/agentic-safe-execution-and-error-handling.md
+++ b/pages/_quests/1001/agentic-safe-execution-and-error-handling.md
@@ -287,14 +287,16 @@ Every failed agent run should produce a machine-readable error report:
 
 ## ✅ Quest Validation
 
+Run this self-contained check (no external script needed) from your sandbox repo root:
+
 ```bash
-python3 scripts/validate_quest.py --quest q7
-# ✅ Workflow: agent-with-retries.yml present
-# ✅ Retry config: exponential backoff implemented
-# ✅ Timeout: job-level and step-level timeouts set
-# ✅ Escalation: PR comment + label on failure
-# ✅ Error report schema: present
-# 🏆 Quest Q7 complete!
+WF=.github/workflows/agent-with-retries.yml
+test -f "$WF"                 && echo "✅ Workflow: agent-with-retries.yml present" || echo "❌ Workflow missing"
+grep -q 'RETRY_MAX'      "$WF" && echo "✅ Retry config: exponential backoff implemented" || echo "❌ No retry config"
+grep -q 'timeout-minutes' "$WF" && echo "✅ Timeout: job-level and step-level timeouts set" || echo "❌ No timeouts"
+grep -q 'createComment'  "$WF" && echo "✅ Escalation: PR comment + label on failure" || echo "❌ No escalation"
+grep -q 'error_report_version' work/gh-600/scripts/*.json 2>/dev/null && echo "✅ Error report schema: present" || echo "ℹ️  Error report schema: sample only (see Chapter 5)"
+# 🏆 All green → Quest Q7 complete!
 ```
 
 ## 🏆 Quest Rewards


### PR DESCRIPTION
## 🔧 Quest fix — `system-engineer/1001`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: system-engineer/1001

Evidence: `mode=execute`, non-truncated, all 5 results `executed=true` (M7 gate passed).
Acted on the 3 non-pass quests (1 fail, 2 warn); the 2 `pass` quests were skipped.
None of the edited quests are vendored (no `source_repo:`/`source_url:`). No frontmatter
touched, so `_data/quests/**` needs no regeneration.

- **pages/_quests/1001/agentic-dev-environment-integration.md** (verdict: fail) — fixed
  the failed command `check_agent_env.sh` (`commands[].status=failed`: script can never
  pass because no exercise creates `.github/copilot-instructions.md`, and the
  `GITHUB_TOKEN` check fails until a token is exported). Added an Exercise 6.3 step that
  creates `.github/copilot-instructions.md` and notes exporting a real `GITHUB_TOKEN`
  before the check — also resolves the **high** recommendation (*Chapter 4 —
  check_agent_env.sh*). tier-1 score_pct 85.1 → 85.1 (held), brand clean. ✅ kept.
- **pages/_quests/1001/agentic-safe-execution-and-error-handling.md** (verdict: warn) —
  fixed the failed command `python3 scripts/validate_quest.py --quest q7`
  (`commands[].status=failed`: FileNotFoundError, script ships nowhere). Replaced it with
  a self-contained runnable shell check against the workflow the quest produces — resolves
  the **high** recommendation (*Quest Validation section*). tier-1 score_pct 85.1 → 85.1
  (held), brand clean. ✅ kept.
- **pages/_quests/1001/agentic-memory-strategies.md** (verdict: warn) — (a) fixed the
  failed command `python3 scripts/validate_quest.py --quest q8` (FileNotFoundError) by
  replacing it with a self-contained runnable check — resolves the **high** recommendation
  (*Quest Validation section*); (b) unquoted the session.json heredoc delimiter
  (`<< 'EOF'` → `<< EOF`) so `started_at`'s `$(date …)` actually expands instead of being
  written literally — resolves the **high** recommendation (*Chapter 3 — session.json
  'started_at' field*). tier-1 score_pct 78.4 → 78.4 (held), brand clean. ✅ kept.

_Left (not fixed):_
- **agentic-safe-execution** — high rec to replace the echo-only
  `test_failure_scenarios.sh` (Exercise 7.3) with a real mocking script: a substantive
  rewrite beyond a smallest-faithful edit; medium (`run_agent_task.py` provenance) and low
  (`jq` fallback, level/topic reclassification) recs left for a future pass.
- **agentic-dev-environment-integration** — low recs (devcontainer JSONC comment note,
  `YOUR_ORG/YOUR_REPO` placeholder note, PAT-prefix reconciliation) left as below the
  per-slice cap; the `GITHUB_TOKEN`-must-be-real point was partly addressed by the token
  note added in Chapter 4.
- **agentic-memory-strategies** — medium/low recs (heredoc-indentation warning note,
  ephemeral-memory exercise, `actions/cache` vs `upload-artifact` clarification) left for a
  future pass.
- No edits were reverted; no vendored quest was encountered.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/29577137232)._
