### PR TITLE
PostHog analytics: instrument Ruby SEO/content scripts

### DIFF
--- a/.claude/skills/integration-ruby/SKILL.md
+++ b/.claude/skills/integration-ruby/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: integration-ruby
+description: PostHog integration for any Ruby application using the Ruby SDK
+metadata:
+  author: PostHog
+  version: 1.30.4
+---
+
+# PostHog integration for Ruby
+
+This skill helps you add PostHog analytics to Ruby applications.
+
+## Workflow
+
+Follow these steps in order to complete the integration:
+
+1. `references/1-begin.md` - PostHog Setup - Begin ← **Start here**
+2. `references/2-edit.md` - PostHog Setup - Edit
+3. `references/3-revise.md` - PostHog Setup - Revise
+4. `references/4-conclude.md` - PostHog Setup - Conclusion
+
+## Reference files
+
+- `references/EXAMPLE.md` - Ruby example project code
+- `references/1-begin.md` - Start the event tracking setup process by analyzing the project and creating an event tracking plan
+- `references/2-edit.md` - Implement PostHog event tracking in the identified files, following best practices and the example project
+- `references/3-revise.md` - Review and fix any errors in the PostHog integration implementation
+- `references/4-conclude.md` - Review and fix any errors in the PostHog integration implementation
+- `references/ruby.md` - Ruby - docs
+- `references/identify-users.md` - Identify users - docs
+- `references/COMMANDMENTS.md` - Framework-specific rules the integration must follow
+
+The example project shows the target implementation pattern. Consult the documentation for API details.
+
+## Key principles
+
+- **Environment variables**: Always use environment variables for PostHog keys. Never hardcode them.
+- **Minimal changes**: Add PostHog code alongside existing integrations. Don't replace or restructure existing code.
+- **Match the example**: Your implementation should follow the example project's patterns as closely as possible.
+
+## Framework guidelines
+
+- posthog-ruby is the Ruby SDK gem name (add `gem 'posthog-ruby'` to Gemfile) but require it with `require 'posthog'` (NOT `require 'posthog-ruby'`)
+- Use PostHog::Client.new(api_key: key, host: host) for instance-based initialization in scripts and CLIs
+- In CLIs and scripts: MUST call client.shutdown before exit or all events are lost
+- Use begin/rescue/ensure with shutdown in the ensure block for proper cleanup
+- capture and identify take a single hash argument: client.capture(distinct_id: 'user_123', event: 'my_event', properties: { key: 'value' })
+- capture_exception takes POSITIONAL args (not keyword): client.capture_exception(exception, distinct_id, additional_properties) — do NOT use `distinct_id:` keyword syntax
+
+## Identifying users
+
+Identify users during login and signup events. Refer to the example code and documentation for the correct identify pattern for this framework. If both frontend and backend code exist, pass the client-side session and distinct ID using `X-POSTHOG-DISTINCT-ID` and `X-POSTHOG-SESSION-ID` headers to maintain correlation.
+
+## Error tracking
+
+Add PostHog error tracking to relevant files, particularly around critical user flows and API boundaries.

--- a/.claude/skills/integration-ruby/references/1-begin.md
+++ b/.claude/skills/integration-ruby/references/1-begin.md
@@ -1,0 +1,56 @@
+---
+title: PostHog Setup - Begin
+description: Start the event tracking setup process by analyzing the project and creating an event tracking plan
+---
+
+We're making an event tracking plan for this project.
+
+This is the first of several phases — plan the events, implement them, revise and validate changes, then conclude by creating a dashboard and writing a setup report.
+
+## Task list
+
+As soon as you've read this description and have a rough sense of the work, make a single **call `TaskCreate` immediately** before reading any reference file or beginning analysis. The user is watching the task pane and shouldn't see it sit empty.
+
+It's fine if your first list is incomplete or imprecise. Seed it with whatever high-level items you can infer from the overview above, then call `TaskCreate` again (or `TaskUpdate` to refine existing items) every time your understanding sharpens: after a phase reveals work you didn't anticipate, after planning surfaces concrete sub-items, after you hit something new. Use `TaskUpdate` to mark items `in_progress` when you start them and `completed` when you finish. Keeping the list current matters more than getting it right on the first call.
+
+Keep task titles broad and job-oriented. Describe the purpose or area of work with wording like "Planning event tracking", "Identifying users", "Installing PostHog", "Capturing events", or "Creating dashboards", not the specific files, paths, or symbols involved. Adjust the task names according to the user's project and context.
+
+Before proceeding, find any existing `posthog.capture()` code. Make note of event name formatting.
+
+From the project's file list, select between 10 and 15 files that might have interesting business value for event tracking, especially conversion and churn events. Also look for additional files related to login that could be used for identifying users, along with error handling. Read the files. If a file is already well-covered by PostHog events, replace it with another option. Do not spawn subagents.
+
+Look for opportunities to track client-side events.
+
+**IMPORTANT: Server-side events are REQUIRED** if the project includes any instrumentable server-side code. If the project has API routes (e.g., `app/api/**/route.ts`) or Server Actions, you MUST include server-side events for critical business operations like:
+
+  - Payment/checkout completion
+  - Webhook handlers
+  - Authentication endpoints
+
+Do not skip server-side events - they capture actions that cannot be tracked client-side.
+
+Create a new file with a JSON array at the root of the project: .posthog-events.json. It should include one object for each event we want to add with these exact field names: `event_name` (the event name), `event_description` (one sentence), and `file` (the file path the event goes in). The wizard reads this file to surface the plan in the UI. If events already exist, don't duplicate them; supplement them.
+
+Track actions only, not pageviews. These can be captured automatically. Exceptions can be made for "viewed"-type events that correspond to the top of a conversion funnel.
+
+As you review files, make an internal note of opportunities to identify users and catch errors. We'll need them for the next step.
+
+## Status
+
+Before beginning a phase of the setup, you will send a status message with the exact prefix '[STATUS]', as in:
+
+[STATUS] Checking project structure.
+
+Status to report in this phase:
+
+- Checking project structure
+- Verifying PostHog dependencies
+- Generating events based on project
+
+## Abort statuses
+
+If and only if the instructions have `[ABORT]` states specified, and you clearly match the conditions for an abort, emit the abort message. Do NOT attempt to exit or halt yourself — the wizard's middleware catches `[ABORT]` and terminates the run for you.
+
+---
+
+**Upon completion, continue with:** [2-edit.md](2-edit.md)

--- a/.claude/skills/integration-ruby/references/2-edit.md
+++ b/.claude/skills/integration-ruby/references/2-edit.md
@@ -1,0 +1,36 @@
+---
+title: PostHog Setup - Edit
+description: Implement PostHog event tracking in the identified files, following best practices and the example project
+---
+
+For each of the files and events noted in .posthog-events.json, make edits to capture events using PostHog. Make sure to set up any helper files needed. Carefully examine the included example project code: your implementation should match it as closely as possible. Do not spawn subagents.
+
+Use environment variables for PostHog keys. Do not hardcode PostHog keys.
+
+If a file already has existing integration code for other tools or services, don't overwrite or remove that code. Place PostHog code below it.
+
+For each event, add useful properties, and use your access to the PostHog source code to ensure correctness. You also have access to documentation about creating new events with PostHog. Consider this documentation carefully and follow it closely before adding events. Your integration should be based on documented best practices. Carefully consider how the user project's framework version may impact the correct PostHog integration approach.
+
+Remember that you can find the source code for any dependency in the node_modules directory. This may be necessary to properly populate property names. There are also example project code files available via the PostHog MCP; use these for reference.
+
+Where possible, add calls for PostHog's identify() function on the client side upon events like logins and signups. Use the contents of login and signup forms to identify users on submit. If there is server-side code, pass the client-side session and distinct ID to the server-side code to identify the user. On the server side, make sure events have a matching distinct ID where relevant. 
+
+It's essential to do this in both client code and server code, so that user behavior from both domains is easy to correlate.
+
+You should also add PostHog exception capture error tracking to these files where relevant.
+
+Remember: Do not alter the fundamental architecture of existing files. Make your additions minimal and targeted.
+
+Remember the documentation and example project resources you were provided at the beginning. Read them now.
+
+## Status
+
+Status to report in this phase:
+
+- Inserting PostHog capture code
+- A status message for each file whose edits you are planning, including a high level summary of changes
+- A status message for each file you have edited
+
+---
+
+**Upon completion, continue with:** [3-revise.md](3-revise.md)

--- a/.claude/skills/integration-ruby/references/3-revise.md
+++ b/.claude/skills/integration-ruby/references/3-revise.md
@@ -1,0 +1,22 @@
+---
+title: PostHog Setup - Revise
+description: Review and fix any errors in the PostHog integration implementation
+---
+
+Check the project for errors. Read the package.json file for any type checking or build scripts that may provide input about what to fix. Remember that you can find the source code for any dependency in the node_modules directory. Do not spawn subagents.
+
+Ensure that any components created were actually used.
+
+Once all other tasks are complete, run any linter or prettier-like scripts found in the package.json, but ONLY on the files you have edited or created during this session. Do not run formatting or linting across the entire project's codebase.
+
+## Status
+
+Status to report in this phase:
+
+- Finding and correcting errors
+- Report details of any errors you fix
+- Linting, building and prettying
+
+---
+
+**Upon completion, continue with:** [4-conclude.md](4-conclude.md)

--- a/.claude/skills/integration-ruby/references/4-conclude.md
+++ b/.claude/skills/integration-ruby/references/4-conclude.md
@@ -1,0 +1,139 @@
+---
+title: PostHog Setup - Conclusion
+description: Review and fix any errors in the PostHog integration implementation
+---
+
+Create a live PostHog dashboard named "Analytics basics (wizard)" from the events you just instrumented, then populate it with up to five insights — lead with the business-critical views: conversion funnels, churn events, and other key signals. Use the exact same event names as implemented in the code. Keep the `(wizard)` tag with that exact casing so anyone browsing PostHog can see the wizard created this dashboard, and so a quick search for `(wizard)` surfaces every wizard-created artifact in one go.
+
+## How to call PostHog MCP tools
+
+The PostHog MCP server exposes a single `exec` tool. Every PostHog operation is driven by a CLI-style command string passed in its `command` parameter — the tool may be namespaced by the host (`mcp__posthog__exec`, `mcp__posthog-wizard__exec`), but the command grammar is the same. Tool names and schemas are not predictable, so discover and inspect before you call.
+
+**Grammar** — run in this order:
+
+```text
+exec({ "command": "search <regex>" })      # find tools by name/title/description; `tools` lists them all
+exec({ "command": "info <tool_name>" })     # REQUIRED before every call — description + input schema
+exec({ "command": "schema <tool_name> <field_path>" })  # drill into a field the schema flags with a `hint`
+exec({ "command": "call <tool_name> <json_input>" })    # run the tool
+```
+
+Running `info <tool_name>` before `call <tool_name>` is mandatory, the same way you read a file before editing it. `info` returns the full schema for simple tools; for large ones it summarizes and attaches `hint` entries pointing at fields to drill into with `schema`. Dot-notation descends objects (`query.source`), array items (`series.0.properties`), and unions. Never guess the structure of a field that carries a hint — drill first.
+
+Every PostHog tool goes through `exec` this way — there is no separate named tool to call directly. The inner tool names and JSON payloads below are what you pass to `call`.
+
+**Errors** carry a suggestion and similar tool names — read it before retrying. If a name isn't found it may have been renamed; run `search <pattern>` or `tools` again to find the current one.
+
+Create the parent dashboard first with `dashboard-create`, capture its returned `id`, then attach every insight to it via `dashboards: [<id>]`:
+
+```json
+{
+  "name": "Analytics basics (wizard)",
+  "description": "Key views for the events instrumented by the PostHog wizard.",
+  "tags": ["wizard"]
+}
+```
+
+When calling `insight-create`, use these known-good query shapes — they are verified against the MCP schema, and the common variations around them are rejected:
+
+A trends insight with a breakdown (breakdowns go in `breakdownFilter.breakdowns`, an array — there is NO top-level `breakdown` field on `TrendsQuery`):
+
+```json
+{
+  "name": "Signups by plan (wizard)",
+  "dashboards": [<dashboard id from dashboard-create>],
+  "query": {
+    "kind": "InsightVizNode",
+    "source": {
+      "kind": "TrendsQuery",
+      "series": [{ "kind": "EventsNode", "event": "user_signed_up", "math": "total" }],
+      "interval": "day",
+      "dateRange": { "date_from": "-30d" },
+      "breakdownFilter": { "breakdowns": [{ "type": "event", "property": "plan" }] },
+      "trendsFilter": { "display": "ActionsBar" }
+    }
+  }
+}
+```
+
+A conversion funnel (the window fields are camelCase and live INSIDE `funnelsFilter` — not at the top level of `FunnelsQuery`, and not snake_case):
+
+```json
+{
+  "name": "Signup funnel (wizard)",
+  "dashboards": [<dashboard id from dashboard-create>],
+  "query": {
+    "kind": "InsightVizNode",
+    "source": {
+      "kind": "FunnelsQuery",
+      "series": [
+        { "kind": "EventsNode", "event": "page_viewed" },
+        { "kind": "EventsNode", "event": "user_signed_up" }
+      ],
+      "dateRange": { "date_from": "-30d" },
+      "funnelsFilter": {
+        "funnelVizType": "steps",
+        "funnelOrderType": "ordered",
+        "funnelWindowInterval": 14,
+        "funnelWindowIntervalUnit": "day"
+      }
+    }
+  }
+}
+```
+
+Valid `trendsFilter.display` values are `ActionsLineGraph`, `ActionsBar`, `ActionsAreaGraph`, `ActionsPie`, `ActionsStackedBar`, `BoldNumber`, and `ActionsTable` — names like `ActionsBarChart` or `ActionsBarGraph` are rejected. If an insight call is rejected anyway, fix the payload against these examples rather than retrying variations.
+
+Once the dashboard exists, emit its URL on its own line in your assistant message using this exact marker: `[DASHBOARD_URL] <full https url>`. The wizard parses this marker from your visible message and surfaces the link in the success summary. Mentioning the URL only in thinking or in prose without the marker means the link is dropped.
+
+Search for a file called `.posthog-events.json` and read it for available events.
+
+Do not spawn subagents.
+
+Create the file posthog-setup-report.md. It should include a summary of the integration edits, a table with the event names, event descriptions, and files where events were added, a list of links for the dashboard and insights created, and a "Verify before merging" checklist (see below). Follow this format:
+
+<wizard-report>
+# PostHog post-wizard report
+
+The wizard has completed a deep integration of your project. [Detailed summary of changes]
+
+[table of events/descriptions/files]
+
+## Next steps
+
+We've built some insights and a dashboard for you to keep an eye on user behavior, based on the events we just instrumented:
+
+[links]
+
+## Verify before merging
+
+[checklist]
+
+### Agent skill
+
+We've left an agent skill folder in your project. You can use this context for further agent development when using Claude Code. This will help ensure the model provides the most up-to-date approaches for integrating PostHog.
+
+</wizard-report>
+
+For the "Verify before merging" checklist, write GitHub-style checkboxes (`- [ ] ...`) covering what the developer (or their coding agent) still needs to do to take this from "wizard finished" to "merged". Include ONLY the items that actually apply to the integration you just performed — judge each against the code you changed in this run, and drop any that don't fit. Phrase each item as a concrete, checkable action. Candidate items, with the condition for including each:
+
+- Always: "Run a full production build (the wizard only verified the files it touched) and fix any lint or type errors introduced by the generated code."
+- Always: "Run the test suite — call sites that were rewritten or instrumented may need updated mocks or fixtures."
+- If you added environment variables: "Add the exact PostHog env var names you added to `.env.example` and any monorepo/bootstrap scripts so collaborators know what to set."
+- If this integration ships a minified production browser bundle (most SPA/SSR web frameworks — e.g. Next.js, Nuxt, SvelteKit, Astro, Vite-based apps): "Wire source-map upload (`posthog-cli sourcemap` or your bundler's upload step) into CI so production stack traces de-minify."
+- If LLM analytics was set up in this run: "Trigger the LLM call path(s) you instrumented and confirm `$ai_generation` events appear in PostHog AI Observability."
+- If the app has user auth and an `identify` call was added: "Confirm the returning-visitor path also calls `identify` — a handler that only identifies on fresh login can leave returning sessions on anonymous distinct IDs."
+
+Do not invent items beyond what applies. If only the two "Always" items apply, the checklist is just those two.
+
+Then mirror the report into a shareable PostHog notebook so the user has an in-app copy to link and comment on. Call `notebooks-create` with a `title` (e.g. `PostHog setup (wizard) – <repo_name>`) and `content` set to a single markdown node wrapping the report verbatim — `{"type":"doc","content":[{"type":"ph-markdown-notebook","attrs":{"nodeId":"markdown-notebook-v2","markdown":"<the full contents of posthog-setup-report.md>"}}]}`. Take the `short_id` from the response, build the notebook URL as `<host>/project/<project_id>/notebooks/<short_id>`, and emit it on its own line so the wizard can surface it: `[NOTEBOOK_URL]` followed by that URL. Keep the local `posthog-setup-report.md` — the notebook is an extra copy, not a replacement.
+
+Upon completion, update `.posthog-events.json` so it matches the events you actually implemented, then remove it with your file tools. If removal is blocked or fails in your environment, leave the file in place and move on — the wizard host cleans it up after the run. Do not retry the removal or reach for shell commands to force it.
+
+## Status
+
+Status to report in this phase:
+
+- Configured dashboard: [insert PostHog dashboard URL]
+- Created setup report: [insert full local file path]
+- Created notebook: [insert PostHog notebook URL]

--- a/.claude/skills/integration-ruby/references/COMMANDMENTS.md
+++ b/.claude/skills/integration-ruby/references/COMMANDMENTS.md
@@ -1,0 +1,10 @@
+# Framework rules
+
+Follow these when integrating PostHog into this framework.
+
+- posthog-ruby is the Ruby SDK gem name (add `gem 'posthog-ruby'` to Gemfile) but require it with `require 'posthog'` (NOT `require 'posthog-ruby'`)
+- Use PostHog::Client.new(api_key: key, host: host) for instance-based initialization in scripts and CLIs
+- In CLIs and scripts: MUST call client.shutdown before exit or all events are lost
+- Use begin/rescue/ensure with shutdown in the ensure block for proper cleanup
+- capture and identify take a single hash argument: client.capture(distinct_id: 'user_123', event: 'my_event', properties: { key: 'value' })
+- capture_exception takes POSITIONAL args (not keyword): client.capture_exception(exception, distinct_id, additional_properties) — do NOT use `distinct_id:` keyword syntax

--- a/.claude/skills/integration-ruby/references/EXAMPLE.md
+++ b/.claude/skills/integration-ruby/references/EXAMPLE.md
@@ -1,7 +1,6 @@
 # PostHog Ruby Example Project
 
-Repository: https://github.com/PostHog/context-mill
-Path: example-apps/ruby
+Repository: https://github.com/PostHog/context-mill Path: example-apps/ruby
 
 ---
 

--- a/.claude/skills/integration-ruby/references/EXAMPLE.md
+++ b/.claude/skills/integration-ruby/references/EXAMPLE.md
@@ -1,0 +1,452 @@
+# PostHog Ruby Example Project
+
+Repository: https://github.com/PostHog/context-mill
+Path: example-apps/ruby
+
+---
+
+## README.md
+
+# PostHog Ruby Example - CLI Todo App
+
+A simple command-line todo application built with plain Ruby (no frameworks) demonstrating PostHog integration for CLIs, scripts, data pipelines, and non-web Ruby applications.
+
+## Purpose
+
+This example serves as:
+- **Verification** that the context-mill wizard works for plain Ruby projects
+- **Reference implementation** of PostHog best practices for non-framework Ruby code
+- **Working example** you can run and modify
+
+## Features Demonstrated
+
+- **Instance-based API** - Uses `PostHog::Client.new(...)` for explicit client management
+- **Proper shutdown** - Uses `shutdown` in `ensure` block to flush events before exit
+- **Event tracking** - Captures user actions with `distinct_id` and properties
+- **User identification** - Associates properties with users via `identify`
+- **Error handling** - Manual exception capture for handled errors
+
+## Quick Start
+
+### 1. Install Dependencies
+
+```bash
+# Install bundler if needed
+gem install bundler
+
+# Install dependencies
+bundle install
+```
+
+### 2. Configure PostHog
+
+```bash
+# Copy environment template
+cp .env.example .env
+
+# Edit .env and add your PostHog project token
+# POSTHOG_PROJECT_TOKEN=phc_your_project_token_here
+# POSTHOG_HOST=https://us.i.posthog.com
+```
+
+### 3. Run the App
+
+```bash
+# Add a todo
+ruby todo.rb add "Buy groceries"
+
+# List all todos
+ruby todo.rb list
+
+# Complete a todo
+ruby todo.rb complete 1
+
+# Delete a todo
+ruby todo.rb delete 1
+
+# Show statistics
+ruby todo.rb stats
+```
+
+## What Gets Tracked
+
+The app tracks these events in PostHog:
+
+| Event | Properties | Purpose |
+|-------|-----------|---------|
+| `todo_added` | `todo_id`, `todo_length`, `total_todos` | When user adds a new todo |
+| `todos_viewed` | `total_todos`, `completed_todos` | When user lists todos |
+| `todo_completed` | `todo_id`, `time_to_complete_hours` | When user completes a todo |
+| `todo_deleted` | `todo_id`, `was_completed` | When user deletes a todo |
+| `stats_viewed` | `total_todos`, `completed_todos`, `pending_todos` | When user views stats |
+
+## Code Structure
+
+```
+basics/ruby/
+├── todo.rb              # Main CLI application
+├── Gemfile              # Ruby dependencies
+├── .env.example         # Environment variable template
+├── .gitignore           # Git ignore rules
+└── README.md            # This file
+```
+
+## Key Implementation Patterns
+
+### 1. Instance-Based Initialization
+
+```ruby
+require 'posthog-ruby'
+
+posthog = PostHog::Client.new(
+  api_key: api_key,
+  host: 'https://us.i.posthog.com',
+  on_error: proc { |status, msg| puts "PostHog error: #{status} - #{msg}" }
+)
+```
+
+### 2. Event Tracking Pattern
+
+```ruby
+# Track events with distinct_id
+posthog.capture(
+  distinct_id: 'user_123',
+  event: 'event_name',
+  properties: { key: 'value' }
+)
+```
+
+### 3. Proper Shutdown
+
+```ruby
+begin
+  # Your application code
+ensure
+  # Always call shutdown to flush events and close connections
+  posthog&.shutdown
+end
+```
+
+### 4. Identifying Users
+
+```ruby
+# Identify users (optional - adds user properties)
+posthog.identify(
+  distinct_id: 'user_123',
+  properties: { email: 'user@example.com', plan: 'pro' }
+)
+```
+
+## Running Without PostHog
+
+The app works fine without PostHog configured - it simply won't track analytics. You'll see a warning message but the app continues to function normally.
+
+## Next Steps
+
+- Modify `todo.rb` to experiment with PostHog tracking
+- Add new commands and track their usage
+- Explore feature flags: `posthog.is_feature_enabled('flag-name', 'user_id')`
+- Check your PostHog dashboard to see tracked events
+
+## Learn More
+
+- [PostHog Ruby SDK Documentation](https://posthog.com/docs/libraries/ruby)
+- [PostHog Product Analytics](https://posthog.com/docs/product-analytics)
+
+---
+
+## .env.example
+
+```example
+# PostHog Configuration
+POSTHOG_PROJECT_TOKEN=phc_your_project_token_here
+POSTHOG_HOST=https://us.i.posthog.com
+
+# Optional: Enable debug mode to see PostHog requests
+# POSTHOG_DEBUG=true
+
+```
+
+---
+
+## Gemfile
+
+```
+source 'https://rubygems.org'
+
+gem 'posthog-ruby', '~> 3.3'
+gem 'dotenv', '~> 3.0'
+
+```
+
+---
+
+## todo.rb
+
+```rb
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Simple CLI Todo App with PostHog Analytics
+#
+# A minimal plain Ruby CLI application demonstrating PostHog integration
+# for non-framework Ruby projects (CLIs, scripts, data pipelines, etc.).
+
+require 'json'
+require 'securerandom'
+require 'time'
+require 'dotenv/load'
+require 'posthog'
+
+# Data file location
+DATA_FILE = File.join(Dir.home, '.todo_app.json')
+
+def initialize_posthog
+  # Initialize PostHog with instance-based API.
+  # Returns PostHog client or nil if project token not configured.
+  project_token = ENV['POSTHOG_PROJECT_TOKEN']
+
+  unless project_token
+    puts 'WARNING: PostHog not configured (POSTHOG_PROJECT_TOKEN not set)'
+    puts '         App will work but analytics won\'t be tracked'
+    return nil
+  end
+
+  PostHog::Client.new(
+    api_key: project_token,
+    host: ENV.fetch('POSTHOG_HOST', 'https://us.i.posthog.com'),
+    on_error: proc { |status, msg| puts "PostHog error: #{status} - #{msg}" }
+  )
+end
+
+def get_user_id
+  # Get or create a user ID for this installation.
+  # Uses a UUID stored in the data file to represent this user.
+  if File.exist?(DATA_FILE)
+    data = JSON.parse(File.read(DATA_FILE))
+    return data['user_id'] if data['user_id']
+  end
+
+  "user_#{SecureRandom.hex(4)}"
+end
+
+def load_todos
+  # Load todos from disk.
+  return { 'user_id' => get_user_id, 'todos' => [] } unless File.exist?(DATA_FILE)
+
+  JSON.parse(File.read(DATA_FILE))
+end
+
+def save_todos(data)
+  # Save todos to disk.
+  File.write(DATA_FILE, JSON.pretty_generate(data))
+end
+
+def track_event(posthog, event_name, properties = {})
+  # Track an event with PostHog.
+  return unless posthog
+
+  posthog.capture(
+    distinct_id: get_user_id,
+    event: event_name,
+    properties: properties
+  )
+end
+
+def cmd_add(text, posthog)
+  # Add a new todo item.
+  data = load_todos
+
+  todo = {
+    'id' => data['todos'].length + 1,
+    'text' => text,
+    'completed' => false,
+    'created_at' => Time.now.iso8601
+  }
+
+  data['todos'] << todo
+  save_todos(data)
+
+  puts "Added todo ##{todo['id']}: #{todo['text']}"
+
+  track_event(posthog, 'todo_added', {
+    'todo_id' => todo['id'],
+    'todo_length' => todo['text'].length,
+    'total_todos' => data['todos'].length
+  })
+end
+
+def cmd_list(posthog)
+  # List all todos.
+  data = load_todos
+
+  if data['todos'].empty?
+    puts "No todos yet! Add one with: ruby todo.rb add 'Your task'"
+    return
+  end
+
+  puts "\nYour Todos (#{data['todos'].length} total):\n\n"
+
+  data['todos'].each do |todo|
+    status = todo['completed'] ? 'X' : ' '
+    puts "  [#{status}] ##{todo['id']}: #{todo['text']}"
+  end
+
+  puts
+
+  track_event(posthog, 'todos_viewed', {
+    'total_todos' => data['todos'].length,
+    'completed_todos' => data['todos'].count { |t| t['completed'] }
+  })
+end
+
+def cmd_complete(id, posthog)
+  # Mark a todo as completed.
+  data = load_todos
+
+  todo = data['todos'].find { |t| t['id'] == id }
+
+  unless todo
+    puts "ERROR: Todo ##{id} not found"
+    return
+  end
+
+  if todo['completed']
+    puts "Todo ##{id} is already completed"
+    return
+  end
+
+  todo['completed'] = true
+  todo['completed_at'] = Time.now.iso8601
+  save_todos(data)
+
+  puts "Completed todo ##{todo['id']}: #{todo['text']}"
+
+  time_to_complete = (Time.parse(todo['completed_at']) - Time.parse(todo['created_at'])) / 3600.0
+
+  track_event(posthog, 'todo_completed', {
+    'todo_id' => todo['id'],
+    'time_to_complete_hours' => time_to_complete
+  })
+end
+
+def cmd_delete(id, posthog)
+  # Delete a todo.
+  data = load_todos
+
+  todo = data['todos'].find { |t| t['id'] == id }
+
+  unless todo
+    puts "ERROR: Todo ##{id} not found"
+    return
+  end
+
+  data['todos'].delete(todo)
+  save_todos(data)
+
+  puts "Deleted todo ##{id}"
+
+  track_event(posthog, 'todo_deleted', {
+    'todo_id' => todo['id'],
+    'was_completed' => todo['completed']
+  })
+end
+
+def cmd_stats(posthog)
+  # Show usage statistics.
+  data = load_todos
+
+  total = data['todos'].length
+  completed = data['todos'].count { |t| t['completed'] }
+  pending = total - completed
+
+  puts "\nStats:\n\n"
+  puts "  Total todos:     #{total}"
+  puts "  Completed:       #{completed}"
+  puts "  Pending:         #{pending}"
+  puts "  Completion rate: #{total > 0 ? format('%.1f', completed.to_f / total * 100) : '0.0'}%"
+  puts
+
+  track_event(posthog, 'stats_viewed', {
+    'total_todos' => total,
+    'completed_todos' => completed,
+    'pending_todos' => pending
+  })
+end
+
+def print_usage
+  puts <<~USAGE
+    Simple todo app with PostHog analytics
+
+    Usage:
+      ruby todo.rb add "Todo text"    Add a new todo
+      ruby todo.rb list               List all todos
+      ruby todo.rb complete <id>      Mark todo as completed
+      ruby todo.rb delete <id>        Delete a todo
+      ruby todo.rb stats              Show statistics
+  USAGE
+end
+
+# Main entry point
+posthog = nil
+
+begin
+  posthog = initialize_posthog
+
+  command = ARGV[0]
+
+  unless command
+    print_usage
+    exit 0
+  end
+
+  case command
+  when 'add'
+    text = ARGV[1]
+    unless text
+      puts 'ERROR: Please provide todo text'
+      puts 'Usage: ruby todo.rb add "Your task"'
+      exit 1
+    end
+    cmd_add(text, posthog)
+  when 'list'
+    cmd_list(posthog)
+  when 'complete'
+    id = ARGV[1]&.to_i
+    unless id && id > 0
+      puts 'ERROR: Please provide a valid todo ID'
+      puts 'Usage: ruby todo.rb complete <id>'
+      exit 1
+    end
+    cmd_complete(id, posthog)
+  when 'delete'
+    id = ARGV[1]&.to_i
+    unless id && id > 0
+      puts 'ERROR: Please provide a valid todo ID'
+      puts 'Usage: ruby todo.rb delete <id>'
+      exit 1
+    end
+    cmd_delete(id, posthog)
+  when 'stats'
+    cmd_stats(posthog)
+  else
+    puts "ERROR: Unknown command '#{command}'"
+    print_usage
+    exit 1
+  end
+rescue StandardError => e
+  puts "ERROR: #{e.message}"
+
+  # Manually capture handled errors
+  posthog&.capture_exception(e, get_user_id)
+
+  exit 1
+ensure
+  # IMPORTANT: Always shutdown PostHog to flush events
+  posthog&.shutdown
+end
+
+```
+
+---
+

--- a/.claude/skills/integration-ruby/references/identify-users.md
+++ b/.claude/skills/integration-ruby/references/identify-users.md
@@ -1,0 +1,272 @@
+# Identify users - Docs
+
+Linking events to specific users enables you to build a full picture of how they're using your product across different sessions, devices, and platforms.
+
+This is straightforward to do when [capturing backend events](/docs/product-analytics/capture-events?tab=Node.js.md), as you associate events to a specific user using a `distinct_id`, which is a required argument.
+
+However, in the frontend of a [web](/docs/libraries/js/features.md#capturing-events) or [mobile app](/docs/libraries/ios.md#capturing-events), a `distinct_id` is not a required argument — PostHog's SDKs will generate an anonymous `distinct_id` for you automatically and you can capture events anonymously, provided you use the appropriate [configuration](/docs/libraries/js/features.md#capturing-anonymous-events).
+
+To link events to specific users, call `identify`:
+
+PostHog AI
+
+### Web
+
+```javascript
+posthog.identify(
+  'distinct_id',  // Replace 'distinct_id' with your user's unique identifier
+  { email: 'max@hedgehogmail.com', name: 'Max Hedgehog' } // optional: set additional person properties
+);
+```
+
+### Android
+
+```kotlin
+PostHog.identify(
+    distinctId = distinctID, // Replace 'distinctID' with your user's unique identifier
+    // optional: set additional person properties
+    userProperties = mapOf(
+        "name" to "Max Hedgehog",
+        "email" to "max@hedgehogmail.com"
+    )
+)
+```
+
+### iOS
+
+```swift
+PostHogSDK.shared.identify("distinct_id", // Replace "distinct_id" with your user's unique identifier
+                           userProperties: ["name": "Max Hedgehog", "email": "max@hedgehogmail.com"]) // optional: set additional person properties
+```
+
+### React Native
+
+```jsx
+posthog.identify('distinct_id', { // Replace "distinct_id" with your user's unique identifier
+    email: 'max@hedgehogmail.com', // optional: set additional person properties
+    name: 'Max Hedgehog'
+})
+```
+
+### Dart
+
+```dart
+await Posthog().identify(
+  userId: 'distinct_id', // Replace "distinct_id" with your user's unique identifier
+  userProperties: {
+    'email': 'max@hedgehogmail.com', // optional: set additional person properties
+    'name': 'Max Hedgehog',
+  },
+);
+```
+
+Events captured after calling `identify` are identified events and this creates a person profile if one doesn't exist already.
+
+Due to the cost of processing them, anonymous events can be up to 4x cheaper than identified events, so it's recommended you only capture identified events when needed.
+
+## How identify works
+
+When a user starts browsing your website or app, PostHog automatically assigns them an **anonymous ID**, which is stored locally.
+
+Provided you've [configured persistence](/docs/libraries/js/persistence.md) to use cookies or `localStorage`, this enables us to track anonymous users – even across different sessions.
+
+By calling `identify` with a `distinct_id` of your choice (usually the user's ID in your database, or their email), you link the anonymous ID and distinct ID together.
+
+Thus, all past and future events made with that anonymous ID are now associated with the distinct ID.
+
+This enables you to do things like associate events with a user from before they log in for the first time, or associate their events across different devices or platforms.
+
+Using identify in the backend
+
+Although you can call `identify` using our backend SDKs, it is used most in frontends. This is because there is no concept of anonymous sessions in the backend SDKs, so calling `identify` only updates person profiles.
+
+## Best practices when using `identify`
+
+### 1\. Call `identify` as soon as you're able to
+
+In your frontend, you should call `identify` as soon as you're able to.
+
+Typically, this is every time your **app loads** for the first time, and directly after your **users log in**.
+
+This ensures that events sent during your users' sessions are correctly associated with them.
+
+You only need to call `identify` once per session, and you should avoid calling it multiple times unnecessarily.
+
+If you call `identify` multiple times with the same data without reloading the page in between, PostHog will ignore the subsequent calls.
+
+### 2\. Use unique strings for distinct IDs
+
+If two users have the same distinct ID, their data is merged and they are considered one user in PostHog. Two common ways this can happen are:
+
+-   Your logic for generating IDs does not generate sufficiently strong IDs and you can end up with a clash where 2 users have the same ID.
+-   There's a bug, typo, or mistake in your code leading to most or all users being identified with generic IDs like `null`, `true`, or `distinctId`.
+
+PostHog also has built-in protections to stop the most common distinct ID mistakes.
+
+### 3\. Reset after logout
+
+If a user logs out on your frontend, you should call `reset()` to unlink any future events made on that device with that user.
+
+This is important if your users are sharing a computer, as otherwise all of those users are grouped together into a single user due to shared cookies between sessions.
+
+**We strongly recommend you call `reset` on logout even if you don't expect users to share a computer.**
+
+You can do that like so:
+
+PostHog AI
+
+### Web
+
+```javascript
+posthog.reset()
+```
+
+### iOS
+
+```swift
+PostHogSDK.shared.reset()
+```
+
+### Android
+
+```kotlin
+PostHog.reset()
+```
+
+### React Native
+
+```jsx
+posthog.reset()
+```
+
+### Dart
+
+```dart
+await Posthog().reset();
+```
+
+If you *also* want to reset the `device_id` so that the device will be considered a new device in future events, you can pass `true` as an argument:
+
+Web
+
+PostHog AI
+
+```javascript
+posthog.reset(true)
+```
+
+### 4\. Person profiles and properties
+
+You'll notice that one of the parameters in the `identify` method is a `properties` object.
+
+This enables you to set [person properties](/docs/product-analytics/person-properties.md).
+
+Whenever possible, we recommend passing in all person properties you have available each time you call identify, as this ensures their person profile on PostHog is up to date.
+
+Person properties can also be set being adding a `$set` property to a event `capture` call.
+
+See our [person properties docs](/docs/product-analytics/person-properties.md) for more details on how to work with them and best practices.
+
+### 5\. Use deep links between platforms
+
+We recommend you call `identify` [as soon as you're able](#1-call-identify-as-soon-as-youre-able), typically when a user signs up or logs in.
+
+This doesn't work if one or both platforms are unauthenticated. Some examples of such cases are:
+
+-   Onboarding and signup flows before authentication.
+-   Unauthenticated web pages redirecting to authenticated mobile apps.
+-   Authenticated web apps prompting an app download.
+
+In these cases, you can use a [deep link](https://developer.android.com/training/app-links/deep-linking) on Android and [universal links](https://developer.apple.com/documentation/xcode/supporting-universal-links-in-your-app) on iOS to identify users.
+
+1.  Use `posthog.get_distinct_id()` to get the current distinct ID. Even if you cannot call identify because the user is unauthenticated, this will return an anonymous distinct ID generated by PostHog.
+2.  Add the distinct ID to the deep link as query parameters, along with other properties like UTM parameters.
+3.  When the user is redirected to the app, parse the deep link and handle the following cases:
+
+-   The mobile app is already authenticated. In this case, call [`posthog.alias()`](/docs/libraries/js/features.md#alias) with the distinct ID from the web. This associates the two distinct IDs as a single person.
+-   The mobile app is unauthenticated. In this case, call [`posthog.identify()`](/docs/libraries/js/features.md#identifying-users) with the distinct ID from the web so pre-login mobile events stay connected to the web session. When the user later logs in on mobile, call `identify()` again with your canonical user ID.
+
+As long as you associate the distinct IDs with `posthog.identify()` or `posthog.alias()`, you can track events generated across platforms.
+
+Here's an example implementation for handling deep links from web to mobile:
+
+PostHog AI
+
+### iOS
+
+```swift
+import PostHog
+class DeepLinkIdentityManager {
+    static let shared = DeepLinkIdentityManager()
+    // MARK: - Deep Link Received
+    func handleDeepLink(_ url: URL, isAuthenticatedOnMobile: Bool) {
+        guard let webDistinctId = URLComponents(url: url, resolvingAgainstBaseURL: true)?
+            .queryItems?.first(where: { $0.name == "ph_distinct_id" })?.value else {
+            return
+        }
+        if isAuthenticatedOnMobile {
+            // The mobile app already knows the current user.
+            // Alias the incoming web distinct ID to that user.
+            PostHogSDK.shared.alias(webDistinctId)
+        } else {
+            // Reuse the web distinct ID until login on mobile.
+            PostHogSDK.shared.identify(webDistinctId)
+        }
+    }
+    // MARK: - Login/Signup
+    func handleLogin(canonicalUserId: String) {
+        // Switch from the web distinct ID (or a mobile anon ID)
+        // to your canonical user ID.
+        PostHogSDK.shared.identify(canonicalUserId)
+        // Set user properties, track signup event, etc.
+    }
+    func handleLogout() {
+        PostHogSDK.shared.reset()
+    }
+}
+```
+
+### Android
+
+```kotlin
+import android.net.Uri
+import com.posthog.PostHog
+object DeepLinkIdentityManager {
+    // Deep Link Received
+    fun handleDeepLink(uri: Uri, isAuthenticatedOnMobile: Boolean) {
+        val webDistinctId = uri.getQueryParameter("ph_distinct_id") ?: return
+        if (isAuthenticatedOnMobile) {
+            // The mobile app already knows the current user.
+            // Alias the incoming web distinct ID to that user.
+            PostHog.alias(webDistinctId)
+        } else {
+            // Reuse the web distinct ID until login on mobile.
+            PostHog.identify(webDistinctId)
+        }
+    }
+    // Login/Signup
+    fun handleLogin(canonicalUserId: String) {
+        // Switch from the web distinct ID (or a mobile anon ID)
+        // to your canonical user ID.
+        PostHog.identify(canonicalUserId)
+        // Set user properties, track signup event, etc.
+    }
+    fun handleLogout() {
+        PostHog.reset()
+    }
+}
+```
+
+## Further reading
+
+-   [Identifying users docs](/docs/product-analytics/identify.md)
+-   [How person processing works](/docs/how-posthog-works/ingestion-pipeline.md#2-person-processing)
+-   [An introductory guide to identifying users in PostHog](/tutorials/identifying-users-guide.md)
+
+### Community questions
+
+Ask a question
+
+### Was this page useful?
+
+HelpfulCould be better

--- a/.claude/skills/integration-ruby/references/ruby.md
+++ b/.claude/skills/integration-ruby/references/ruby.md
@@ -1,0 +1,759 @@
+# Ruby - Docs
+
+The `posthog-ruby` library provides tracking functionality on the server-side for applications built in Ruby.
+
+It uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your web app or other server-side application that needs performance.
+
+> **Use a single client instance (singleton)** — Create the PostHog client once and reuse it throughout your application. Multiple client instances with the same API key can cause dropped events and inconsistent behavior. The SDK logs a warning if it detects multiple instances.
+
+## Installation
+
+Add this to your `Gemfile`:
+
+Terminal
+
+PostHog AI
+
+```bash
+gem "posthog-ruby"
+```
+
+In your app, set your API key **before** making any calls. If setting a custom `host`, make sure to include the protocol (e.g. `https://`).
+
+Ruby
+
+PostHog AI
+
+```ruby
+require 'posthog'
+posthog = PostHog::Client.new({
+  api_key: "<ph_project_token>",
+  host: "https://us.i.posthog.com",
+  on_error: Proc.new { |status, msg| print msg }
+})
+```
+
+You can find your project token and instance address in the [project settings](https://app.posthog.com/project/settings) page in PostHog.
+
+## Configuration
+
+Initialize the client with your project token before making any calls:
+
+Ruby
+
+PostHog AI
+
+```ruby
+require 'posthog'
+posthog = PostHog::Client.new({
+  api_key: '<ph_project_token>',
+  host: 'https://us.i.posthog.com',
+  on_error: Proc.new { |status, msg| print msg }
+})
+```
+
+Available client options:
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| api_key | String | required | Your PostHog project token. |
+| host | String | https://us.i.posthog.com | Fully qualified PostHog API host. Include the protocol, for example https://us.i.posthog.com or https://eu.i.posthog.com. |
+| personal_api_key | String | nil | Personal API key. Required for local feature flag evaluation and remote config payloads. |
+| max_queue_size | Integer | 10000 | Maximum number of events to keep in the async queue before dropping new events. |
+| batch_size | Integer | 100 | Maximum number of events to send in one async batch. |
+| test_mode | Boolean | false | Keep events queued and do not send them. Useful for tests. |
+| sync_mode | Boolean | false | Send events synchronously on the calling thread. Useful in forking environments like Sidekiq and Resque. |
+| on_error | Proc | no-op | Callback called as on_error.call(status, error) for API or serialization errors. |
+| feature_flags_polling_interval | Integer | 30 | Seconds between local feature flag definition polls. |
+| feature_flag_request_timeout_seconds | Integer | 3 | Timeout, in seconds, for feature flag requests. |
+| before_send | Proc | nil | Callback that receives the event hash before it is queued or sent. Return a modified event hash, or nil to drop the event. |
+| disable_singleton_warning | Boolean | false | Suppress warnings about multiple clients with the same API key. Use only when you intentionally need multiple clients. |
+| skip_ssl_verification | Boolean | false | Disable SSL certificate verification. Intended only for local development or custom deployments. |
+| flag_definition_cache_provider | Object | nil | Provider for distributed feature flag definition caching. See [distributed flag definition caching](#distributed-flag-definition-caching). |
+
+### Filtering or modifying events before sending
+
+Use `before_send` to add, modify, or drop events immediately before the SDK queues or sends them:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog = PostHog::Client.new({
+  api_key: '<ph_project_token>',
+  before_send: Proc.new do |event|
+    event[:properties] ||= {}
+    event[:properties]['environment'] = ENV['RACK_ENV']
+    # Return nil to drop the event
+    event[:properties]['internal_user'] == true ? nil : event
+  end
+})
+```
+
+### Flushing and shutting down
+
+For short-lived scripts, call `flush` before the process exits. Call `shutdown` when your application is stopping to flush pending events and stop background resources.
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.capture({ distinct_id: 'user_123', event: 'script_finished' })
+posthog.flush
+posthog.shutdown
+```
+
+## Identifying users
+
+> **Identifying users is required.** Backend events need a `distinct_id` that matches the ID your frontend uses when calling `posthog.identify()`. Without this, backend events are orphaned — they can't be linked to frontend event captures, [session replays](/docs/session-replay.md), [LLM traces](/docs/ai-engineering.md), or [error tracking](/docs/error-tracking.md).
+>
+> See our guide on [identifying users](/docs/getting-started/identify-users.md) for how to set this up.
+
+Identify a user and set their person properties with `identify`:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.identify({
+  distinct_id: 'distinct_id_of_your_user',
+  properties: {
+    email: 'john@doe.com',
+    pro_user: false
+  }
+})
+```
+
+## Capturing events
+
+You can send custom events using `capture`:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.capture({
+    distinct_id: 'distinct_id_of_the_user',
+    event: 'user_signed_up'
+})
+```
+
+> **Tip:** We recommend using a `[object] [verb]` format for your event names, where `[object]` is the entity that the behavior relates to, and `[verb]` is the behavior itself. For example, `project created`, `user signed up`, or `invite sent`.
+
+### Setting event properties
+
+Optionally, you can include additional information with the event by including a [properties](/docs/data/events.md#event-properties) object:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.capture({
+    distinct_id: 'distinct_id_of_the_user',
+    event: 'user_signed_up',
+    properties: {
+        login_type: 'email',
+        is_free_trial: true
+    }
+})
+```
+
+### Sending pageviews
+
+If you're aiming for a backend-only implementation of PostHog and won't be capturing events from your frontend, you can send `pageviews` from your backend like so:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.capture({
+    distinct_id: 'distinct_id_of_the_user',
+    event: '$pageview',
+    properties: {
+        '$current_url': 'https://example.com'
+    }
+})
+```
+
+`capture` accepts these fields:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| distinct_id | String | The user ID. If omitted, framework integrations can provide request context; otherwise the SDK generates a UUID and marks the event as personless. |
+| event | String | Event name. Required. |
+| properties | Hash | Event properties. |
+| groups | Hash | Group analytics mapping from group type to group key. |
+| timestamp | Time | When the event occurred. Defaults to the current time. |
+| message_id | String | Optional message ID. |
+| uuid | String | Optional event UUID used for deduplication. Must be a valid UUID. |
+| flags | PostHog::FeatureFlagEvaluations | Snapshot returned by evaluate_flags. Adds $feature/<key> and $active_feature_flags properties without another /flags request. |
+| send_feature_flags | Boolean, Hash, or PostHog::SendFeatureFlagsOptions | Deprecated. Prefer passing flags: from evaluate_flags. |
+
+## Person profiles and properties
+
+The Ruby SDK captures identified events by default. These create [person profiles](/docs/data/persons.md). To set [person properties](/docs/data/user-properties.md) in these profiles, include them when capturing an event:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.capture({
+    distinct_id: 'distinct_id',
+    event: 'event_name',
+    properties: {
+        '$set': { name: 'Max Hedgehog' },
+        '$set_once': { initial_url: '/blog' }
+    }
+})
+```
+
+For more details on the difference between `$set` and `$set_once`, see our [person properties docs](/docs/data/user-properties.md#what-is-the-difference-between-set-and-set_once).
+
+To capture [anonymous events](/docs/data/anonymous-vs-identified-events.md) without person profiles, set the event's `$process_person_profile` property to `false`:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.capture({
+    distinct_id: 'distinct_id',
+    event: 'event_name',
+    properties: {
+        '$process_person_profile': false
+    }
+})
+```
+
+## Alias
+
+Sometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend.
+
+In this case, you can use `alias` to assign another distinct ID to the same user.
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.alias({
+  distinct_id: 'distinct_id',
+  alias: 'alias_id'
+})
+```
+
+We strongly recommend reading our docs on [alias](/docs/data/identify.md#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
+
+## Feature flags
+
+PostHog's [feature flags](/docs/feature-flags.md) enable you to safely deploy and roll back new features as well as target specific users and groups with them.
+
+There are two steps to implement feature flags in Ruby:
+
+### Step 1: Evaluate flags once
+
+Call `posthog.evaluate_flags()` once for the user, then read values from the returned snapshot.
+
+#### Boolean feature flags
+
+Ruby
+
+PostHog AI
+
+```ruby
+flags = posthog.evaluate_flags('distinct_id_of_your_user')
+if flags.enabled?('flag-key')
+    # Do something differently for this user
+    # Optional: fetch the payload
+    matched_flag_payload = flags.get_flag_payload('flag-key')
+end
+```
+
+#### Multivariate feature flags
+
+Ruby
+
+PostHog AI
+
+```ruby
+flags = posthog.evaluate_flags('distinct_id_of_your_user')
+enabled_variant = flags.get_flag('flag-key')
+if enabled_variant == 'variant-key' # replace 'variant-key' with the key of your variant
+    # Do something differently for this user
+    # Optional: fetch the payload
+    matched_flag_payload = flags.get_flag_payload('flag-key')
+end
+```
+
+`flags.get_flag()` returns the variant string for multivariate flags, `true` for enabled boolean flags, `false` for disabled flags, and `nil` when the flag wasn't returned by the evaluation.
+
+> **Note:** `posthog.is_feature_enabled()`, `posthog.get_feature_flag()`, `posthog.get_feature_flag_result()`, `posthog.get_feature_flag_payload()`, and `capture({ ..., send_feature_flags: true })` still work during the migration period, but they're deprecated. Prefer `evaluate_flags()` for new code.
+
+### Step 2: Include feature flag information when capturing events
+
+If you want use your feature flag to breakdown or filter events in your [insights](/docs/product-analytics/insights.md), you'll need to include feature flag information in those events. This ensures that the feature flag value is attributed correctly to the event.
+
+> **Note:** This step is only required for events captured using our server-side SDKs or [API](/docs/api.md).
+
+There are two methods you can use to include feature flag information in your events:
+
+#### Method 1: Pass the evaluated flags snapshot to `capture()`
+
+Pass the same `flags` object that you used for branching. This attaches the exact flag values from that evaluation and doesn't make another `/flags` request.
+
+Ruby
+
+PostHog AI
+
+```ruby
+flags = posthog.evaluate_flags('distinct_id_of_your_user')
+if flags.enabled?('flag-key')
+    # Do something differently for this user
+end
+posthog.capture({
+    distinct_id: 'distinct_id_of_your_user',
+    event: 'event_name',
+    flags: flags,
+})
+```
+
+By default, this attaches every flag in the snapshot using `$feature/<flag-key>` properties and `$active_feature_flags`.
+
+To reduce event property bloat, pass a filtered snapshot:
+
+Ruby
+
+PostHog AI
+
+```ruby
+# Attach only flags accessed with enabled?() or get_flag() before this call
+posthog.capture({
+    distinct_id: 'distinct_id_of_your_user',
+    event: 'event_name',
+    flags: flags.only_accessed,
+})
+# Attach only specific flags
+posthog.capture({
+    distinct_id: 'distinct_id_of_your_user',
+    event: 'event_name',
+    flags: flags.only(['checkout-flow', 'new-dashboard']),
+})
+```
+
+`only_accessed` is order-dependent. If you call it before accessing any flags with `enabled?()` or `get_flag()`, no feature flag properties are attached.
+
+#### Method 2: Include the `$feature/feature_flag_name` property manually
+
+In the event properties, include `$feature/feature_flag_name: variant_key`:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.capture({
+    distinct_id: 'distinct_id_of_your_user',
+    event: 'event_name',
+    properties: {
+        # Replace feature-flag-key with your flag key and 'variant-key' with the key of your variant
+        '$feature/feature-flag-key': 'variant-key',
+    },
+})
+```
+
+### Evaluating only specific flags
+
+By default, `evaluate_flags()` evaluates every flag for the user. If you only need a few flags, pass `flag_keys` to request only those flags:
+
+Ruby
+
+PostHog AI
+
+```ruby
+flags = posthog.evaluate_flags(
+    'distinct_id_of_your_user',
+    flag_keys: ['checkout-flow', 'new-dashboard'],
+)
+```
+
+### Evaluating locally only
+
+If you want to skip the remote `/flags` request and only use locally cached definitions, pass `only_evaluate_locally: true`:
+
+Ruby
+
+PostHog AI
+
+```ruby
+flags = posthog.evaluate_flags(
+    'distinct_id_of_your_user',
+    only_evaluate_locally: true,
+)
+```
+
+### Disabling GeoIP for flag evaluation
+
+Pass `disable_geoip: true` to disable GeoIP lookup for remote flag evaluation:
+
+Ruby
+
+PostHog AI
+
+```ruby
+flags = posthog.evaluate_flags(
+    'distinct_id_of_your_user',
+    disable_geoip: true,
+)
+```
+
+### Sending `$feature_flag_called` events
+
+Capturing `$feature_flag_called` events enables PostHog to know when a flag was accessed by a user and provide [analytics and insights](/docs/product-analytics/insights.md) on the flag. With `evaluate_flags()`, the SDK sends this event when you call `flags.enabled?()` or `flags.get_flag()` for a flag.
+
+The SDK deduplicates these events per `(distinct_id, flag, value)` in a local cache. If you reinitialize the PostHog client, the cache resets and `$feature_flag_called` events may be sent again. PostHog handles duplicates, so duplicate `$feature_flag_called` events don't affect your analytics.
+
+`flags.get_flag_payload()` doesn't send `$feature_flag_called` events and doesn't count as an access for `only_accessed`.
+
+### Advanced: Overriding server properties
+
+Sometimes, you may want to evaluate feature flags using [person properties](/docs/product-analytics/person-properties.md), [groups](/docs/product-analytics/group-analytics.md), or group properties that haven't been ingested yet, or were set incorrectly earlier.
+
+You can provide properties to evaluate the flag with by using the `person properties`, `groups`, and `group properties` arguments. PostHog will then use these values to evaluate the flag, instead of any properties currently stored on your PostHog server.
+
+For example:
+
+Ruby
+
+PostHog AI
+
+```ruby
+flags = posthog.evaluate_flags(
+    'distinct_id_of_the_user',
+    person_properties: {
+        property_name: 'value'
+    },
+    groups: {
+        your_group_type: 'your_group_id',
+        another_group_type: 'your_group_id',
+    },
+    group_properties: {
+        your_group_type: {
+            group_property_name: 'value'
+        },
+        another_group_type: {
+            group_property_name: 'value'
+        },
+    },
+)
+if flags.enabled?('flag-key')
+    # Do something differently for this user
+end
+```
+
+### Overriding GeoIP properties
+
+By default, a user's GeoIP properties are set using the IP address they use to capture events on the frontend. You may want to override the these properties when evaluating feature flags. A common reason to do this is when you're not using PostHog on your frontend, so the user has no GeoIP properties.
+
+You can override GeoIP properties by including them in the `person_properties` parameter when evaluating feature flags. This is useful when you're evaluating flags on your backend and want to use the client's location instead of your server's location.
+
+The following GeoIP properties can be overridden:
+
+-   `$geoip_country_code`
+-   `$geoip_country_name`
+-   `$geoip_city_name`
+-   `$geoip_city_confidence`
+-   `$geoip_continent_code`
+-   `$geoip_continent_name`
+-   `$geoip_latitude`
+-   `$geoip_longitude`
+-   `$geoip_postal_code`
+-   `$geoip_subdivision_1_code`
+-   `$geoip_subdivision_1_name`
+-   `$geoip_subdivision_2_code`
+-   `$geoip_subdivision_2_name`
+-   `$geoip_subdivision_3_code`
+-   `$geoip_subdivision_3_name`
+-   `$geoip_time_zone`
+
+Simply include any of these properties in the `person_properties` parameter alongside your other person properties when calling feature flags.
+
+### Request timeout
+
+You can configure the `feature_flag_request_timeout_seconds` parameter when initializing your PostHog client to set a flag request timeout. This helps prevent your code from being blocked if PostHog's servers are too slow to respond. By default, this is set to 3 seconds.
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog = PostHog::Client.new({
+    # rest of your configuration...
+    feature_flag_request_timeout_seconds: 3 # Time in seconds. Defaults to 3.
+})
+```
+
+### Legacy single-flag methods
+
+The following methods are still available during the migration period, but are deprecated. Prefer `evaluate_flags` for new code.
+
+| Method | Replacement |
+| --- | --- |
+| posthog.is_feature_enabled(flag_key, distinct_id, ...) | posthog.evaluate_flags(distinct_id, ...).enabled?(flag_key) |
+| posthog.get_feature_flag(flag_key, distinct_id, ...) | posthog.evaluate_flags(distinct_id, ...).get_flag(flag_key) |
+| posthog.get_feature_flag_payload(flag_key, distinct_id, ...) | posthog.evaluate_flags(distinct_id, ...).get_flag_payload(flag_key) |
+| posthog.get_feature_flag_result(flag_key, distinct_id, ...) | posthog.evaluate_flags(distinct_id, ...) and read get_flag / get_flag_payload |
+| posthog.capture({ ..., send_feature_flags: true }) | posthog.capture({ ..., flags: flags }) |
+
+### Local Evaluation
+
+Evaluating feature flags requires making a request to PostHog for each flag. However, you can improve performance by evaluating flags locally. Instead of making a request for each flag, PostHog will periodically request and store feature flag definitions locally, enabling you to evaluate flags without making additional requests.
+
+It is best practice to use local evaluation flags when possible, since this enables you to resolve flags faster and with fewer API calls.
+
+For details on how to implement local evaluation, see our [local evaluation guide](/docs/feature-flags/local-evaluation.md).
+
+#### Evaluating feature flags locally in unicorn server
+
+If you have `preload_app true` in your unicorn config, you can use the [`after_fork`](https://www.rubydoc.info/gems/unicorn/Unicorn%2FConfigurator:after_fork) hook (which is part of the unicorn's configuration) to enable the feature flag cache to receive the updates from PostHog.
+
+Ruby
+
+PostHog AI
+
+```ruby
+after_fork do |_server, _worker|
+  $posthog = PostHog::Client.new({
+    api_key: '<ph_project_token>',
+    personal_api_key: '<ph_personal_api_key>',
+    host: 'https://us.i.posthog.com',
+    on_error: Proc.new { |status, msg| print msg }
+  })
+end
+```
+
+#### Evaluating feature flags locally in a Puma server
+
+If you use Puma with multiple workers, you can use the `on_worker_boot` hook (which is part of Puma's configuration) to enable the feature flag cache to receive updates from PostHog.
+
+Ruby
+
+PostHog AI
+
+```ruby
+on_worker_boot do
+  $posthog = PostHog::Client.new({
+    api_key: '<ph_project_token>',
+    personal_api_key: '<ph_personal_api_key>',
+    host: 'https://us.i.posthog.com',
+    on_error: Proc.new { |status, msg| print msg }
+  })
+end
+```
+
+### Distributed flag definition caching
+
+`flag_definition_cache_provider` shares locally evaluated feature flag definitions across multiple workers or processes. The provider object must implement:
+
+-   `flag_definitions` – returns cached definitions as a hash with `:flags`, `:group_type_mapping`, and `:cohorts`, or `nil` if empty.
+-   `should_fetch_flag_definitions?` – returns `true` if this process should fetch fresh definitions from PostHog.
+-   `on_flag_definitions_received(data)` – stores freshly fetched definitions.
+-   `shutdown` – releases locks or other resources.
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog = PostHog::Client.new({
+  api_key: '<ph_project_token>',
+  personal_api_key: '<ph_personal_api_key>',
+  flag_definition_cache_provider: my_cache_provider
+})
+```
+
+### Remote config payloads
+
+Use `get_remote_config_payload` to fetch the decrypted remote config payload for a flag. This requires `personal_api_key`.
+
+Ruby
+
+PostHog AI
+
+```ruby
+payload = posthog.get_remote_config_payload('flag-key')
+```
+
+## Experiments (A/B tests)
+
+Since [experiments](/docs/experiments/start-here.md) use feature flags, the code for running an experiment is very similar to the feature flags code:
+
+Ruby
+
+PostHog AI
+
+```ruby
+flags = posthog.evaluate_flags('user_distinct_id')
+variant = flags.get_flag('experiment-feature-flag-key')
+if variant == 'variant-name'
+    # Do something
+end
+```
+
+It's also possible to [run experiments without using feature flags](/docs/experiments/running-experiments-without-feature-flags.md).
+
+## Group analytics
+
+Group analytics allows you to associate an event with a group (e.g. teams, organizations, etc.). Read the [Group Analytics](/docs/user-guides/group-analytics.md) guide for more information.
+
+> **Note:** This is a paid feature and is not available on the open-source or free cloud plan. Learn more on the [pricing page](/pricing.md).
+
+Capture an event and associate it with a group:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.capture({
+    distinct_id: 'distinct_id_of_the_user',
+    event: 'movie_played',
+    properties: {
+        movie_id: '123',
+        category: 'romcom'
+    },
+    groups: {
+        'company': 'company_id_in_your_db'
+    }
+})
+```
+
+Update properties on a group:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.group_identify({
+  group_type: 'company',
+  group_key: 'company_id_in_your_db',
+  properties: {
+    name: 'Awesome Inc.'
+  }
+})
+```
+
+The `name` is a special property which is used in the PostHog UI for the name of the group. If you don't specify a `name` property, the group ID will be used instead.
+
+If the optional `distinct_id` is not provided in the group identify call, it defaults to `$#{group_type}_#{group_key}` (e.g., `$company_company_id_in_your_db` in the example above). This default behavior will result in each group appearing as a separate person in PostHog. To avoid this, it's often more practical to use a consistent `distinct_id`, such as `group_identifier`.
+
+## Exception capture
+
+You can capture exceptions using the `posthog-ruby` library. This enables you to see stack traces and debug errors in your application. Learn more in our [error tracking docs](/docs/error-tracking/installation/ruby.md).
+
+**Using Rails?**
+
+The [posthog-rails](/docs/libraries/ruby-on-rails.md) gem provides automatic exception capture, ActiveJob instrumentation, and user context out of the box. See our [Rails error tracking guide](/docs/error-tracking/installation/ruby-on-rails.md) for details.
+
+For non-Rails Ruby applications, you can manually capture exceptions with `capture_exception`:
+
+Ruby
+
+PostHog AI
+
+```ruby
+begin
+  # Code that might raise an exception
+  raise StandardError, 'Something went wrong'
+rescue => e
+  posthog.capture_exception(
+    e,
+    'user_distinct_id',
+    {
+      custom_property: 'custom_value'
+    }
+  )
+end
+```
+
+The `capture_exception` method accepts the following parameters:
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| exception | Exception, String, or exception-like object | The exception to capture. Required. |
+| distinct_id | String | The distinct ID of the user. Optional; request context can provide a default, otherwise the SDK generates a UUID. |
+| additional_properties | Hash | Additional properties to attach to the exception event. Optional. |
+| flags | PostHog::FeatureFlagEvaluations | Optional keyword argument. Adds the same feature flag properties as capture({ flags: flags }). |
+
+You can also override the [fingerprint](/docs/error-tracking/fingerprints.md) to customize how exceptions are grouped into issues:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.capture_exception(
+  e,
+  'user_distinct_id',
+  {
+    '$exception_fingerprint': 'CustomExceptionGroup'
+  }
+)
+```
+
+## Debug mode
+
+The Ruby SDK logs warnings by default. You can change the log level to `DEBUG` to debug the client:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog.logger.level = Logger::DEBUG
+```
+
+You can also replace the SDK logger globally:
+
+Ruby
+
+PostHog AI
+
+```ruby
+PostHog::Logging.logger = Rails.logger
+```
+
+## Test helpers
+
+When `test_mode: true`, events remain queued. You can inspect and clear the queue in tests:
+
+Ruby
+
+PostHog AI
+
+```ruby
+posthog = PostHog::Client.new({ api_key: '<ph_project_token>', test_mode: true })
+posthog.capture({ distinct_id: 'user_123', event: 'test_event' })
+posthog.queued_messages
+posthog.dequeue_last_message
+posthog.clear
+```
+
+## Thank you
+
+This library is largely based on the `analytics-ruby` package.
+
+### Community questions
+
+Ask a question
+
+### Was this page useful?
+
+HelpfulCould be better

--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,11 @@ OPENAI_API_KEY=your-openai-api-key-here
 # Stability AI (alternative provider)
 # Get your key from: https://platform.stability.ai/
 STABILITY_API_KEY=your-stability-api-key-here
+
+# PostHog analytics (optional)
+# Used by the Ruby SEO/content scripts to capture run metrics. When unset,
+# the scripts skip analytics entirely and run exactly as before.
+# Project API key (starts with "phc_"): PostHog → Settings → Project → API keys
+POSTHOG_PROJECT_TOKEN=your-posthog-project-token-here
+# Host for your PostHog region (US cloud shown; EU is https://eu.i.posthog.com)
+POSTHOG_HOST=https://us.i.posthog.com

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,9 @@ end
 gem "ffi"
 gem 'webrick'
 
+# PostHog analytics
+gem 'posthog-ruby'
+
 # TODO: build a bootstrap plugin for jekyll
 
 #  bootstrap https://getbootstrap.com/docs/5.1/getting-started/introduction/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,6 +260,8 @@ GEM
       sawyer (~> 0.9)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    posthog-ruby (3.19.0)
+      concurrent-ruby (~> 1)
     prism (1.9.0)
     public_suffix (5.1.1)
     racc (1.8.1)
@@ -302,6 +304,7 @@ DEPENDENCIES
   ffi
   github-pages
   jekyll-include-cache
+  posthog-ruby
   webrick
 
 BUNDLED WITH

--- a/docs/setup/POSTHOG_ANALYTICS.md
+++ b/docs/setup/POSTHOG_ANALYTICS.md
@@ -1,0 +1,65 @@
+# PostHog Analytics for IT-Journey Scripts
+
+IT-Journey's Ruby SEO/content scripts optionally emit structured PostHog events
+on each run, so script activity and content health can be tracked over time. The
+integration uses the instance-based `PostHog::Client` API (from the
+`posthog-ruby` gem) and always calls `shutdown` in an `ensure` block so buffered
+events are flushed before the process exits.
+
+## Opt-in by design
+
+Every script reads its configuration from the environment at runtime — **no
+tokens are hardcoded**:
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `POSTHOG_PROJECT_TOKEN` | PostHog project API key (starts with `phc_`). | _unset_ |
+| `POSTHOG_HOST` | Ingestion host for your region. | `https://us.i.posthog.com` |
+
+When `POSTHOG_PROJECT_TOKEN` is **unset**, the scripts skip analytics entirely —
+no client is created, no network call is made, and behavior/exit codes are
+identical to before. This means CI without the secret runs unchanged; set the
+token (locally in `.env`, in CI as a secret) only where you want capture.
+
+See [`.env.example`](../../.env.example) for the variable stubs.
+
+## Events
+
+| Event | Fires when | File |
+|-------|------------|------|
+| `content_scan_completed` | A content freshness scan finishes — file counts, freshness breakdown, average age, computed health score. | [`scripts/validation/content-freshness-check.rb`](../../scripts/validation/content-freshness-check.rb) |
+| `ctr_report_generated` | A CTR/SEO report is generated — report type (`baseline`/`weekly`/`opportunities`/`json`) and whether it was saved. | [`scripts/validation/ctr-report-generator.rb`](../../scripts/validation/ctr-report-generator.rb) |
+| `gsc_csv_parsed` | A Google Search Console CSV export is parsed — page/query counts, total impressions, total clicks, average CTR. | [`scripts/validation/ctr-report-generator.rb`](../../scripts/validation/ctr-report-generator.rb) |
+| `frontmatter_validation_completed` | Frontmatter validation finishes — total/valid/invalid counts, error/warning totals, average SEO score, filter options. | [`scripts/validation/frontmatter-validator.rb`](../../scripts/validation/frontmatter-validator.rb) |
+| `statistics_generated` | Content statistics generation completes — post counts, category/tag/author counts, focus-area and content-type counts. | [`scripts/generation/generate_statistics.rb`](../../scripts/generation/generate_statistics.rb) |
+
+All events are captured with the `distinct_id` `it-journey-ci`.
+
+> **Note:** `statistics_generated` currently reports zeros because the blog
+> (`pages/_posts`) was removed in the quests-only overhaul; the instrumentation
+> is correct and will report real numbers if that script is revised to read the
+> quest collections.
+
+## Dashboards (PostHog project 517639)
+
+- [Analytics basics — Dashboard](https://us.posthog.com/project/517639/dashboard/1867288)
+- [Script runs over time](https://us.posthog.com/project/517639/insights/Kmt50zd0)
+- [Content health score trend](https://us.posthog.com/project/517639/insights/XZzhZ2Rd)
+- [Frontmatter validation quality](https://us.posthog.com/project/517639/insights/szOu5Gqt)
+- [CTR reports by type](https://us.posthog.com/project/517639/insights/dtzaeI6b)
+- [Content critical file rate](https://us.posthog.com/project/517639/insights/cpRzO8T8)
+
+## Verification
+
+The integration was verified end-to-end by pointing `POSTHOG_HOST` at a local
+mock ingestion server and running each script:
+
+- All five events fire with correct, well-typed properties.
+- With `POSTHOG_PROJECT_TOKEN` unset, no events are sent, no network call is
+  attempted, and exit codes are unchanged.
+- The event capture is placed **before** each script's `exit`, so events are not
+  lost when a script exits non-zero (e.g. content-freshness exiting `1` on
+  critical content).
+
+For further PostHog work in this repo, see the agent skill under
+[`.claude/skills/integration-ruby/`](../../.claude/skills/integration-ruby/).

--- a/docs/setup/POSTHOG_ANALYTICS.md
+++ b/docs/setup/POSTHOG_ANALYTICS.md
@@ -1,25 +1,17 @@
 # PostHog Analytics for IT-Journey Scripts
 
-IT-Journey's Ruby SEO/content scripts optionally emit structured PostHog events
-on each run, so script activity and content health can be tracked over time. The
-integration uses the instance-based `PostHog::Client` API (from the
-`posthog-ruby` gem) and always calls `shutdown` in an `ensure` block so buffered
-events are flushed before the process exits.
+IT-Journey's Ruby SEO/content scripts optionally emit structured PostHog events on each run, so script activity and content health can be tracked over time. The integration uses the instance-based `PostHog::Client` API (from the `posthog-ruby` gem) and always calls `shutdown` in an `ensure` block so buffered events are flushed before the process exits.
 
 ## Opt-in by design
 
-Every script reads its configuration from the environment at runtime — **no
-tokens are hardcoded**:
+Every script reads its configuration from the environment at runtime — **no tokens are hardcoded**:
 
 | Variable | Purpose | Default |
 |----------|---------|---------|
 | `POSTHOG_PROJECT_TOKEN` | PostHog project API key (starts with `phc_`). | _unset_ |
 | `POSTHOG_HOST` | Ingestion host for your region. | `https://us.i.posthog.com` |
 
-When `POSTHOG_PROJECT_TOKEN` is **unset**, the scripts skip analytics entirely —
-no client is created, no network call is made, and behavior/exit codes are
-identical to before. This means CI without the secret runs unchanged; set the
-token (locally in `.env`, in CI as a secret) only where you want capture.
+When `POSTHOG_PROJECT_TOKEN` is **unset**, the scripts skip analytics entirely — no client is created, no network call is made, and behavior/exit codes are identical to before. This means CI without the secret runs unchanged; set the token (locally in `.env`, in CI as a secret) only where you want capture.
 
 See [`.env.example`](../../.env.example) for the variable stubs.
 
@@ -51,15 +43,12 @@ All events are captured with the `distinct_id` `it-journey-ci`.
 
 ## Verification
 
-The integration was verified end-to-end by pointing `POSTHOG_HOST` at a local
-mock ingestion server and running each script:
+The integration was verified end-to-end by pointing `POSTHOG_HOST` at a local mock ingestion server and running each script:
 
 - All five events fire with correct, well-typed properties.
 - With `POSTHOG_PROJECT_TOKEN` unset, no events are sent, no network call is
   attempted, and exit codes are unchanged.
 - The event capture is placed **before** each script's `exit`, so events are not
-  lost when a script exits non-zero (e.g. content-freshness exiting `1` on
-  critical content).
+lost when a script exits non-zero (e.g. content-freshness exiting `1` on critical content).
 
-For further PostHog work in this repo, see the agent skill under
-[`.claude/skills/integration-ruby/`](../../.claude/skills/integration-ruby/).
+For further PostHog work in this repo, see the agent skill under [`.claude/skills/integration-ruby/`](../../.claude/skills/integration-ruby/).

--- a/pages/_quest-reports/2026-07-17-data-scientist-0011.md
+++ b/pages/_quest-reports/2026-07-17-data-scientist-0011.md
@@ -37,56 +37,28 @@ source_report: test/quest-validator/walkthroughs/2026-07-17-data-scientist-0011.
 
 ## 🎯 Session Summary
 
-I walked the full **Data Scientist · Level 0011 (AI-Assisted Development, 🌱 Apprentice)**
-slice — all **4** main quests the planner selected, in plan order — as a learner
-would, using the workflow-sealed execute-mode evidence plus a close read of each
-quest source. Headline: **warn — the slice is mostly usable, but it is not a clean
-linear path and it contains one hard, blocking failure.**
+I walked the full **Data Scientist · Level 0011 (AI-Assisted Development, 🌱 Apprentice)** slice — all **4** main quests the planner selected, in plan order — as a learner would, using the workflow-sealed execute-mode evidence plus a close read of each quest source. Headline: **warn — the slice is mostly usable, but it is not a clean linear path and it contains one hard, blocking failure.**
 
-Three quests hold up when their commands are actually run (Summon the Golem passes
-cleanly at 88; Hidden Gem and Prompt Crystal warn at 68/64 with fixable defects).
-The one that breaks a learner is **The PRD Codex (43, fail)**: its entire hands-on
-core hangs on `docker compose build prd-machine`, which the engine verified fails
-with *"no configuration file provided"* in any repo that doesn't already ship the
-PRD Machine tooling — and the quest never shows how to obtain that tooling. A
-maintainer's most valuable next action is to make PRD Codex self-contained (or
-gate it behind the repo it assumes); everything else in the slice is polish.
+Three quests hold up when their commands are actually run (Summon the Golem passes cleanly at 88; Hidden Gem and Prompt Crystal warn at 68/64 with fixable defects). The one that breaks a learner is **The PRD Codex (43, fail)**: its entire hands-on core hangs on `docker compose build prd-machine`, which the engine verified fails with *"no configuration file provided"* in any repo that doesn't already ship the PRD Machine tooling — and the quest never shows how to obtain that tooling. A maintainer's most valuable next action is to make PRD Codex self-contained (or gate it behind the repo it assumes); everything else in the slice is polish.
 
-Note on cohesion: these four quests share the `0011` level but belong to **four
-different quest series/lines** (The Ouroboros Loop, Documentation Mastery,
-Web Publishing, AI Development Mastery). This is a themed *bundle*, not a single
-authored chain — an important framing for the continuity findings below.
+Note on cohesion: these four quests share the `0011` level but belong to **four different quest series/lines** (The Ouroboros Loop, Documentation Mastery, Web Publishing, AI Development Mastery). This is a themed *bundle*, not a single authored chain — an important framing for the continuity findings below.
 
 ## 🗺️ The Journey
 
 Plan order (dependency-sorted by the planner):
 
 1. ✅ **Summon the Golem: An AI Agent Joins the Loop** — **88/100** (pass) ·
-   Drive headless Claude Code from GitHub Actions under a bounded role. Technically
-   tight: every CLI flag, env var, and Action version checked out; the gating/no-op
-   bash ran exactly as claimed. Only gaps are a missing env-wiring reference and no
-   answer key for the knowledge checks.
+Drive headless Claude Code from GitHub Actions under a bounded role. Technically tight: every CLI flag, env var, and Action version checked out; the gating/no-op bash ran exactly as claimed. Only gaps are a missing env-wiring reference and no answer key for the knowledge checks.
 2. ❌ **The PRD Codex: Master Product Reality Distillation** — **43/100** (fail) ·
-   The pivotal `docker compose build prd-machine` was verified to fail with *"no
-   configuration file provided"* — the quest never provides or points to the PRD
-   Machine tooling, so Chapters 2–3 and all four Challenges are unrunnable from the
-   document alone. **Blocking.**
+The pivotal `docker compose build prd-machine` was verified to fail with *"no configuration file provided"* — the quest never provides or points to the PRD Machine tooling, so Chapters 2–3 and all four Challenges are unrunnable from the document alone. **Blocking.**
 3. ⚠️ **Hidden Gem: Publish AI Chats on GitHub Pages** — **68/100** (warn) ·
-   Jekyll config, Gemfile, AI-chat post, and `bundle exec jekyll serve` genuinely
-   work; a Linux `bundle install` permission gotcha (no vendor-path/.gitignore
-   guidance) plus a wrong theme URL and a suspect extension ID drag accuracy down.
+Jekyll config, Gemfile, AI-chat post, and `bundle exec jekyll serve` genuinely work; a Linux `bundle install` permission gotcha (no vendor-path/.gitignore guidance) plus a wrong theme URL and a suspect extension ID drag accuracy down.
 4. ⚠️ **Forging the Prompt Crystal: VS Code Copilot Mastery** — **64/100** (warn) ·
-   Cross-platform scaffolding and both Mermaid diagrams run; but `{​% raw %​}` Jekyll
-   build artifacts leak into the `.prompt.md` templates, several prompt blocks are
-   mislabeled `javascript` and error as JS, and the Windows/Cloud setup silently
-   overwrites an existing `copilot-instructions.md`.
+Cross-platform scaffolding and both Mermaid diagrams run; but `{​% raw %​}` Jekyll build artifacts leak into the `.prompt.md` templates, several prompt blocks are mislabeled `javascript` and error as JS, and the Windows/Cloud setup silently overwrites an existing `copilot-instructions.md`.
 
 ## 🔬 Evidence
 
-All results are from **execute mode** (`walk-evidence.json`, sealed by the
-workflow — I consumed it as-is and did not re-run the engine). Snippet counts are
-`ran / passed / failed / skipped / reasoned`. Dimension scores are on the 1–5
-rubric (commands_work, content_accuracy, completeness, clarity, structure, safety).
+All results are from **execute mode** (`walk-evidence.json`, sealed by the workflow — I consumed it as-is and did not re-run the engine). Snippet counts are `ran / passed / failed / skipped / reasoned`. Dimension scores are on the 1–5 rubric (commands_work, content_accuracy, completeness, clarity, structure, safety).
 
 ### 1. Summon the Golem — 88 ✅ (5/5 passed, 1 skipped, 2 reasoned)
 Dimensions: commands_work 4 · content_accuracy 5 · completeness 4 · clarity 4 · structure 5 · safety 5
@@ -94,32 +66,23 @@ Dimensions: commands_work 4 · content_accuracy 5 · completeness 4 · clarity 4
 - **passed** — Composite `action.yml` and the workflow step YAML fragments parse
   cleanly with pyyaml (no syntax errors).
 - **passed** — The no-auth guard `if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then …
-  exit 0; fi` was extracted and run with the var unset: it printed the `::warning::`
-  line and exited 0, exactly as the quest claims ("No auth = exit 0 with a warning").
+exit 0; fi` was extracted and run with the var unset: it printed the `::warning::` line and exited 0, exactly as the quest claims ("No auth = exit 0 with a warning").
 - **passed** — The gate logic (`go=false; if [ "$ENABLED" = "true" ] && [ -n
-  "$OAUTH" ]; then go=true; fi`) tested across all 4 ENABLED/OAUTH combinations —
-  arms only when both true, matching stated intent.
+"$OAUTH" ]; then go=true; fi`) tested across all 4 ENABLED/OAUTH combinations — arms only when both true, matching stated intent.
 - **passed** — Mermaid quest-network diagram compiled to valid SVG.
 - **reasoned** — `claude -p … --append-system-prompt … --allowedTools … --permission-mode
-  acceptEdits`, `npm install -g @anthropic-ai/claude-code`, `claude setup-token` are
-  all valid/current commands (verified against docs, not executed end-to-end — a full
-  CI run needs a real repo + secret).
+acceptEdits`, `npm install -g @anthropic-ai/claude-code`, `claude setup-token` are all valid/current commands (verified against docs, not executed end-to-end — a full CI run needs a real repo + secret).
 - **skipped** — `.claude/agents/potion-scribe.md` role file (markdown, nothing to run).
 
 ### 2. The PRD Codex — 43 ❌ (13 ran: 5 passed, 8 failed, 2 skipped, 4 reasoned)
 Dimensions: commands_work 1 · content_accuracy 2 · completeness 2 · clarity 3 · structure 4 · safety 4
 
 - **failed** — Cloud Realms path `cd /workspaces/it-journey; docker compose build
-  prd-machine; …` — build fails: *"no configuration file provided: not found"*. The
-  same `docker compose build prd-machine` recurs at source lines 182, 208, 234, 249
-  across the macOS / Linux / Cloud paths; none can succeed without pre-existing
-  tooling the quest never supplies.
+prd-machine; …` — build fails: *"no configuration file provided: not found"*. The same `docker compose build prd-machine` recurs at source lines 182, 208, 234, 249 across the macOS / Linux / Cloud paths; none can succeed without pre-existing tooling the quest never supplies.
 - **failed** — All downstream `docker compose run --rm prd-machine …/prd-machine sync`
-  (incl. `--days 7`, `--output /tmp/custom-prd.md`), `status`, `conflicts`, and the
-  "Quick Win Checkpoint" sequence — every one fails because the container never built.
+(incl. `--days 7`, `--output /tmp/custom-prd.md`), `status`, `conflicts`, and the "Quick Win Checkpoint" sequence — every one fails because the container never built.
 - **failed** — macOS and Linux path bash blocks (`docker --version; … cd
-  /path/to/your/repository; cd ~/github/it-journey; …`) error as written (contradictory
-  back-to-back `cd`s, unbuildable target).
+/path/to/your/repository; cd ~/github/it-journey; …`) error as written (contradictory back-to-back `cd`s, unbuildable target).
 - **failed** — "Best Practices for Commit Signals" block (~line 384) is fenced
   ```bash``` but is commit-message prose; run as bash it throws *"syntax error near
   unexpected token 'auth'"*.
@@ -217,73 +180,34 @@ a command the engine actually ran or an exact line in the quest source.)
 
 ## 🔗 Chain Continuity
 
-**This slice is a level bundle, not a single authored chain.** The four quests carry
-four different `quest_series`: *The Ouroboros Loop* (Golem), *Documentation Mastery*
-(PRD Codex), *Web Publishing* (Hidden Gem), *AI Development Mastery* (Prompt Crystal).
-A Data Scientist arriving at 0011 is not walking one story — they're picking among
-parallel AI-assisted-development tracks. Judged that way, the *theme* coheres
-(everything is about wielding AI tooling), but the *narrative* does not.
+**This slice is a level bundle, not a single authored chain.** The four quests carry four different `quest_series`: *The Ouroboros Loop* (Golem), *Documentation Mastery* (PRD Codex), *Web Publishing* (Hidden Gem), *AI Development Mastery* (Prompt Crystal). A Data Scientist arriving at 0011 is not walking one story — they're picking among parallel AI-assisted-development tracks. Judged that way, the *theme* coheres (everything is about wielding AI tooling), but the *narrative* does not.
 
 Prerequisite reality for a learner walking in plan order:
 
 - **Golem** assumes "your potion-book repository with the Warden's Gate in place"
-  (Chapters I–II of the Ouroboros Loop, which live at level **0101** — outside this
-  slice) *and* a `claude setup-token` OAuth token. Its `quest_dependencies.required_quests`
-  is empty, so nothing in-slice or in-frontmatter surfaces that gate. A learner who
-  starts here cold has no gated loop to attach the golem to — the quest teaches the
-  agent well in isolation, but its assumed repo state is unmet by the slice.
+(Chapters I–II of the Ouroboros Loop, which live at level **0101** — outside this slice) *and* a `claude setup-token` OAuth token. Its `quest_dependencies.required_quests` is empty, so nothing in-slice or in-frontmatter surfaces that gate. A learner who starts here cold has no gated loop to attach the golem to — the quest teaches the agent well in isolation, but its assumed repo state is unmet by the slice.
 - **PRD Codex** `unlocks_quests` explicitly lists **prompt-crystal** and **github-pages** —
-  the only real intra-slice dependency edge, and the planner honored it by ordering
-  PRD before those two. But PRD is exactly the quest that *fails*: its Docker core is
-  unrunnable, so the "unlock" is hollow — a learner following the intended order hits a
-  wall on quest 2 and cannot legitimately complete it before moving on. The good news:
-  Hidden Gem and Prompt Crystal don't actually consume any artifact PRD produces, so the
-  wall is a motivation/credential break, not a hard technical block on quests 3–4.
+the only real intra-slice dependency edge, and the planner honored it by ordering PRD before those two. But PRD is exactly the quest that *fails*: its Docker core is unrunnable, so the "unlock" is hollow — a learner following the intended order hits a wall on quest 2 and cannot legitimately complete it before moving on. The good news: Hidden Gem and Prompt Crystal don't actually consume any artifact PRD produces, so the wall is a motivation/credential break, not a hard technical block on quests 3–4.
 - **Hidden Gem** requires `/quests/0000/hello-noob/` (an earlier level — reasonable and
-  met by normal progression) and is the gentlest, most self-contained entry (🟢 Easy) —
-  arguably the best *first* quest for a newcomer to this level, ahead of the Medium ones.
+met by normal progression) and is the gentlest, most self-contained entry (🟢 Easy) — arguably the best *first* quest for a newcomer to this level, ahead of the Medium ones.
 - **Prompt Crystal** requires `/quests/0010/prompt-engineering-mastery/` (prior level).
   It stands alone fine; its defects are content-quality, not continuity.
 
-**Ordering observation for a maintainer:** as a *learning* path for a Data Scientist,
-Hidden Gem (Easy, self-contained) → Prompt Crystal (prompt skills) → Golem (agent in CI,
-but flag the 0101 Warden's-Gate prerequisite) is a smoother ramp than the current
-dependency-sort, and PRD Codex should be treated as *not yet walkable* until its tooling
-bootstrap is added. No quest in the slice silently depends on an artifact produced by
-another that I could not otherwise obtain — the friction is (a) the unmet Warden's-Gate
-repo state Golem assumes, and (b) PRD's missing tooling.
+**Ordering observation for a maintainer:** as a *learning* path for a Data Scientist, Hidden Gem (Easy, self-contained) → Prompt Crystal (prompt skills) → Golem (agent in CI, but flag the 0101 Warden's-Gate prerequisite) is a smoother ramp than the current dependency-sort, and PRD Codex should be treated as *not yet walkable* until its tooling bootstrap is added. No quest in the slice silently depends on an artifact produced by another that I could not otherwise obtain — the friction is (a) the unmet Warden's-Gate repo state Golem assumes, and (b) PRD's missing tooling.
 
 ## 🧠 Reasoning & Method
 
 - **Mode:** execute. I did **not** run the engine myself — per the skill and the CI
-  contract, the workflow pre-computed and sealed `walk-evidence.json` / `walk-evidence.md`
-  (the engine's child `claude` processes can't authenticate from an agent's Bash tool).
-  I consumed the sealed evidence verbatim and did not edit, regenerate, or hand-write any
-  number. `walk-plan.json` and `walk-evidence.*` were left untouched.
+contract, the workflow pre-computed and sealed `walk-evidence.json` / `walk-evidence.md` (the engine's child `claude` processes can't authenticate from an agent's Bash tool). I consumed the sealed evidence verbatim and did not edit, regenerate, or hand-write any number. `walk-plan.json` and `walk-evidence.*` were left untouched.
 - **What was actually run (in the sandbox, by the sealed engine):** 32 recorded
-  commands across the four quests, of which the engine ran ~32 and reasoned statically
-  about the rest — Golem 5/5 passed; PRD Codex 5 passed / 8 failed; Hidden Gem 3 passed /
-  1 failed; Prompt Crystal 5 passed / 5 failed. Every `passed`/`failed` above traces to
-  one of those runs; every `reasoned` item is labeled as static-only.
+commands across the four quests, of which the engine ran ~32 and reasoned statically about the rest — Golem 5/5 passed; PRD Codex 5 passed / 8 failed; Hidden Gem 3 passed / 1 failed; Prompt Crystal 5 passed / 5 failed. Every `passed`/`failed` above traces to one of those runs; every `reasoned` item is labeled as static-only.
 - **What I reasoned about (me, statically):** the linked-journey continuity — series
-  cohesion, prerequisite satisfaction, and ordering — by reading each quest's frontmatter
-  and body in plan order. Those are the §🔗 findings and are explicitly reasoning, not
-  fresh command evidence.
+cohesion, prerequisite satisfaction, and ordering — by reading each quest's frontmatter and body in plan order. Those are the §🔗 findings and are explicitly reasoning, not fresh command evidence.
 - **Coverage / limits:** Nothing was capped by me (the planner's window covers the full
-  4-quest level; `truncated: false`). OS-specific installs and `code`-CLI steps were
-  `skipped` by the engine as environment-dependent, so cross-platform install accuracy is
-  only partially witnessed. PRD Codex's Docker path is genuinely broken in a clean repo, so
-  its downstream chapters are unverifiable *by design of the defect* — that is itself the
-  finding, not a coverage gap on my side. No network-dependent or destructive steps were run.
+4-quest level; `truncated: false`). OS-specific installs and `code`-CLI steps were `skipped` by the engine as environment-dependent, so cross-platform install accuracy is only partially witnessed. PRD Codex's Docker path is genuinely broken in a clean repo, so its downstream chapters are unverifiable *by design of the defect* — that is itself the finding, not a coverage gap on my side. No network-dependent or destructive steps were run.
 - **Confidence:** High on the per-quest verdicts (they come from real sandbox runs with
-  quoted failure output). High on the PRD blocking-fail and the two high-severity Prompt
-  Crystal defects. Medium on the extension-ID / theme-URL slips (asserted by the engine's
-  content check, not independently re-verified here). The overall slice verdict is **warn**:
-  three of four quests are usable today, but the slice contains one hard fail that a
-  content pass should fix before this level is called "perfect."
+quoted failure output). High on the PRD blocking-fail and the two high-severity Prompt Crystal defects. Medium on the extension-ID / theme-URL slips (asserted by the engine's content check, not independently re-verified here). The overall slice verdict is **warn**: three of four quests are usable today, but the slice contains one hard fail that a content pass should fix before this level is called "perfect."
 
 ---
 
-*Machine evidence header (verbatim from `walk-evidence.md`): "**4** quests evaluated ·
-✅ 1 pass · ⚠️ 2 warn · ❌ 1 fail · avg **65.8%** · ~$6.4993". One slice, one report —
-findings only; a content pass (content-curator / human) acts on the issues above.*
+*Machine evidence header (verbatim from `walk-evidence.md`): "**4** quests evaluated · ✅ 1 pass · ⚠️ 2 warn · ❌ 1 fail · avg **65.8%** · ~$6.4993". One slice, one report — findings only; a content pass (content-curator / human) acts on the issues above.*

--- a/pages/_quest-reports/2026-07-17-developer-0001.md
+++ b/pages/_quest-reports/2026-07-17-developer-0001.md
@@ -37,122 +37,66 @@ source_report: test/quest-validator/walkthroughs/2026-07-17-developer-0001.md
 
 ## 🎯 Session Summary
 
-I played a **5-quest window** (window 2 of 6; quests 11–15 of the 26 that make up
-the Developer path's Level **0001 · Web Fundamentals · Apprentice 🌱** tier) as a
-beginner developer would, driving the sealed execute-mode engine evidence and then
-reading every quest source in plan order to reason about the linked journey.
+I played a **5-quest window** (window 2 of 6; quests 11–15 of the 26 that make up the Developer path's Level **0001 · Web Fundamentals · Apprentice 🌱** tier) as a beginner developer would, driving the sealed execute-mode engine evidence and then reading every quest source in plan order to reason about the linked journey.
 
-**Headline verdict: ❌ fail.** The engine scored **0 pass · 1 warn · 4 fail**,
-average **49.5%**. This slice is *not* ready for a real beginner: the very first
-main quest (**GitHub Pages Portal**) hard-blocks on a `gem install`/`bundle`
-permissions failure on the exact Linux setup it recommends, and a leftover
-`index.html` silently shadows all the Jekyll content it later teaches; one side
-quest (**Personal Website**, 19%) is a bare reference table with placeholder
-objectives and no runnable steps; the flagship **Summoning** main quest (57%) fails
-to build against the very theme it names because it omits `jekyll-include-cache`;
-and even the best of the set (**SEO Optimization**, 68% ⚠️) teaches a plugin-setup
-sequence that silently produces no sitemap until a *later* chapter. The
-**Stack Analysis** side quest **timed out at 600s** in the engine, so it has **no
-execute evidence** — I reasoned about it statically only. A maintainer's highest-value
-fixes are the two `high`-severity blockers in Portal and the missing plugin in
-Summoning, because they stop a learner cold at the start of the path.
+**Headline verdict: ❌ fail.** The engine scored **0 pass · 1 warn · 4 fail**, average **49.5%**. This slice is *not* ready for a real beginner: the very first main quest (**GitHub Pages Portal**) hard-blocks on a `gem install`/`bundle` permissions failure on the exact Linux setup it recommends, and a leftover `index.html` silently shadows all the Jekyll content it later teaches; one side quest (**Personal Website**, 19%) is a bare reference table with placeholder objectives and no runnable steps; the flagship **Summoning** main quest (57%) fails to build against the very theme it names because it omits `jekyll-include-cache`; and even the best of the set (**SEO Optimization**, 68% ⚠️) teaches a plugin-setup sequence that silently produces no sitemap until a *later* chapter. The **Stack Analysis** side quest **timed out at 600s** in the engine, so it has **no execute evidence** — I reasoned about it statically only. A maintainer's highest-value fixes are the two `high`-severity blockers in Portal and the missing plugin in Summoning, because they stop a learner cold at the start of the path.
 
 ## 🗺️ The Journey
 
 Plan order (from `walk-plan.json`); emoji = engine verdict, score = overall:
 
 1. ❌ **The GitHub Pages Portal: Forging Your Digital Realm** — `main_quest` · **54** ·
-   Solid git/Pages content, but a gem-permissions wall and a silent `index.html`
-   vs `index.md` shadowing would block/mislead a beginner exactly where it promises
-   the least friction.
+Solid git/Pages content, but a gem-permissions wall and a silent `index.html` vs `index.md` shadowing would block/mislead a beginner exactly where it promises the least friction.
 2. ❌ **Stack Attack Analysis: IT-Journey** — `side_quest` · **— (timed out at 600s)** ·
-   No execute evidence gathered; a ~1,300-line reference report with auto-seeded
-   placeholder objectives and no real hands-on exercises (reasoned only).
+No execute evidence gathered; a ~1,300-line reference report with auto-seeded placeholder objectives and no real hands-on exercises (reasoned only).
 3. ❌ **Build a Personal Website with GitHub Pages** — `side_quest` · **19** ·
-   Effectively a stub: one link table, zero runnable commands, unrendered Liquid,
-   duplicate/mislabeled rows. Needs a full rewrite to match its title.
+Effectively a stub: one link table, zero runnable commands, unrendered Liquid, duplicate/mislabeled rows. Needs a full rewrite to match its title.
 4. ❌ **The Summoning: Raise the Site and Give It a Voice** — `main_quest` · **57** ·
-   Well-structured, but Chapter 1's Gemfile/`_config.yml` won't build against the
-   named `bamr87/zer0-mistakes` theme (missing `jekyll-include-cache`); no
-   `.gitignore` step. Everything else tested clean.
+Well-structured, but Chapter 1's Gemfile/`_config.yml` won't build against the named `bamr87/zer0-mistakes` theme (missing `jekyll-include-cache`); no `.gitignore` step. Everything else tested clean.
 5. ⚠️ **SEO Optimization: Meta Tags, Sitemaps & Structured Data** — `main_quest` · **68** ·
-   Individual SEO techniques all verified working, but the first platform-path step
-   yields no sitemap until Chapter 2's `_config.yml` edit, and the
-   `JEKYLL_ENV=production` "minifies output" claim is factually wrong.
+Individual SEO techniques all verified working, but the first platform-path step yields no sitemap until Chapter 2's `_config.yml` edit, and the `JEKYLL_ENV=production` "minifies output" claim is factually wrong.
 
 ## 🔬 Evidence
 
-All outcomes below come from the sealed `walk-evidence.json` (execute mode; commands
-actually run in the engine's disposable sandbox). Snippet coverage is reported as
-`ran/runnable`. I did not re-run the engine.
+All outcomes below come from the sealed `walk-evidence.json` (execute mode; commands actually run in the engine's disposable sandbox). Snippet coverage is reported as `ran/runnable`. I did not re-run the engine.
 
 ### 1. GitHub Pages Portal — 54% (fail) · snippets ran **18** (14✓ / 4✗), 3 reasoned
 - **passed** — `git clone` / `git add` / `git commit` on a real local repo (verified
-  three successive commits succeed); `bundle exec jekyll serve` bound
-  `http://127.0.0.1:4000/` matching the quest's stated URL; both Mermaid diagrams
-  rendered via `mmdc`; the Windows PowerShell here-string ran under `pwsh`.
+three successive commits succeed); `bundle exec jekyll serve` bound `http://127.0.0.1:4000/` matching the quest's stated URL; both Mermaid diagrams rendered via `mmdc`; the Windows PowerShell here-string ran under `pwsh`.
 - **failed** — `gem install jekyll bundler` (Ch.3 s1) → `Gem::FilePermissionError:
-  You don't have write permissions for the /var/lib/gems/3.2.0 directory` on stock
-  Ubuntu 24.04 / Ruby 3.2.3 — the exact env produced by the quest's own
-  `sudo apt-get install ruby-full`. `bundle install` (s6) similarly threw
-  `Bundler::PermissionError` until an undocumented `bundle config set --local path
-  vendor/bundle`.
+You don't have write permissions for the /var/lib/gems/3.2.0 directory` on stock Ubuntu 24.04 / Ruby 3.2.3 — the exact env produced by the quest's own `sudo apt-get install ruby-full`. `bundle install` (s6) similarly threw `Bundler::PermissionError` until an undocumented `bundle config set --local path vendor/bundle`.
 - **failed** — a real `bundle exec jekyll build` confirmed the Chapter 1 `index.html`
-  silently wins over the Chapter 3 `index.md`; none of the Jekyll homepage content
-  the quest teaches is ever rendered. `jekyll new . --force` did not remove it — it
-  added a competing `index.markdown`.
+silently wins over the Chapter 3 `index.md`; none of the Jekyll homepage content the quest teaches is ever rendered. `jekyll new . --force` did not remove it — it added a competing `index.markdown`.
 - **failed** — copy-pasting the `index.md` block verbatim (with literal
-  `{​% raw %​}{​{ site.url }​}{​% endraw %​}`) built `<a href="{​{ site.url }​}">View Site</a>`
-  — a broken link.
+`{​% raw %​}{​{ site.url }​}{​% endraw %​}`) built `<a href="{​{ site.url }​}">View Site</a>` — a broken link.
 - **reasoned** — `git push origin main` and placeholder-URL clones can't be verified
   without a real authenticated remote (expected, not a defect).
 
 ### 2. Stack Attack Analysis — no score (fail) · **no snippets executed**
 - **error** — `claude timed out after 600s`; `verdict_obj` is null, `overall` 0.0.
-  **No command evidence exists for this quest.** My notes on it (Chain Continuity,
-  Issues) are **reasoned** from reading the source only, and labeled as such.
+**No command evidence exists for this quest.** My notes on it (Chain Continuity, Issues) are **reasoned** from reading the source only, and labeled as such.
 
 ### 3. Build a Personal Website — 19% (fail) · snippets ran **2** (1✓ / 1✗), 1 skipped, 1 reasoned
 - **failed / reasoned** — engine confirms **zero runnable code blocks**
-  (`available_runnable: 0`): no `git init`, no repo creation, no `_config.yml`, no
-  Pages-enable step. The one content section is a link table.
+(`available_runnable: 0`): no `git init`, no repo creation, no `_config.yml`, no Pages-enable step. The one content section is a link table.
 - Source read confirms every engine finding: rows 2 and 6 render to the identical
-  `https://{​{ site.github_user }​}.github.io/` yet are labeled different hosts; row 12
-  labels `jekyllrb.com` a "Comments service" (it's a static-site generator); Liquid
-  tags render literally; the objectives block is the auto-seeded placeholder ("authors
-  should refine these").
+`https://{​{ site.github_user }​}.github.io/` yet are labeled different hosts; row 12 labels `jekyllrb.com` a "Comments service" (it's a static-site generator); Liquid tags render literally; the objectives block is the auto-seeded placeholder ("authors should refine these").
 
 ### 4. The Summoning — 57% (fail) · snippets ran **7** (6✓ / 1✗), 2 reasoned
 - **failed** — building the exact Chapter 1 `_config.yml` + `Gemfile` against a
-  *cloned* real `bamr87/zer0-mistakes` theme → `Liquid Exception: Liquid syntax
-  error (line 70): Unknown tag 'include_cached'` in the theme's `_layouts/root.html`.
-  Adding `gem "jekyll-include-cache", group: :jekyll_plugins` (a fix the quest never
-  names) made `bundle exec jekyll build` succeed and render correctly.
+*cloned* real `bamr87/zer0-mistakes` theme → `Liquid Exception: Liquid syntax error (line 70): Unknown tag 'include_cached'` in the theme's `_layouts/root.html`. Adding `gem "jekyll-include-cache", group: :jekyll_plugins` (a fix the quest never names) made `bundle exec jekyll build` succeed and render correctly.
 - **passed** — `_data/brand.yml` parses and the `{​{ site.data.brand.* }​}` include
-  renders as claimed; `scripts/session-scribe.sh` run twice (first commit + second
-  commit) produced the dispatch exactly as described, including the documented
-  `HEAD^1`→`git show` fallback on a first commit; the Actions workflow YAML is valid.
+renders as claimed; `scripts/session-scribe.sh` run twice (first commit + second commit) produced the dispatch exactly as described, including the documented `HEAD^1`→`git show` fallback on a first commit; the Actions workflow YAML is valid.
 - **reasoned** — the "Reproduce It" links to merged `bamr87/lifehacker.dev` PRs
-  couldn't be SHA-verified without deeper API access (treated as unverified, not a
-  failure). Committing without a `.gitignore` was verified to sweep the entire
-  generated `_site/` tree into the repo.
+couldn't be SHA-verified without deeper API access (treated as unverified, not a failure). Committing without a `.gitignore` was verified to sweep the entire generated `_site/` tree into the repo.
 
 ### 5. SEO Optimization — 68% (warn) · snippets ran **8** (5✓ / 3✗), 2 skipped, 5 reasoned
 - **failed** — real Jekyll 4.4.1 build of the platform-path sequence
-  (`bundle add jekyll-seo-tag jekyll-sitemap; jekyll build`): `/sitemap.xml` was
-  **not** generated (`ls _site/sitemap.xml` → No such file). `bundle add` lands gems
-  in the default group, not `:jekyll_plugins`, so `jekyll-sitemap` never activates
-  until Chapter 2's `plugins:` list is added — after which a rebuild produced
-  `/sitemap.xml` with all 3 URLs (Ch.2 is correct, just out of sequence).
+(`bundle add jekyll-seo-tag jekyll-sitemap; jekyll build`): `/sitemap.xml` was **not** generated (`ls _site/sitemap.xml` → No such file). `bundle add` lands gems in the default group, not `:jekyll_plugins`, so `jekyll-sitemap` never activates until Chapter 2's `plugins:` list is added — after which a rebuild produced `/sitemap.xml` with all 3 URLs (Ch.2 is correct, just out of sequence).
 - **failed (accuracy)** — verified against Jekyll 4.4.1 source: `JEKYLL_ENV=production`
-  only toggles the `jekyll.environment` Liquid variable; it performs **no**
-  HTML/CSS/JS minification. The Chapter 4 claim (line 313) and matching knowledge
-  check (line 339) are wrong.
+only toggles the `jekyll.environment` Liquid variable; it performs **no** HTML/CSS/JS minification. The Chapter 4 claim (line 313) and matching knowledge check (line 339) are wrong.
 - **passed** — the `{​% seo %​}` tag rendered full `<title>`/meta/canonical/OpenGraph/
-  Twitter/JSON-LD; `robots.txt` built unchanged; the Chapter 3 JSON-LD parsed via
-  `json.loads`; the `author:` block verified against `jekyll-seo-tag` 2.9.0's
-  `AuthorDrop`. `jekyll-seo-tag` rendering after bare `bundle add` was noted as
-  **theme-specific luck** (minima declares it as a gemspec dep), not reliable behavior.
+Twitter/JSON-LD; `robots.txt` built unchanged; the Chapter 3 JSON-LD parsed via `json.loads`; the `author:` block verified against `jekyll-seo-tag` 2.9.0's `AuthorDrop`. `jekyll-seo-tag` rendering after bare `bundle add` was noted as **theme-specific luck** (minima declares it as a gemspec dep), not reliable behavior.
 - **reasoned/skipped** — macOS-only tools (`sips`, `imageoptim`, `open`) and the
   interactive `jekyll serve` + browser steps couldn't run in the Linux sandbox.
 
@@ -162,132 +106,83 @@ actually run in the engine's disposable sandbox). Snippet coverage is reported a
 
 ## 🐞 Issues Found
 
-Grouped by quest; every item cites a witnessed command result or a quoted source
-line. Severity mirrors the engine's own `high/medium/low` where it ran.
+Grouped by quest; every item cites a witnessed command result or a quoted source line. Severity mirrors the engine's own `high/medium/low` where it ran.
 
 **GitHub Pages Portal** (`pages/_quests/0001/github-pages-portal.md`)
 - **high** · Ch.3 s1/s6, `gem install jekyll bundler` / `bundle install` — *observed:*
-  `Gem::FilePermissionError` / `Bundler::PermissionError` on the Linux env the quest
-  itself recommends. *Fix:* add guidance for the system-Ruby permission wall
-  (rbenv/rvm/asdf, or `gem install --user-install` + `bundle config set path
-  vendor/bundle`).
+`Gem::FilePermissionError` / `Bundler::PermissionError` on the Linux env the quest itself recommends. *Fix:* add guidance for the system-Ruby permission wall (rbenv/rvm/asdf, or `gem install --user-install` + `bundle config set path vendor/bundle`).
 - **high** · Ch.3 s5, `index.md` shadowed — *observed via `jekyll build`:* the
-  Chapter 1 `index.html` silently wins; the taught homepage never renders. *Fix:*
-  instruct learners to delete/rename `index.html` before creating `index.md`.
+Chapter 1 `index.html` silently wins; the taught homepage never renders. *Fix:* instruct learners to delete/rename `index.html` before creating `index.md`.
 - **high** · Objectives — *observed:* "Custom domain configuration" is a stated
-  objective but the doc has **zero** mentions of CNAME/DNS/A records. *Fix:* add real
-  CNAME+DNS+Settings steps, or drop the objective.
+objective but the doc has **zero** mentions of CNAME/DNS/A records. *Fix:* add real CNAME+DNS+Settings steps, or drop the objective.
 - **medium** · Ch.1→Ch.3, Jekyll version — standalone `gem install` gives Jekyll
-  4.4.1, then the `github-pages` Gemfile pins 3.10.0 (per `Gemfile.lock`) with no
-  explanation. *Fix:* explain the intentional downgrade.
+4.4.1, then the `github-pages` Gemfile pins 3.10.0 (per `Gemfile.lock`) with no explanation. *Fix:* explain the intentional downgrade.
 - **medium** · `index.md` `{​% raw %​}{​{ site.url }​}{​% endraw %​}` — verbatim copy builds
   a literal broken link. *Fix:* use a plain placeholder outside raw tags.
 - **low** · `_config.yml` `highlander: true` is a non-standard key; **low** ·
   Quest-Network diagram has contradictory bidirectional `A↔D` prerequisite edges.
 - **low (⚠ likely engine artifact — my witness note)** · The engine flagged
-  "missing YAML front matter," but **I read the on-disk file and it has full,
-  well-formed front matter (lines 1–60+)**. This is almost certainly the sandbox
-  presenting a stripped `QUEST.md`, not a real content defect — do **not** act on it.
+"missing YAML front matter," but **I read the on-disk file and it has full, well-formed front matter (lines 1–60+)**. This is almost certainly the sandbox presenting a stripped `QUEST.md`, not a real content defect — do **not** act on it.
 
-**Stack Attack Analysis** (`pages/_quests/0001/it-journey-stack-analysis.md`) —
-*all reasoned (engine timed out; no execute evidence)*
+**Stack Attack Analysis** (`pages/_quests/0001/it-journey-stack-analysis.md`) — *all reasoned (engine timed out; no execute evidence)*
 - **medium (reasoned)** · Objectives are the auto-seeded placeholder block (source
-  lines 79–83: "objectives auto-seeded during framework alignment") and
-  `learning_style: hands-on` / "Complete the hands-on exercises" promise exercises
-  the ~1,300-line report never provides. *Fix:* author real objectives, or reclassify
-  as a reference/reading quest.
+lines 79–83: "objectives auto-seeded during framework alignment") and `learning_style: hands-on` / "Complete the hands-on exercises" promise exercises the ~1,300-line report never provides. *Fix:* author real objectives, or reclassify as a reference/reading quest.
 - **low (reasoned)** · Content is stale in spots (e.g., "Jekyll 3.9.5 … latest GitHub
   Pages-compatible") relative to the Jekyll 4.4.1 used elsewhere in this level.
 
 **Build a Personal Website** (`pages/_quests/0001/personal-site.md`)
 - **high** · Whole quest — *observed:* no runnable steps at all for a "Build a…"
-  title. *Fix:* rewrite to teach creating `<user>.github.io`, scaffolding
-  index/Jekyll, enabling Pages, verifying the live URL.
+title. *Fix:* rewrite to teach creating `<user>.github.io`, scaffolding index/Jekyll, enabling Pages, verifying the live URL.
 - **high** · Unrendered `{​% raw %​}{​{ site.github_user }​}{​% endraw %​}` throughout the
   table. *Fix:* substitute a concrete example or explain the templating.
 - **medium** · Row 12 `jekyllrb.com` mislabeled "Comments service"; rows 2 & 6 are
-  duplicate/contradictory; `nanobar.jacoborus.codes` dead; Travis CI reference
-  outdated. *Fix:* correct the table.
+duplicate/contradictory; `nanobar.jacoborus.codes` dead; Travis CI reference outdated. *Fix:* correct the table.
 - **medium** · Placeholder objectives (same auto-seeded block); no prerequisites or
   validation criteria.
 
 **The Summoning** (`pages/_quests/0001/self-operating-website-01-the-summoning.md`)
 - **high** · Ch.1 Gemfile/`_config.yml` — *observed:* `Unknown tag 'include_cached'`
-  hard build failure against the real named theme. *Fix:* add
-  `jekyll-include-cache` to both the plugins list and the Gemfile `:jekyll_plugins`
-  group (or adopt the theme's recommended `gem "github-pages"`).
+hard build failure against the real named theme. *Fix:* add `jekyll-include-cache` to both the plugins list and the Gemfile `:jekyll_plugins` group (or adopt the theme's recommended `gem "github-pages"`).
 - **medium** · No `.gitignore` step — *observed:* `git add -A` sweeps the entire
-  `_site/` build + `vendor/bundle` into the repo. *Fix:* add a `.gitignore` snippet
-  before the first commit.
+`_site/` build + `vendor/bundle` into the repo. *Fix:* add a `.gitignore` snippet before the first commit.
 - **medium** · Actions versions behind current majors and `configure-pages` ordered
-  before `checkout`; no `--baseurl` for project pages. *Fix:* align with GitHub's
-  official Jekyll-on-Pages starter.
+before `checkout`; no `--baseurl` for project pages. *Fix:* align with GitHub's official Jekyll-on-Pages starter.
 - **low** · No explicit `bundle install` step before the first `jekyll build`/push.
 
 **SEO Optimization** (`pages/_quests/0001/seo-optimization.md`)
 - **high** · Platform-path setup (lines ~61–114) — *observed:* `/sitemap.xml` not
-  produced by `bundle add` alone. *Fix:* introduce the `_config.yml` `plugins:` list
-  (or `bundle add --group jekyll_plugins`) in the setup step, or warn that plugins
-  don't activate until Chapter 2.
+produced by `bundle add` alone. *Fix:* introduce the `_config.yml` `plugins:` list (or `bundle add --group jekyll_plugins`) in the setup step, or warn that plugins don't activate until Chapter 2.
 - **high** · Line 313 + knowledge-check line 339 — *observed against Jekyll 4.4.1
-  source:* `JEKYLL_ENV=production` does not minify. *Fix:* correct the claim (point to
-  `jekyll-minifier` or Sass `style: compressed`) and the matching question.
+source:* `JEKYLL_ENV=production` does not minify. *Fix:* correct the claim (point to `jekyll-minifier` or Sass `style: compressed`) and the matching question.
 - **medium** · Chapter 1 example description is 119 chars vs the stated ~150–160
-  target. **low** · Cloud Realms path lacks a validation step the other three paths
-  have.
+target. **low** · Cloud Realms path lacks a validation step the other three paths have.
 
-**No blocking issues** exist only in the *tested-clean* portions — the brand-as-data
-include, the session-scribe script (Summoning) and the `{​% seo %​}`/JSON-LD/robots
-mechanics (SEO). Everything else above is a real, evidenced defect.
+**No blocking issues** exist only in the *tested-clean* portions — the brand-as-data include, the session-scribe script (Summoning) and the `{​% seo %​}`/JSON-LD/robots mechanics (SEO). Everything else above is a real, evidenced defect.
 
 ## 🔗 Chain Continuity
 
-Context: this is a **rotating window (2 of 6)** of a 26-quest level, so these five are
-a *slice*, not a strict N→N+1 dependency chain — and indeed **all five declare
-`required_quests: []`**. As a learner sweeping them in plan order, I found:
+Context: this is a **rotating window (2 of 6)** of a 26-quest level, so these five are a *slice*, not a strict N→N+1 dependency chain — and indeed **all five declare `required_quests: []`**. As a learner sweeping them in plan order, I found:
 
 - **Conflicting "build a site" recipes.** Portal (quest 1) and Summoning (quest 4)
-  both teach Jekyll-on-GitHub-Pages from scratch but with *incompatible* stacks:
-  Portal uses `jekyll new` + the `github-pages` gem (Jekyll 3.10), Summoning uses
-  `remote_theme` + a GitHub Actions build (Jekyll 4). A beginner who did Portal first
-  arrives at Summoning with a different site layout and toolchain than Summoning
-  assumes. Neither cross-references the other. This is the biggest continuity gap.
+both teach Jekyll-on-GitHub-Pages from scratch but with *incompatible* stacks: Portal uses `jekyll new` + the `github-pages` gem (Jekyll 3.10), Summoning uses `remote_theme` + a GitHub Actions build (Jekyll 4). A beginner who did Portal first arrives at Summoning with a different site layout and toolchain than Summoning assumes. Neither cross-references the other. This is the biggest continuity gap.
 - **Both site-build quests are blocked at step one, independently.** Portal dies on
-  gem permissions; Summoning dies on `include_cached`. A learner walking the slice
-  top-to-bottom would be stuck twice before reaching a working site — and the later
-  SEO quest's stated prerequisite is "A Jekyll site to edit," which neither
-  predecessor reliably delivers out of the box.
+gem permissions; Summoning dies on `include_cached`. A learner walking the slice top-to-bottom would be stuck twice before reaching a working site — and the later SEO quest's stated prerequisite is "A Jekyll site to edit," which neither predecessor reliably delivers out of the box.
 - **SEO (quest 5) is the payoff and mostly holds** — its prerequisite ("a Jekyll
-  site") is thematically satisfied by quests 1/4, and its content is the strongest in
-  the set. But its platform-path sitemap bug would bite a learner who just built a
-  site via Portal exactly the same way, compounding the earlier friction.
+site") is thematically satisfied by quests 1/4, and its content is the strongest in the set. But its platform-path sitemap bug would bite a learner who just built a site via Portal exactly the same way, compounding the earlier friction.
 - **Two quests read as unfinished.** Stack Analysis (2) and Personal Website (3) both
-  carry the *identical* auto-seeded placeholder objectives block. Seeing "objectives
-  auto-seeded during framework alignment — authors should refine these" twice in one
-  slice signals to a learner that the path isn't finished, and neither delivers the
-  hands-on exercise its own objectives promise. They function as reference material
-  wedged between three hands-on build quests, breaking the "do something" rhythm.
+carry the *identical* auto-seeded placeholder objectives block. Seeing "objectives auto-seeded during framework alignment — authors should refine these" twice in one slice signals to a learner that the path isn't finished, and neither delivers the hands-on exercise its own objectives promise. They function as reference material wedged between three hands-on build quests, breaking the "do something" rhythm.
 - **Ordering nit:** Personal Website (a services *reference*) sits *before* the
-  Summoning (which actually *builds* the site). A learner would benefit from building
-  first, then consulting the services catalog — the current order front-loads a
-  context-free link table.
+Summoning (which actually *builds* the site). A learner would benefit from building first, then consulting the services catalog — the current order front-loads a context-free link table.
 
-Net: the slice does **not** yet hold together as a smooth learning path — two hard
-blockers, two conflicting site recipes, and two placeholder-objective reference pages
-mean a real Apprentice developer would stall early and repeatedly.
+Net: the slice does **not** yet hold together as a smooth learning path — two hard blockers, two conflicting site recipes, and two placeholder-objective reference pages mean a real Apprentice developer would stall early and repeatedly.
 
 ## 🧠 Reasoning & Method
 
 - **Mode:** `execute` (sandboxed), consuming **workflow-sealed** `walk-evidence.json`
   + `walk-evidence.md`. Per the skill's step 2, the engine was pre-run
-  deterministically by the workflow (its child `claude` processes can't authenticate
-  from my Bash tool); **I did not run, regenerate, or edit the evidence or the plan.**
+deterministically by the workflow (its child `claude` processes can't authenticate from my Bash tool); **I did not run, regenerate, or edit the evidence or the plan.**
 - **What I ran vs. reasoned:** the *engine* actually executed commands in a disposable
-  temp dir per quest (git flows, `gem/bundle`, `jekyll build`, a cloned real theme,
-  `mmdc`, `pwsh`, `json.loads`, source cross-checks) — those are the `passed`/`failed`
-  facts in §Evidence. **I** then read all five quest sources in plan order to reason
-  about the *linked journey* (§Chain Continuity). Everything I concluded without a
-  sandbox command is labeled **reasoned**.
+temp dir per quest (git flows, `gem/bundle`, `jekyll build`, a cloned real theme, `mmdc`, `pwsh`, `json.loads`, source cross-checks) — those are the `passed`/`failed` facts in §Evidence. **I** then read all five quest sources in plan order to reason about the *linked journey* (§Chain Continuity). Everything I concluded without a sandbox command is labeled **reasoned**.
 - **Coverage & limits, stated honestly:**
   - **Quest 2 (Stack Analysis) has ZERO execute evidence** — it timed out at 600s.
     All my remarks on it are reasoned from source only; do not read them as tested.
@@ -299,8 +194,6 @@ mean a real Apprentice developer would stall early and repeatedly.
     on-disk file (which has full front matter). I flagged it as a **likely sandbox
     artifact** and recommend ignoring it — an honest witness note, not a validated bug.
 - **Confidence:** High on the four scored quests' blockers (each backed by a real,
-  reproduced command). Medium-low on Stack Analysis (source-only). Overall verdict
-  **fail** follows directly from the sealed counts (0 pass · 1 warn · 4 fail, 49.5%),
-  not from my own grading.
+reproduced command). Medium-low on Stack Analysis (source-only). Overall verdict **fail** follows directly from the sealed counts (0 pass · 1 warn · 4 fail, 49.5%), not from my own grading.
 - **Scope discipline:** one slice, one report. No quest content was edited; no branch,
   commit, or PR was made. The workflow handles git.

--- a/pages/_quest-reports/2026-07-17-digital-artist-0001.md
+++ b/pages/_quest-reports/2026-07-17-digital-artist-0001.md
@@ -37,23 +37,9 @@ source_report: test/quest-validator/walkthroughs/2026-07-17-digital-artist-0001.
 
 ## 🎯 Session Summary
 
-Walked a **5-quest window (2 of 6)** of the **Digital Artist → Level 0001 "Web
-Fundamentals" (🌱 Apprentice)** path, in the dependency-sorted order the planner
-selected, as a UI/UX-leaning beginner would. Evidence is the workflow-sealed
-execute-mode engine run (`walk-evidence.json`); I read all five quest sources and
-reasoned about them as one linked journey.
+Walked a **5-quest window (2 of 6)** of the **Digital Artist → Level 0001 "Web Fundamentals" (🌱 Apprentice)** path, in the dependency-sorted order the planner selected, as a UI/UX-leaning beginner would. Evidence is the workflow-sealed execute-mode engine run (`walk-evidence.json`); I read all five quest sources and reasoned about them as one linked journey.
 
-**Headline verdict: FAIL.** No quest passed — 2 warn (68%), 3 fail (48/16/58),
-average **51.6%**. The strongest quest, *The GitHub Pages Portal*, actually deploys
-a working Jekyll/GitHub Pages site end-to-end in the sandbox and is the true spine
-of this slice. But the window also contains two "quests" that are not tutorials at
-all (*Personal Site*, 16%; *Stack Attack Analysis*, 48% — both carry the tell-tale
-"objectives auto-seeded during framework alignment" placeholder note), and two
-otherwise-solid main quests (*The Summoning*, *SEO Optimization*) each ship with **one
-reproducible build-breaking defect** a beginner hits on their very first build. A
-maintainer should treat *Personal Site* and *Stack Attack Analysis* as needing a
-rewrite/retype, and land the two single-line/single-config fixes in the two main
-quests.
+**Headline verdict: FAIL.** No quest passed — 2 warn (68%), 3 fail (48/16/58), average **51.6%**. The strongest quest, *The GitHub Pages Portal*, actually deploys a working Jekyll/GitHub Pages site end-to-end in the sandbox and is the true spine of this slice. But the window also contains two "quests" that are not tutorials at all (*Personal Site*, 16%; *Stack Attack Analysis*, 48% — both carry the tell-tale "objectives auto-seeded during framework alignment" placeholder note), and two otherwise-solid main quests (*The Summoning*, *SEO Optimization*) each ship with **one reproducible build-breaking defect** a beginner hits on their very first build. A maintainer should treat *Personal Site* and *Stack Attack Analysis* as needing a rewrite/retype, and land the two single-line/single-config fixes in the two main quests.
 
 ## 🗺️ The Journey
 
@@ -67,8 +53,7 @@ quests.
 
 ## 🔬 Evidence
 
-All statuses below come from the sealed execute-mode engine run (`--mode execute`,
-sandboxed per quest). "ran N/M" = engine's recorded/available snippet accounting.
+All statuses below come from the sealed execute-mode engine run (`--mode execute`, sandboxed per quest). "ran N/M" = engine's recorded/available snippet accounting.
 
 ### 1. The GitHub Pages Portal — ⚠️ 68 (ran 14 snippets, 14 passed / 0 failed / 1 skipped / 2 reasoned)
 Dimensions: commands_work **4**, content_accuracy 3, completeness **2**, clarity 4, structure 3, safety 4.
@@ -105,8 +90,7 @@ Dimensions: commands_work 3, content_accuracy 3, completeness **4**, clarity 3, 
 
 ## 🐞 Issues Found
 
-Every item below is backed by a sandbox command result or a quoted quest line.
-Severity reflects learner impact (blocks progress > misleads > polish).
+Every item below is backed by a sandbox command result or a quoted quest line. Severity reflects learner impact (blocks progress > misleads > polish).
 
 1. **HIGH · Personal Site · whole document ·** Zero fenced code blocks, zero runnable steps, zero verification — `grep` confirmed 0 code fences; engine scored commands_work/completeness/clarity all 0. It's the author's personal reference table, not a tutorial. **Fix:** rewrite as a real step-by-step (create `<username>.github.io` repo → add `index.html` → push → enable Pages → verify live URL) and replace the auto-seeded placeholder objectives (line 63).
 2. **HIGH · Personal Site · §1 table ·** Factual errors: row 12 calls `jekyllrb.com` a "Comments service" (line 86, it's a static-site generator); row 6 reuses row 2's GitHub Pages URL for a "Cloudflare" domain (lines 76/80); `travis-ci.org` (77) and `*.netlify.com` (78) are outdated; unresolved `{​{ site.github_user }​}` Liquid renders as literal `{}`. **Fix:** correct descriptions, de-duplicate the domain row, update to `*.netlify.app`/GitHub Actions, and substitute concrete example values or `<your-username>`.
@@ -128,58 +112,23 @@ Severity reflects learner impact (blocks progress > misleads > polish).
 Reading the five in plan order as one Digital-Artist journey:
 
 - **The window is not a clean linear path — it's one strong spine plus satellites.**
-  Quest 1 (*GitHub Pages Portal*) is the real backbone: it takes a beginner from
-  nothing to a live Jekyll/GitHub Pages site, and it's the only quest that
-  self-contains the full install→build→deploy loop. Everything else in the window
-  assumes that spine but doesn't declare it — every quest here has empty
-  `quest_dependencies.required_quests`, so the chain's ordering is implicit, not
-  enforced.
+Quest 1 (*GitHub Pages Portal*) is the real backbone: it takes a beginner from nothing to a live Jekyll/GitHub Pages site, and it's the only quest that self-contains the full install→build→deploy loop. Everything else in the window assumes that spine but doesn't declare it — every quest here has empty `quest_dependencies.required_quests`, so the chain's ordering is implicit, not enforced.
 - **Two satellites break the learning flow.** After the momentum of quest 1, a
-  learner hits quest 2 (*Stack Attack Analysis*, an architecture report) and quest 3
-  (*Personal Site*, a reference table) — neither has runnable steps, and both openly
-  admit "objectives auto-seeded during framework alignment." For a UI/UX beginner
-  expecting to *build* something, these read as dead ends and erode trust in the path.
+learner hits quest 2 (*Stack Attack Analysis*, an architecture report) and quest 3 (*Personal Site*, a reference table) — neither has runnable steps, and both openly admit "objectives auto-seeded during framework alignment." For a UI/UX beginner expecting to *build* something, these read as dead ends and erode trust in the path.
 - **Prerequisite gap at quest 4.** *The Summoning* states it needs "a live
-  zer0-mistakes Jekyll site — complete the prequel epic first" (line 96) and a
-  "Claude Code OAuth token" (line 101). Nothing earlier in *this* window provides a
-  zer0-mistakes/remote-theme site — quest 1 builds a **default** `jekyll new` site,
-  not a `bamr87/zer0-mistakes` one. So the summoning's remote-theme + `include_cached`
-  build (the exact thing that fails) lands on a learner who was never walked through
-  a remote-theme build. This is a genuine continuity gap, compounded by issue #5.
+zer0-mistakes Jekyll site — complete the prequel epic first" (line 96) and a "Claude Code OAuth token" (line 101). Nothing earlier in *this* window provides a zer0-mistakes/remote-theme site — quest 1 builds a **default** `jekyll new` site, not a `bamr87/zer0-mistakes` one. So the summoning's remote-theme + `include_cached` build (the exact thing that fails) lands on a learner who was never walked through a remote-theme build. This is a genuine continuity gap, compounded by issue #5.
 - **Quest 5 (*SEO Optimization*) chains best.** It explicitly assumes "an existing
-  Jekyll site" — satisfied by quest 1 — and its concepts build naturally on a deployed
-  site. Its only real snag (the quickstart missing the plugins-list edit, issue #6) is
-  self-contained, not a cross-quest dependency.
+Jekyll site" — satisfied by quest 1 — and its concepts build naturally on a deployed site. Its only real snag (the quickstart missing the plugins-list edit, issue #6) is self-contained, not a cross-quest dependency.
 - **Net:** as a *character path*, a Digital Artist would get real value from quests
-  1 → 5 → 4-once-fixed, but quests 2 and 3 don't yet function as quests and quest 4
-  assumes setup this window never provides. The slice holds together thematically
-  (Web Fundamentals) but not yet as an executable, ordered learning chain.
+1 → 5 → 4-once-fixed, but quests 2 and 3 don't yet function as quests and quest 4 assumes setup this window never provides. The slice holds together thematically (Web Fundamentals) but not yet as an executable, ordered learning chain.
 
 ## 🧠 Reasoning & Method
 
 - **Mode: execute.** Evidence is the workflow-sealed `walk-evidence.json` /
-  `walk-evidence.md` — the agentic execute engine ran each quest's safe snippets in a
-  disposable per-quest sandbox (5 quests, avg 51.6%, ~$4.99, sessions 36-40 turns).
-  Per the skill, I consumed it **as-is**; I did not re-run, regenerate, or edit the
-  engine (its child `claude` processes can't authenticate from my Bash tool), and I
-  did not touch `walk-plan.json` or `walk-evidence.*`.
+`walk-evidence.md` — the agentic execute engine ran each quest's safe snippets in a disposable per-quest sandbox (5 quests, avg 51.6%, ~$4.99, sessions 36-40 turns). Per the skill, I consumed it **as-is**; I did not re-run, regenerate, or edit the engine (its child `claude` processes can't authenticate from my Bash tool), and I did not touch `walk-plan.json` or `walk-evidence.*`.
 - **What I ran vs. reasoned:** all `passed`/`failed`/`skipped` statuses are the
-  engine's actual sandbox results (I quoted its recorded commands and outputs). I
-  additionally **read all five quest sources in plan order** and cross-checked the
-  engine's findings against the source — items I verified only by reading (e.g. the
-  Personal Site table errors at lines 76-88, the Summoning prerequisite at line 96,
-  the SEO quickstart at lines 149-198, the `JEKYLL_ENV` claim at line 400) are the
-  learner-continuity layer and are labeled by line rather than presented as new
-  command runs. I invented no output, score, or issue.
+engine's actual sandbox results (I quoted its recorded commands and outputs). I additionally **read all five quest sources in plan order** and cross-checked the engine's findings against the source — items I verified only by reading (e.g. the Personal Site table errors at lines 76-88, the Summoning prerequisite at line 96, the SEO quickstart at lines 149-198, the `JEKYLL_ENV` claim at line 400) are the learner-continuity layer and are labeled by line rather than presented as new command runs. I invented no output, score, or issue.
 - **Coverage & limits:** this is **window 2 of 6** — 5 of the level's **26** quests.
-  Verdicts apply only to these five; the rest of Digital-Artist/0001 is not certified
-  by this run. Engine snippet accounting was capped where noted (e.g. SEO ran 10 with
-  4 skipped — image-optimization `sips`/`brew`/`imageoptim` and the PowerShell Windows
-  path were not executed in this Linux sandbox). Network-dependent steps (`git clone`
-  of placeholder repos, `git push`) could not truly deploy and are correctly recorded
-  as `reasoned`/expected-fail, not `passed`.
+Verdicts apply only to these five; the rest of Digital-Artist/0001 is not certified by this run. Engine snippet accounting was capped where noted (e.g. SEO ran 10 with 4 skipped — image-optimization `sips`/`brew`/`imageoptim` and the PowerShell Windows path were not executed in this Linux sandbox). Network-dependent steps (`git clone` of placeholder repos, `git push`) could not truly deploy and are correctly recorded as `reasoned`/expected-fail, not `passed`.
 - **Confidence: high** on the five per-quest verdicts (backed by real sandbox
-  builds, including a full Jekyll build/serve for quest 1 and the confirmed
-  `include_cached` failure for quest 4) and on the two "not-a-tutorial" findings
-  (quests 2-3). **Medium** on the chain-continuity conclusions, which are reasoned
-  from reading rather than executed cross-quest.
+builds, including a full Jekyll build/serve for quest 1 and the confirmed `include_cached` failure for quest 4) and on the two "not-a-tutorial" findings (quests 2-3). **Medium** on the chain-continuity conclusions, which are reasoned from reading rather than executed cross-quest.

--- a/pages/_quest-reports/2026-07-17-game-developer-0111.md
+++ b/pages/_quest-reports/2026-07-17-game-developer-0111.md
@@ -38,24 +38,9 @@ source_report: test/quest-validator/walkthroughs/2026-07-17-game-developer-0111.
 
 ## 🎯 Session Summary
 
-I walked the first window (5 of 10 quests) of the **Game Developer → Level 0111
-(API Development, Adventurer ⚔️)** slice as a learner, consuming the workflow-sealed
-execute-mode evidence and reading every quest source in plan order to reason about
-the linked journey. The headline verdict is **fail**: the engine averaged **66.2%**
-with **2 pass, 1 warn, 2 fail**, and the two failing quests are broken in ways a real
-beginner would hit within the first five minutes of the hands-on work.
+I walked the first window (5 of 10 quests) of the **Game Developer → Level 0111 (API Development, Adventurer ⚔️)** slice as a learner, consuming the workflow-sealed execute-mode evidence and reading every quest source in plan order to reason about the linked journey. The headline verdict is **fail**: the engine averaged **66.2%** with **2 pass, 1 warn, 2 fail**, and the two failing quests are broken in ways a real beginner would hit within the first five minutes of the hands-on work.
 
-The slice is really **two unrelated learning tracks braided together** by the
-dependency-sorter: a polished *API Design Mastery* pair (API Fundamentals → REST
-Principles) and a *GH-600 Agentic Codex* trio. Within the agentic trio, the well-built
-hub quest (`agentic-codex-01`, 95%) teaches plan-then-act cleanly with a self-contained
-lab, while the two sibling quests that drill the *same* Domain 1 sub-skills
-(`agentic-sdlc-integration` 44%, `agentic-plan-vs-action-boundaries` 38%) both send the
-learner into a `work/gh-600/` scaffold and a `scripts/validate_quest.py` self-check that
-**do not exist in the repo** — I verified both absences directly. The maintainer-actionable
-takeaway: the API pair is solid, and the agentic content already has a working reference
-(the codex hub) whose lab pattern should replace the broken scaffold assumptions in its two
-siblings.
+The slice is really **two unrelated learning tracks braided together** by the dependency-sorter: a polished *API Design Mastery* pair (API Fundamentals → REST Principles) and a *GH-600 Agentic Codex* trio. Within the agentic trio, the well-built hub quest (`agentic-codex-01`, 95%) teaches plan-then-act cleanly with a self-contained lab, while the two sibling quests that drill the *same* Domain 1 sub-skills (`agentic-sdlc-integration` 44%, `agentic-plan-vs-action-boundaries` 38%) both send the learner into a `work/gh-600/` scaffold and a `scripts/validate_quest.py` self-check that **do not exist in the repo** — I verified both absences directly. The maintainer-actionable takeaway: the API pair is solid, and the agentic content already has a working reference (the codex hub) whose lab pattern should replace the broken scaffold assumptions in its two siblings.
 
 ## 🗺️ The Journey
 
@@ -69,9 +54,7 @@ Plan order (dependency-sorted; `walk-plan.json`):
 
 ## 🔬 Evidence
 
-All results below are from the workflow's sealed `walk-evidence.json` (execute mode,
-`mock: false`), corroborated where noted by my own read-only repo checks. I did **not**
-re-run the engine.
+All results below are from the workflow's sealed `walk-evidence.json` (execute mode, `mock: false`), corroborated where noted by my own read-only repo checks. I did **not** re-run the engine.
 
 ### 1. API Fundamentals — 74 (⚠️ warn) · ran 8/10 runnable snippets (7✓ 1✗), 3 reasoned
 - `docker run --rm curlimages/curl:latest .../posts/1` → **passed**, returned the exact documented JSON object.

--- a/pages/_quest-reports/2026-07-17-security-specialist-1011.md
+++ b/pages/_quest-reports/2026-07-17-security-specialist-1011.md
@@ -37,52 +37,27 @@ source_report: test/quest-validator/walkthroughs/2026-07-17-security-specialist-
 
 ## 🎯 Session Summary
 
-I walked the **window 2 of 3** slice of the **Security Specialist → Level 1011
-(Security & Compliance, 🔥 Warrior)** path: two `main_quest` pages —
-**Penetration Testing** (🔴 Hard) and **Compliance Standards** (🟡 Medium) — in the
-order the planner sorted them. The full level holds 12 quests; this rotating window
-covered the last two.
+I walked the **window 2 of 3** slice of the **Security Specialist → Level 1011 (Security & Compliance, 🔥 Warrior)** path: two `main_quest` pages — **Penetration Testing** (🔴 Hard) and **Compliance Standards** (🟡 Medium) — in the order the planner sorted them. The full level holds 12 quests; this rotating window covered the last two.
 
-**Headline verdict: ⚠️ warn.** Not because a quest is broken, but because the slice
-is only **half-covered by real evidence**. The **Compliance Standards** quest is
-excellent — it scored **97%**, and all **4/4 runnable snippets actually executed and
-passed** in the sandbox with content verified accurate against current framework
-revisions (SOC 2 TSC, ISO 27001:2022, GDPR, PCI-DSS v4.0). But the **Penetration
-Testing** quest yielded **zero execute evidence**: the engine **timed out after 600s**
-and returned a `fail` with `overall: 0`. That is an *engine/tooling* failure, not a
-demonstrated content defect — so I treat every pentest observation below as
-`reasoned` (read statically from source), never `tested`. A maintainer should read
-this as "one quest proven solid, one quest un-walked" and re-run the pentest quest
-with a longer budget before trusting any verdict on it.
+**Headline verdict: ⚠️ warn.** Not because a quest is broken, but because the slice is only **half-covered by real evidence**. The **Compliance Standards** quest is excellent — it scored **97%**, and all **4/4 runnable snippets actually executed and passed** in the sandbox with content verified accurate against current framework revisions (SOC 2 TSC, ISO 27001:2022, GDPR, PCI-DSS v4.0). But the **Penetration Testing** quest yielded **zero execute evidence**: the engine **timed out after 600s** and returned a `fail` with `overall: 0`. That is an *engine/tooling* failure, not a demonstrated content defect — so I treat every pentest observation below as `reasoned` (read statically from source), never `tested`. A maintainer should read this as "one quest proven solid, one quest un-walked" and re-run the pentest quest with a longer budget before trusting any verdict on it.
 
 ## 🗺️ The Journey
 
 1. ❌ **Penetration Testing: Tools and Ethical Hacking Methodologies** — score **—**
-   (engine timed out after 600s; no snippets run) · *Content reads well and is
-   ethics-first, but it is heavy on external tooling (docker, brew/winget casks,
-   nmap, Burp/ZAP) — almost certainly why the execute engine exhausted its 600s
-   budget. Un-walked; reasoned-only.*
+(engine timed out after 600s; no snippets run) · *Content reads well and is ethics-first, but it is heavy on external tooling (docker, brew/winget casks, nmap, Burp/ZAP) — almost certainly why the execute engine exhausted its 600s budget. Un-walked; reasoned-only.*
 2. ✅ **Compliance Standards: SOC 2, ISO 27001, GDPR, and PCI-DSS** — score **97**
-   (4/4 runnable snippets passed, 4 reasoned) · *A clean, accurate, well-structured
-   documentation/process quest; only thin spots are two lightly-covered secondary
-   objectives.*
+(4/4 runnable snippets passed, 4 reasoned) · *A clean, accurate, well-structured documentation/process quest; only thin spots are two lightly-covered secondary objectives.*
 
 ## 🔬 Evidence
 
 ### Quest 1 — Penetration Testing (❌ no evidence gathered)
 
 - **Engine result:** `error: "claude timed out after 600s"`, `verdict: fail`,
-  `overall: 0.0`, `verdict_obj: null`. No commands were recorded, no snippets ran,
-  no per-dimension scores exist.
+`overall: 0.0`, `verdict_obj: null`. No commands were recorded, no snippets ran, no per-dimension scores exist.
 - **Coverage:** ran **0** snippets — this quest was **not executed**. Everything I say
-  about it is `reasoned` from the source file (`pages/_quests/1011/penetration-testing.md`),
-  not witnessed in the sandbox.
+about it is `reasoned` from the source file (`pages/_quests/1011/penetration-testing.md`), not witnessed in the sandbox.
 - **Why it likely timed out (reasoned):** every platform path front-loads slow,
-  network-heavy installs and container pulls — `brew install --cask zap/burp-suite`
-  (macOS), `winget install …` (Windows), `sudo apt install -y nmap zaproxy` +
-  `docker run … bkimminich/juice-shop` (Linux). An execute engine attempting these
-  will spend its whole budget on downloads. This is consistent with a 600s timeout
-  and is itself a real learner-friction signal (see Issues).
+network-heavy installs and container pulls — `brew install --cask zap/burp-suite` (macOS), `winget install …` (Windows), `sudo apt install -y nmap zaproxy` + `docker run … bkimminich/juice-shop` (Linux). An execute engine attempting these will spend its whole budget on downloads. This is consistent with a 600s timeout and is itself a real learner-friction signal (see Issues).
 
 ### Quest 2 — Compliance Standards (✅ executed, 97%)
 
@@ -100,10 +75,7 @@ Commands actually run (from `walk-evidence.json`):
 | Linux: `mkdir` → `echo … > csv` → `git init -q && git add` | ✅ passed | `git status` afterward confirmed `controls-matrix.csv` staged as a new file |
 | Cloud Realms: `echo "Inherit provider controls; you remain responsible…"` | ✅ passed | Printed the expected shared-responsibility string verbatim |
 
-Reasoned (non-runnable) content the engine verified as accurate: the SOC 2 vs
-ISO 27001 comparison table, the PCI-DSS 1–12 requirement groupings (matches v4.0),
-the MFA controls-mapping matrix (SOC 2 CC6.1 / ISO 27001 A.8.5 / GDPR Art. 32 /
-PCI-DSS Req. 8.4-8.5), and the audit-evidence / Type II period discussion.
+Reasoned (non-runnable) content the engine verified as accurate: the SOC 2 vs ISO 27001 comparison table, the PCI-DSS 1–12 requirement groupings (matches v4.0), the MFA controls-mapping matrix (SOC 2 CC6.1 / ISO 27001 A.8.5 / GDPR Art. 32 / PCI-DSS Req. 8.4-8.5), and the audit-evidence / Type II period discussion.
 
 > From `walk-evidence.md`: *"all four platform snippets ran successfully in the
 > sandbox exactly as described. Minor gaps exist only in the depth of coverage for
@@ -111,101 +83,48 @@ PCI-DSS Req. 8.4-8.5), and the audit-evidence / Type II period discussion.
 
 ## 🐞 Issues Found
 
-**Penetration Testing** (all `reasoned` — the quest was not executed, so these are
-static-read observations, not sandbox-witnessed failures):
+**Penetration Testing** (all `reasoned` — the quest was not executed, so these are static-read observations, not sandbox-witnessed failures):
 
 - **medium · Penetration Testing · platform setup blocks (lines 147-188) · engine
-  timeout / heavy prerequisites.** The engine **timed out after 600s** and captured
-  no evidence. Reading the source, every path requires large external installs plus a
-  Docker container pull (`docker run … bkimminich/juice-shop`). *Suggested fix:*
-  offer a lighter "no-install / hosted lab" default (the Cloud Realms path already
-  points at PortSwigger Academy + TryHackMe — promote it as the primary walkthrough
-  target) so both a real beginner and the execute engine can complete the quest
-  without a multi-hundred-MB toolchain. This is the single highest-value change for
-  making this quest walkable.
+timeout / heavy prerequisites.** The engine **timed out after 600s** and captured no evidence. Reading the source, every path requires large external installs plus a Docker container pull (`docker run … bkimminich/juice-shop`). *Suggested fix:* offer a lighter "no-install / hosted lab" default (the Cloud Realms path already points at PortSwigger Academy + TryHackMe — promote it as the primary walkthrough target) so both a real beginner and the execute engine can complete the quest without a multi-hundred-MB toolchain. This is the single highest-value change for making this quest walkable.
 - **low · Penetration Testing · Linux path (lines 183-187) · privilege assumption.**
-  `sudo apt install …` and `sudo docker run …` assume passwordless sudo and a Docker
-  daemon. A learner on a locked-down machine (or the sandbox) gets stuck with no
-  fallback. *Suggested fix:* note the rootless/Docker-Desktop alternative and that
-  `sudo` may be unavailable.
+`sudo apt install …` and `sudo docker run …` assume passwordless sudo and a Docker daemon. A learner on a locked-down machine (or the sandbox) gets stuck with no fallback. *Suggested fix:* note the rootless/Docker-Desktop alternative and that `sudo` may be unavailable.
 - **low · Penetration Testing · Chapter 3 (line 308) · `zap.sh` on PATH.** The
-  headless command `zap.sh -cmd …` assumes `zap.sh` is on `PATH`, but the macOS cask
-  and Windows winget installs don't guarantee that binary name/location. *Suggested
-  fix:* mention the platform-specific launcher path or that ZAP must be started from
-  its install dir.
+headless command `zap.sh -cmd …` assumes `zap.sh` is on `PATH`, but the macOS cask and Windows winget installs don't guarantee that binary name/location. *Suggested fix:* mention the platform-specific launcher path or that ZAP must be started from its install dir.
 - **low · Penetration Testing · Knowledge Graph (line 436) · stale wiki-link title.**
-  The `**Unlocks:**` link reads `[[Compliance Standards: SOC 2, GDPR, and HIPAA
-  Requirements]]`, but the actual unlocked quest is titled **"SOC 2, ISO 27001,
-  GDPR, and PCI-DSS"** — it covers PCI-DSS, not HIPAA. *Suggested fix:* update the
-  wiki-link to the current title so the graph resolves and no beginner expects a
-  HIPAA chapter that doesn't exist.
+The `**Unlocks:**` link reads `[[Compliance Standards: SOC 2, GDPR, and HIPAA Requirements]]`, but the actual unlocked quest is titled **"SOC 2, ISO 27001, GDPR, and PCI-DSS"** — it covers PCI-DSS, not HIPAA. *Suggested fix:* update the wiki-link to the current title so the graph resolves and no beginner expects a HIPAA chapter that doesn't exist.
 
 **Compliance Standards** (low, from the engine's own recommendations):
 
 - **low · Compliance Standards · Secondary Objectives (lines 105, 107) · thin
-  coverage.** "Gap Assessment" appears only as an unguided mastery challenge and
-  "Shared Responsibility" is only the one-line Cloud Realms echo — both are named
-  objectives. *Suggested fix:* add a short worked example (a mini gap-assessment row;
-  2-3 sentences on provider-vs-customer ownership).
+coverage.** "Gap Assessment" appears only as an unguided mastery challenge and "Shared Responsibility" is only the one-line Cloud Realms echo — both are named objectives. *Suggested fix:* add a short worked example (a mini gap-assessment row; 2-3 sentences on provider-vs-customer ownership).
 - **low · Compliance Standards · Continuous Compliance (line 313) · one-paragraph
-  depth.** Vanta/Drata/custom-scripts get a single paragraph. *Suggested fix:* add a
-  concrete example of what an automated evidence query might check.
+depth.** Vanta/Drata/custom-scripts get a single paragraph. *Suggested fix:* add a concrete example of what an automated evidence query might check.
 
-No **high-severity, sandbox-witnessed** content failures were found. The only high-
-impact problem in this slice is the **inability to gather evidence for the pentest
-quest at all**, which is a tooling/budget issue to resolve on re-run.
+No **high-severity, sandbox-witnessed** content failures were found. The only high- impact problem in this slice is the **inability to gather evidence for the pentest quest at all**, which is a tooling/budget issue to resolve on re-run.
 
 ## 🔗 Chain Continuity
 
 Reading the two quests as one journey a Security Specialist would actually take:
 
 - **Prerequisites are met by earlier windows, not this one.** Both quests declare
-  `required_quests: /quests/1011/security-fundamentals/`. That quest sits in an
-  earlier window of this level (this is window 2 of 3, offset 10), so a learner
-  reaching here is *assumed* to have the CIA-triad / controls grounding both quests
-  lean on. Within this window nothing is orphaned — neither quest assumes setup the
-  other was supposed to provide.
+`required_quests: /quests/1011/security-fundamentals/`. That quest sits in an earlier window of this level (this is window 2 of 3, offset 10), so a learner reaching here is *assumed* to have the CIA-triad / controls grounding both quests lean on. Within this window nothing is orphaned — neither quest assumes setup the other was supposed to provide.
 - **Ordering is correct and the narrative hands off cleanly.** Penetration Testing
-  declares `unlocks_quests: /quests/1011/compliance-standards/`, and Compliance
-  Standards lists pentest as a `recommended_quest`. The pentest quest's closing
-  "Unlocked Quests" explicitly frames the transition — *"Compliance Standards —
-  Penetration tests are often a required audit control"* — and Compliance Standards
-  pays it off in Chapter 2 (PCI-DSS requirements 10-11: *"logging, scans, penetration
-  tests"*). A learner finishing the pentest report arrives at compliance understanding
-  *why* that report is audit evidence. That is genuinely good linked design.
+declares `unlocks_quests: /quests/1011/compliance-standards/`, and Compliance Standards lists pentest as a `recommended_quest`. The pentest quest's closing "Unlocked Quests" explicitly frames the transition — *"Compliance Standards — Penetration tests are often a required audit control"* — and Compliance Standards pays it off in Chapter 2 (PCI-DSS requirements 10-11: *"logging, scans, penetration tests"*). A learner finishing the pentest report arrives at compliance understanding *why* that report is audit evidence. That is genuinely good linked design.
 - **The forward continuity I could verify holds; the backward half I could not
-  execute.** Because the pentest quest never ran, I cannot confirm from evidence that
-  a learner actually *completes* it and emerges "ready" for compliance — only that
-  the two pages are wired together correctly and the prose transition is coherent.
-  The likely real-world snag is upstream of the narrative: a beginner may stall on the
-  pentest tooling install (same friction that timed out the engine) and never reach
-  the hand-off. Making the hosted-lab path the default would protect the whole chain.
+execute.** Because the pentest quest never ran, I cannot confirm from evidence that a learner actually *completes* it and emerges "ready" for compliance — only that the two pages are wired together correctly and the prose transition is coherent. The likely real-world snag is upstream of the narrative: a beginner may stall on the pentest tooling install (same friction that timed out the engine) and never reach the hand-off. Making the hosted-lab path the default would protect the whole chain.
 - **One cosmetic graph break:** the pentest quest's Obsidian `Unlocks` wiki-link names
-  a "HIPAA" version of the compliance quest that doesn't exist (see Issues) — a
-  learner exploring the graph would hit a dead/renamed node.
+a "HIPAA" version of the compliance quest that doesn't exist (see Issues) — a learner exploring the graph would hit a dead/renamed node.
 
 ## 🧠 Reasoning & Method
 
 - **Mode:** `execute`. I consumed **sealed, workflow-minted evidence**
-  (`walk-plan.json` + `walk-evidence.json` + `walk-evidence.md`) exactly as provided.
-  I did **not** run, regenerate, or edit the engine or its evidence (the engine's
-  child `claude` processes cannot authenticate from my Bash tool), and I did not edit
-  any quest content. My only write is this report.
+(`walk-plan.json` + `walk-evidence.json` + `walk-evidence.md`) exactly as provided. I did **not** run, regenerate, or edit the engine or its evidence (the engine's child `claude` processes cannot authenticate from my Bash tool), and I did not edit any quest content. My only write is this report.
 - **What was tested vs. reasoned:** Only **Compliance Standards** carries real
-  sandbox evidence (4/4 runnable snippets executed and passed; 4 text blocks
-  reasoned). **Penetration Testing carries no evidence** — the engine timed out at
-  600s — so every statement I make about it is `reasoned` from the source file, and I
-  have labeled it as such throughout. I did not fabricate a score, command, or output
-  for it.
+sandbox evidence (4/4 runnable snippets executed and passed; 4 text blocks reasoned). **Penetration Testing carries no evidence** — the engine timed out at 600s — so every statement I make about it is `reasoned` from the source file, and I have labeled it as such throughout. I did not fabricate a score, command, or output for it.
 - **Coverage honesty:** This was a **2-quest window (2 of 3)** of a 12-quest level;
-  I did **not** walk the other 10 quests, and I did not walk the level's prerequisite
-  chain — those belong to other windows and are accumulated by the perfection ledger
-  over time. Within my window, **50% of quests produced usable evidence**; the pentest
-  quest is effectively un-walked and should not be counted as validated.
+I did **not** walk the other 10 quests, and I did not walk the level's prerequisite chain — those belong to other windows and are accumulated by the perfection ledger over time. Within my window, **50% of quests produced usable evidence**; the pentest quest is effectively un-walked and should not be counted as validated.
 - **Confidence:** **High** on the Compliance Standards verdict (direct, reproducible
-  execute evidence, accurate content). **Low** on Penetration Testing — I can only
-  attest that it reads coherently and is ethics-first; I cannot attest that its
-  commands work, because none were run. The `warn` overall verdict reflects that split.
+execute evidence, accurate content). **Low** on Penetration Testing — I can only attest that it reads coherently and is ethics-first; I cannot attest that its commands work, because none were run. The `warn` overall verdict reflects that split.
 - **Recommended next action:** re-run the Penetration Testing quest through the execute
-  engine with a larger time/turn budget, or after promoting the hosted-lab (Cloud
-  Realms) path to primary so the sandbox isn't forced through heavyweight installs.
+engine with a larger time/turn budget, or after promoting the hosted-lab (Cloud Realms) path to primary so the sandbox isn't forced through heavyweight installs.

--- a/pages/_quest-reports/2026-07-17-system-engineer-1001.md
+++ b/pages/_quest-reports/2026-07-17-system-engineer-1001.md
@@ -37,26 +37,11 @@ source_report: test/quest-validator/walkthroughs/2026-07-17-system-engineer-1001
 
 ## 🎯 Session Summary
 
-I walked a **5-quest window** (window 1 of 2; the level holds 9 quests total) of the
-**System Engineer** path at **Level 1001 — "Kubernetes Orchestration" (Warrior 🔥)**,
-as a learner following each quest end-to-end. Evidence comes from the sealed
-execute-mode engine run (`walk-evidence.json`), which sandboxed each quest and ran its
-safe snippets for real; my value-add is reasoning about the five as one linked journey.
+I walked a **5-quest window** (window 1 of 2; the level holds 9 quests total) of the **System Engineer** path at **Level 1001 — "Kubernetes Orchestration" (Warrior 🔥)**, as a learner following each quest end-to-end. Evidence comes from the sealed execute-mode engine run (`walk-evidence.json`), which sandboxed each quest and ran its safe snippets for real; my value-add is reasoning about the five as one linked journey.
 
-**Headline verdict: ⚠️ warn.** Average score **75.4%** — two strong passes
-(Kubernetes Fundamentals 92, Codex Memory & State 97), two warns (Safe Execution 67,
-Memory Strategies 65) and one **fail** (Dev Environment Integration 56). The two
-bookend quests are genuinely excellent hands-on labs. The problem is concentrated in
-the middle three GH-600 agentic quests (Q6→Q7→Q8), which share three *repeating,
-verified* defects: a `scripts/validate_quest.py` "Quest Validation" command that does
-not exist (fails identically in Q6, Q7 **and** Q8), undefined cross-quest file
-dependencies (`copilot-instructions.md`, `run_agent_task.py`), and hollow/broken
-"do this" artifacts. A maintainer can fix most of the slice by addressing those three
-patterns once, across the chain.
+**Headline verdict: ⚠️ warn.** Average score **75.4%** — two strong passes (Kubernetes Fundamentals 92, Codex Memory & State 97), two warns (Safe Execution 67, Memory Strategies 65) and one **fail** (Dev Environment Integration 56). The two bookend quests are genuinely excellent hands-on labs. The problem is concentrated in the middle three GH-600 agentic quests (Q6→Q7→Q8), which share three *repeating, verified* defects: a `scripts/validate_quest.py` "Quest Validation" command that does not exist (fails identically in Q6, Q7 **and** Q8), undefined cross-quest file dependencies (`copilot-instructions.md`, `run_agent_task.py`), and hollow/broken "do this" artifacts. A maintainer can fix most of the slice by addressing those three patterns once, across the chain.
 
-A second, structural observation: this level's theme is **"Kubernetes Orchestration,"**
-yet **4 of the 5 quests are GH-600 agentic-AI content with no Kubernetes in them.** Only
-`kubernetes-fundamentals` matches the level name.
+A second, structural observation: this level's theme is **"Kubernetes Orchestration,"** yet **4 of the 5 quests are GH-600 agentic-AI content with no Kubernetes in them.** Only `kubernetes-fundamentals` matches the level name.
 
 ## 🗺️ The Journey
 
@@ -72,35 +57,24 @@ Walked in planner order (dependency-sorted):
 
 ## 🔬 Evidence
 
-All outcomes below are from the sealed execute-mode engine run (`walk-evidence.json`);
-`reasoned` marks snippets judged statically (not runnable in the sandbox, e.g. GitHub
-Actions-only YAML). Outputs are quoted trimmed from the evidence.
+All outcomes below are from the sealed execute-mode engine run (`walk-evidence.json`); `reasoned` marks snippets judged statically (not runnable in the sandbox, e.g. GitHub Actions-only YAML). Outputs are quoted trimmed from the evidence.
 
 ### 1 · Codex Ch. III — Memory & State — 97 ✅ (ran 8, 7 passed / 1 failed; 6 reasoned)
 
 - **Lab Step 1–5 (bash)** — all **passed**. The full drift-guard transcript reproduced
-  the quest's "Expected" block *byte-for-byte*: `Snapshot taken.` / `No drift — safe to
-  act.` / `exit=0` / `README.md: FAILED` / `sha256sum: WARNING: 1 computed checksum did
-  NOT match` / `::warning::Context drift detected…` / `exit=78`. Tier-2 plan/act emitted
-  exactly `read`/`edit`/`verify`; Tier-3 JSONL register read back `local-1 → completed`;
-  context-handoff produced `handoff fresh (0s old) — proceeding`.
+the quest's "Expected" block *byte-for-byte*: `Snapshot taken.` / `No drift — safe to act.` / `exit=0` / `README.md: FAILED` / `sha256sum: WARNING: 1 computed checksum did NOT match` / `::warning::Context drift detected…` / `exit=78`. Tier-2 plan/act emitted exactly `read`/`edit`/`verify`; Tier-3 JSONL register read back `local-1 → completed`; context-handoff produced `handoff fresh (0s old) — proceeding`.
 - **Chapter-3 `drift-guard.sh` (WATCH includes `_config.yml`)** — **failed** in a scratch
-  dir (`sha256sum: _config.yml: No such file or directory`, exit 1). This is the *exact*
-  failure the quest flags inline ("EDIT for YOUR repo — a missing file kills snapshot()
-  under set -e"), so it is documented/intentional template behavior, not a defect.
+dir (`sha256sum: _config.yml: No such file or directory`, exit 1). This is the *exact* failure the quest flags inline ("EDIT for YOUR repo — a missing file kills snapshot() under set -e"), so it is documented/intentional template behavior, not a defect.
 - 4 workflow YAML blocks + the context-handoff JSON — **reasoned** (parse-valid;
   Actions-only pieces can't run in-sandbox, but their local analogues matched).
 
 ### 2 · Q6 — Dev Environment Integration — 56 ❌ (ran 4, 2 passed / 2 failed, 2 skipped; 1 reasoned)
 
 - **`AGENTS.md` (Ex 6.1)** and **`devcontainer.json` (Ex 6.2)** — **passed** as written;
-  `npx @devcontainers/cli read-configuration` parsed the devcontainer, and `docker
-  manifest inspect` confirmed both `mcr.microsoft.com/devcontainers/javascript-node:1-18-bullseye`
-  and `ghcr.io/devcontainers/features/github-cli:1` resolve to real registry artifacts.
+`npx @devcontainers/cli read-configuration` parsed the devcontainer, and `docker manifest inspect` confirmed both `mcr.microsoft.com/devcontainers/javascript-node:1-18-bullseye` and `ghcr.io/devcontainers/features/github-cli:1` resolve to real registry artifacts.
 - **`check_agent_env.sh` (Ex 6.3)** — **failed**. Ran cleanly as a script but reported
   `Passed: 7 | Failed: 1`, exit 1, `❌ Environment not ready for agent use.` — because
-  its `check "copilot-instructions.md present" "test -f .github/copilot-instructions.md"`
-  looks for a file **no exercise ever creates**.
+its `check "copilot-instructions.md present" "test -f .github/copilot-instructions.md"` looks for a file **no exercise ever creates**.
 - **Cold-start clone & Quest Validation** — **skipped**: `YOUR_ORG/YOUR_REPO` is a
   placeholder (intentional templating), and `scripts/validate_quest.py` is not present.
 - Caveat surfaced by testing: `jq` / `python json.load` both reject the devcontainer file
@@ -109,15 +83,9 @@ Actions-only YAML). Outputs are quoted trimmed from the evidence.
 ### 3 · Q7 — Safe Execution & Error Handling — 67 ⚠️ (ran 5, 4 passed / 1 failed; 2 reasoned)
 
 - **`agent-with-retries.yml` retry loop** — **passed**. Simulated end-to-end against a
-  mock `run_agent_task.py`: transient error retried with 1s/2s backoff then succeeded on
-  attempt 3 (exit 0); `auth_error` escalated immediately with no retry (exit 1);
-  persistent errors exhausted 3 attempts and emitted `error_code=max_retries_exceeded`.
-  All three documented behaviors verified. YAML passes `yamllint`; the error-report JSON
-  schema is valid.
+mock `run_agent_task.py`: transient error retried with 1s/2s backoff then succeeded on attempt 3 (exit 0); `auth_error` escalated immediately with no retry (exit 1); persistent errors exhausted 3 attempts and emitted `error_code=max_retries_exceeded`. All three documented behaviors verified. YAML passes `yamllint`; the error-report JSON schema is valid.
 - **`test_failure_scenarios.sh` (Ex 7.3)** — recorded **passed** only in the sense that
-  the shell exited 0; the engine flags it as a **hollow stub** — every "scenario" is just
-  an `echo` and a `# Mock a 503 response and verify…` comment; it never invokes the
-  workflow, mocks a response, or asserts anything.
+the shell exited 0; the engine flags it as a **hollow stub** — every "scenario" is just an `echo` and a `# Mock a 503 response and verify…` comment; it never invokes the workflow, mocks a response, or asserts anything.
 - **`python3 scripts/validate_quest.py --quest q7`** — **failed**: `python3: can't open
   file '.../scripts/validate_quest.py': [Errno 2] No such file or directory`.
 
@@ -125,9 +93,7 @@ Actions-only YAML). Outputs are quoted trimmed from the evidence.
 
 - **`mkdir -p docs/agent-memory && touch …` (Ex 8.2)** — **passed**; all three files created.
 - **`agent-with-session-memory.yml` (Ex 8.1)** — **reasoned**, with a *verified* bug:
-  after correctly accounting for YAML block-scalar dedent, the heredoc runs, but because
-  the delimiter is quoted (`<< 'EOF'`), `"started_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"`
-  is **never expanded** — `session.json` literally stores the command string, not a timestamp.
+after correctly accounting for YAML block-scalar dedent, the heredoc runs, but because the delimiter is quoted (`<< 'EOF'`), `"started_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"` is **never expanded** — `session.json` literally stores the command string, not a timestamp.
 - **`python3 scripts/validate_quest.py --quest q8`** — **failed** (same missing script as Q7).
 - 4 markdown/config blocks (`copilot-instructions.md` snippets, learned-patterns example) — skipped (illustrative, not runnable).
 
@@ -136,88 +102,56 @@ Actions-only YAML). Outputs are quoted trimmed from the evidence.
 - **`kind create cluster --name citadel` → `kubectl cluster-info` / `get nodes`** —
   **passed**; node `Ready` after ~30s.
 - **`hello-pod.yaml` apply / describe / logs / exec**, imperative `kubectl run
-  hello --image=nginx:1.27`, namespace workflow (`create namespace dojo` → apply → set
-  context) — all **passed**.
+hello --image=nginx:1.27`, namespace workflow (`create namespace dojo` → apply → set context) — all **passed**.
 - **Self-healing demo** — **passed**: after `kubectl delete pod hello-pod`, the bare Pod
   did **not** return, confirming the quest's central claim.
 - **Advanced Challenge** — **passed**: `image: nginx:does-not-exist` reproduced
-  `ErrImagePull` → `ImagePullBackOff`, diagnosed via the Events pipeline, fixed to
-  `nginx:1.27`, re-applied → `Running`.
+`ErrImagePull` → `ImagePullBackOff`, diagnosed via the Events pipeline, fixed to `nginx:1.27`, re-applied → `Running`.
 - macOS `brew` / Windows `winget` install blocks — **skipped** (OS-gated on a Linux sandbox).
 
 ## 🐞 Issues Found
 
-Concrete, evidence-backed problems. Severity per the rubric's learner-impact lens.
-Verified = a command actually ran in the sandbox; reasoned = judged from reading the
-sources + evidence across the chain.
+Concrete, evidence-backed problems. Severity per the rubric's learner-impact lens. Verified = a command actually ran in the sandbox; reasoned = judged from reading the sources + evidence across the chain.
 
 - **HIGH · Q6 · Chapter 4 / `check_agent_env.sh` · verified** — Script always reports
   failure (`Passed: 7 | Failed: 1`, exit 1) because it checks for
-  `.github/copilot-instructions.md`, which **no exercise in the quest ever creates**. A
-  learner who follows the quest exactly can never get a green environment check, gutting
-  the whole validation chapter. *Fix:* add an exercise that creates
-  `.github/copilot-instructions.md` (with sample content), or remove that check.
+`.github/copilot-instructions.md`, which **no exercise in the quest ever creates**. A learner who follows the quest exactly can never get a green environment check, gutting the whole validation chapter. *Fix:* add an exercise that creates `.github/copilot-instructions.md` (with sample content), or remove that check.
 - **HIGH · Q7 · Quest Validation · verified** — `python3 scripts/validate_quest.py
-  --quest q7` fails with `No such file or directory`. *Fix:* ship the script, or replace
-  with a runnable check (e.g. `actionlint .github/workflows/agent-with-retries.yml`), or
-  clearly label the block as illustrative expected-output.
+--quest q7` fails with `No such file or directory`. *Fix:* ship the script, or replace with a runnable check (e.g. `actionlint .github/workflows/agent-with-retries.yml`), or clearly label the block as illustrative expected-output.
 - **HIGH · Q7 · Chapter 4 / Exercise 7.3 · verified** — `test_failure_scenarios.sh` is an
-  echo-only stub; it fulfils the "Test failure recovery" objective on paper but tests
-  nothing. *Fix:* replace with a real script that mocks each failure mode and asserts the
-  retry-count / escalation output (the engine's sandbox did exactly this with a stub
-  `run_agent_task.py`).
+echo-only stub; it fulfils the "Test failure recovery" objective on paper but tests nothing. *Fix:* replace with a real script that mocks each failure mode and asserts the retry-count / escalation output (the engine's sandbox did exactly this with a stub `run_agent_task.py`).
 - **HIGH · Q8 · Chapter 3 / `session.json` `started_at` · verified** — `$(date …)` inside
-  the quoted `<< 'EOF'` heredoc never expands; the timestamp field is stored as the
-  literal command string. *Fix:* unquote the delimiter for expanded fields, or compute
-  `NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)` on a separate `run` line and interpolate `$NOW`.
+the quoted `<< 'EOF'` heredoc never expands; the timestamp field is stored as the literal command string. *Fix:* unquote the delimiter for expanded fields, or compute `NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)` on a separate `run` line and interpolate `$NOW`.
 - **HIGH · Q8 · Quest Validation · verified** — same missing `scripts/validate_quest.py`
   as Q7 (`No such file or directory`). *Fix:* provide the script or mark the block illustrative.
 - **MEDIUM · Q7 · Chapter 2 workflow dependency · reasoned** — the workflow calls
-  `python3 work/gh-600/scripts/run_agent_task.py`, never defined in this quest and not
-  produced by Q6 (which only creates `check_agent_env.sh`). Prerequisites don't call it
-  out, so the workflow is unrunnable from the chain alone. *Fix:* state where it comes
-  from, or include a minimal stub.
+`python3 work/gh-600/scripts/run_agent_task.py`, never defined in this quest and not produced by Q6 (which only creates `check_agent_env.sh`). Prerequisites don't call it out, so the workflow is unrunnable from the chain alone. *Fix:* state where it comes from, or include a minimal stub.
 - **MEDIUM · Q6 · Chapter 5 / cold-start · verified+reasoned** — `AGENTS.md` calls
-  `GITHUB_TOKEN` a "fine-grained PAT" but the example uses `ghp_yourToken` (classic-PAT
-  prefix; fine-grained is `github_pat_…`). Placeholder token also makes the check appear
-  runnable when it isn't. *Fix:* reconcile the prefix and note the token must be real.
+`GITHUB_TOKEN` a "fine-grained PAT" but the example uses `ghp_yourToken` (classic-PAT prefix; fine-grained is `github_pat_…`). Placeholder token also makes the check appear runnable when it isn't. *Fix:* reconcile the prefix and note the token must be real.
 - **MEDIUM · Q8 · Chapter 2 objective · reasoned** — "Implement ephemeral memory" is only
-  prose about `copilot-instructions.md`; no concrete exercise/artifact, unlike the other
-  two tiers. *Fix:* add a short worked example.
+prose about `copilot-instructions.md`; no concrete exercise/artifact, unlike the other two tiers. *Fix:* add a short worked example.
 - **MEDIUM · Kubernetes Fundamentals · Chapter 2 · reasoned** — the object-model YAML is
-  never explicitly named; the filename `hello-pod.yaml` is only inferable from the later
-  `kubectl apply -f hello-pod.yaml`. *Fix:* tell the learner to save it as `hello-pod.yaml`.
+never explicitly named; the filename `hello-pod.yaml` is only inferable from the later `kubectl apply -f hello-pod.yaml`. *Fix:* tell the learner to save it as `hello-pod.yaml`.
 - **MEDIUM · Kubernetes Fundamentals · Windows path · reasoned** — `winget install -e
-  --id Kubernetes.kind` uses a package id the engine could not verify as real (kind's
-  docs recommend Chocolatey / `go install` / binary download on Windows). *Fix:* verify
-  or replace to avoid dead-ending Windows learners.
+--id Kubernetes.kind` uses a package id the engine could not verify as real (kind's docs recommend Chocolatey / `go install` / binary download on Windows). *Fix:* verify or replace to avoid dead-ending Windows learners.
 - **LOW · Q6 · devcontainer.json JSONC · verified** — leading `//` comment makes `jq`/
-  strict JSON linters reject the file even though `@devcontainers/cli` accepts it. *Fix:*
-  drop the comment or add a one-line JSONC note.
+strict JSON linters reject the file even though `@devcontainers/cli` accepts it. *Fix:* drop the comment or add a one-line JSONC note.
 - **LOW · Codex Ch. III · Prerequisites vs Lab · verified** — Prerequisites promise "you
-  will run real workflows that upload artifacts and commit files," but the lab is entirely
-  local git/jq/sha256sum; real Actions is never exercised. *Fix:* add a minimal
-  `workflow_dispatch` exercise or soften the prerequisite wording.
+will run real workflows that upload artifacts and commit files," but the lab is entirely local git/jq/sha256sum; real Actions is never exercised. *Fix:* add a minimal `workflow_dispatch` exercise or soften the prerequisite wording.
 - **LOW · Q7 · jq fallback · verified** — `jq -r '.error_code // "unknown"'` yields an
   empty string (not `"unknown"`) when `agent-result.json` is absent entirely. *Fix:*
   guard with `[ -f agent-result.json ]` or `|| echo unknown`.
 - **LOW · Q6/Q7/Q8 · Level metadata · reasoned** — filed under "Kubernetes Orchestration"
-  but contain zero Kubernetes; they are GH-600 / GitHub Actions content. *Fix:* reclassify
-  under the GH-600 / agentic-CI track (see Chain Continuity).
+but contain zero Kubernetes; they are GH-600 / GitHub Actions content. *Fix:* reclassify under the GH-600 / agentic-CI track (see Chain Continuity).
 
-No fabricated results: every "passed/failed" above is an engine-run command; everything
-labeled `reasoned` was judged from the source + evidence, not executed.
+No fabricated results: every "passed/failed" above is an engine-run command; everything labeled `reasoned` was judged from the source + evidence, not executed.
 
 ## 🔗 Chain Continuity
 
-Reading the five in order as one learner, the slice is really **three overlapping
-tracks**, not one path — and the cross-quest seams are where the real problems live:
+Reading the five in order as one learner, the slice is really **three overlapping tracks**, not one path — and the cross-quest seams are where the real problems live:
 
 1. **The clean linear chain Q6 → Q7 → Q8** (dev-env → safe-execution → memory-strategies)
-   is well-wired by frontmatter (`required_quests`/`unlocks_quests`) and by `sub_title`
-   ("Quest 1/3, 2/3, 3/3"). Ordering is correct and each quest's mermaid "Quest Network
-   Position" agrees with its neighbors (Q5→Q6→Q7→Q8→Q9). **But three prerequisite/handoff
-   gaps break the journey:**
+is well-wired by frontmatter (`required_quests`/`unlocks_quests`) and by `sub_title` ("Quest 1/3, 2/3, 3/3"). Ordering is correct and each quest's mermaid "Quest Network Position" agrees with its neighbors (Q5→Q6→Q7→Q8→Q9). **But three prerequisite/handoff gaps break the journey:**
    - **`copilot-instructions.md` is orphaned across the chain.** Q6's parity check
      *requires* `.github/copilot-instructions.md` (verified failure), and Q8 twice tells
      the learner to "update in `copilot-instructions.md`" — yet **no quest in the slice
@@ -234,54 +168,22 @@ tracks**, not one path — and the cross-quest seams are where the real problems
      that a learner hits at the finish line of each.
 
 2. **Codex Ch. III (quest 1) is a parallel "campaign" map**, not a step in the Q6→Q7→Q8
-   line. Its own network diagram is Codex Ch. II → III → IV (levels 1000→1001→1010), and it
-   explicitly points at `agentic-memory-strategies` (Q8) as one of "the chambers" of
-   Domain 3. So it *does* connect to Q8 — but it also **overlaps** it: both teach the
-   three-tier memory model, and they disagree in a way a learner would notice.
-   Codex Ch. III defines **Tier 2 / session = "one run, across jobs," artifacts**; Q8's
-   table defines **Session = "Hours to days," artifacts + issue comments, persist across
-   runs.** A learner reading both gets two different lifespans for "session memory." Worth
-   reconciling so the map and the chamber agree. (Notably, Codex Ch. III is the far
-   stronger, fully-runnable treatment; Q8 is the weaker duplicate.)
+line. Its own network diagram is Codex Ch. II → III → IV (levels 1000→1001→1010), and it explicitly points at `agentic-memory-strategies` (Q8) as one of "the chambers" of Domain 3. So it *does* connect to Q8 — but it also **overlaps** it: both teach the three-tier memory model, and they disagree in a way a learner would notice. Codex Ch. III defines **Tier 2 / session = "one run, across jobs," artifacts**; Q8's table defines **Session = "Hours to days," artifacts + issue comments, persist across runs.** A learner reading both gets two different lifespans for "session memory." Worth reconciling so the map and the chamber agree. (Notably, Codex Ch. III is the far stronger, fully-runnable treatment; Q8 is the weaker duplicate.)
 
 3. **Kubernetes Fundamentals (quest 5) is disconnected from the other four** — it is the
-   only quest that matches the level's "Kubernetes Orchestration" theme, and it stands
-   alone as an excellent self-contained lab. The mismatch cuts both ways: the four agentic
-   quests are mis-themed as Kubernetes, and the one true Kubernetes quest shares no chain
-   with them. For a System Engineer learner arriving at "Level 1001 — Kubernetes," landing
-   on four GitHub-Actions/agentic quests first would be disorienting.
+only quest that matches the level's "Kubernetes Orchestration" theme, and it stands alone as an excellent self-contained lab. The mismatch cuts both ways: the four agentic quests are mis-themed as Kubernetes, and the one true Kubernetes quest shares no chain with them. For a System Engineer learner arriving at "Level 1001 — Kubernetes," landing on four GitHub-Actions/agentic quests first would be disorienting.
 
-**Net:** the slice does *not* yet hold together as one Kubernetes learning path. The
-Q6→Q7→Q8 sub-chain is close but blocked by the three shared gaps above; Codex Ch. III is
-a strong standalone that lightly conflicts with Q8; Kubernetes Fundamentals is a strong
-standalone under the wrong roommates.
+**Net:** the slice does *not* yet hold together as one Kubernetes learning path. The Q6→Q7→Q8 sub-chain is close but blocked by the three shared gaps above; Codex Ch. III is a strong standalone that lightly conflicts with Q8; Kubernetes Fundamentals is a strong standalone under the wrong roommates.
 
 ## 🧠 Reasoning & Method
 
 - **Mode: execute (sealed).** I did **not** run the engine — the workflow pre-computed and
-  sealed `walk-evidence.json` / `walk-evidence.md` (execute mode, real commands in a
-  disposable sandbox: a live `kind` cluster, `docker manifest inspect`, `jq`/`sha256sum`,
-  bash simulation of the retry loops and heredocs). I consumed that evidence as-is and
-  never edited or regenerated it.
+sealed `walk-evidence.json` / `walk-evidence.md` (execute mode, real commands in a disposable sandbox: a live `kind` cluster, `docker manifest inspect`, `jq`/`sha256sum`, bash simulation of the retry loops and heredocs). I consumed that evidence as-is and never edited or regenerated it.
 - **What is tested vs. reasoned.** Every `passed`/`failed` in §Evidence and the "verified"
-  issues came from a command the engine actually ran. GitHub-Actions-only YAML, cross-quest
-  dependency gaps, the metadata/theme mismatch, and the Codex↔Q8 conceptual conflict are
-  **reasoned** — inferred from reading all five sources in plan order plus the sealed
-  evidence. They are labeled as such and not reported as executed results.
+issues came from a command the engine actually ran. GitHub-Actions-only YAML, cross-quest dependency gaps, the metadata/theme mismatch, and the Codex↔Q8 conceptual conflict are **reasoned** — inferred from reading all five sources in plan order plus the sealed evidence. They are labeled as such and not reported as executed results.
 - **My contribution** is §Chain Continuity: the engine scores each quest in isolation, so
-  the orphaned `copilot-instructions.md`, the undelivered `run_agent_task.py`, the
-  thrice-broken validation gate, and the two-tracks-under-one-theme structure are only
-  visible when the five are read as one journey.
+the orphaned `copilot-instructions.md`, the undelivered `run_agent_task.py`, the thrice-broken validation gate, and the two-tracks-under-one-theme structure are only visible when the five are read as one journey.
 - **Coverage limits (honest):** (a) This is **window 1 of 2** — quests 6–9 of Level 1001
-  were **not** walked this run; the ledger accumulates them separately. (b) OS-gated
-  install blocks (macOS `brew`, Windows `winget`) and real GitHub-Actions execution
-  (artifact upload/download, live workflow triggers, real `git push`) could not run in the
-  Linux sandbox and were reasoned/skipped, not executed. (c) The `winget Kubernetes.kind`
-  package id and the GH-600 "19% of the exam" citation are external facts the sandbox
-  could not verify. (d) I made **zero** content edits — fixable bugs live only in
-  §Issues Found for a later content pass.
+were **not** walked this run; the ledger accumulates them separately. (b) OS-gated install blocks (macOS `brew`, Windows `winget`) and real GitHub-Actions execution (artifact upload/download, live workflow triggers, real `git push`) could not run in the Linux sandbox and were reasoned/skipped, not executed. (c) The `winget Kubernetes.kind` package id and the GH-600 "19% of the exam" citation are external facts the sandbox could not verify. (d) I made **zero** content edits — fixable bugs live only in §Issues Found for a later content pass.
 - **Confidence:** High on the per-quest verdicts (grounded in reproduced command output,
-  e.g. the byte-for-byte drift-guard transcript and the live `ImagePullBackOff` fix).
-  High on the chain-continuity findings, which are directly traceable to quoted lines in
-  the sources (`test -f .github/copilot-instructions.md`, `run_agent_task.py`,
-  `scripts/validate_quest.py`, the two divergent session-memory tables).
+e.g. the byte-for-byte drift-guard transcript and the live `ImagePullBackOff` fix). High on the chain-continuity findings, which are directly traceable to quoted lines in the sources (`test -f .github/copilot-instructions.md`, `run_agent_task.py`, `scripts/validate_quest.py`, the two divergent session-memory tables).

--- a/scripts/generation/generate_statistics.rb
+++ b/scripts/generation/generate_statistics.rb
@@ -3,6 +3,7 @@
 
 require 'yaml'
 require 'date'
+require 'posthog'
 
 # Script to generate dynamic content statistics for IT-Journey posts
 # This script analyzes all posts in the _posts directory and generates
@@ -35,14 +36,16 @@ class ContentStatisticsGenerator
 
   def generate
     puts "📊 Generating content statistics for IT-Journey..."
-    
+
     analyze_posts
     calculate_derived_stats
     save_statistics
-    
+
     puts "✅ Statistics generated successfully!"
     puts "📁 Output saved to: #{OUTPUT_FILE}"
     display_summary
+
+    track_generation_event
   end
 
   private
@@ -261,6 +264,35 @@ class ContentStatisticsGenerator
     
     # Default fallback
     increment_content_type('Article') if @stats['content_types'].empty?
+  end
+
+  def track_generation_event
+    token = ENV['POSTHOG_PROJECT_TOKEN']
+    return unless token
+
+    posthog = PostHog::Client.new(
+      api_key: token,
+      host: ENV.fetch('POSTHOG_HOST', 'https://us.i.posthog.com'),
+      on_error: proc { |_status, _msg| nil }
+    )
+    begin
+      posthog.capture(
+        distinct_id: 'it-journey-ci',
+        event: 'statistics_generated',
+        properties: {
+          total_posts: @stats['total_posts'],
+          published_posts: @stats['published'],
+          draft_posts: @stats['drafts'],
+          category_count: @stats['category_count'],
+          tag_count: @stats['tag_count'],
+          author_count: @stats['author_count'],
+          focus_area_count: @stats['focus_areas'].size,
+          content_type_count: @stats['content_types'].size
+        }
+      )
+    ensure
+      posthog.shutdown
+    end
   end
 
   def increment_content_type(type)

--- a/scripts/validation/content-freshness-check.rb
+++ b/scripts/validation/content-freshness-check.rb
@@ -29,6 +29,7 @@ require 'optparse'
 require 'date'
 require 'pathname'
 require 'time'
+require 'posthog'
 
 # ANSI color codes
 module Colors
@@ -501,6 +502,17 @@ class ContentFreshnessChecker
   end
 end
 
+def initialize_posthog
+  token = ENV['POSTHOG_PROJECT_TOKEN']
+  return nil unless token
+
+  PostHog::Client.new(
+    api_key: token,
+    host: ENV.fetch('POSTHOG_HOST', 'https://us.i.posthog.com'),
+    on_error: proc { |status, msg| print_warning("PostHog error: #{status} - #{msg}") }
+  )
+end
+
 # Main execution
 if __FILE__ == $PROGRAM_NAME
   options = {
@@ -608,5 +620,34 @@ if __FILE__ == $PROGRAM_NAME
 
   # Exit with code based on critical content
   critical_count = report.by_status[FreshnessStatus::CRITICAL]
+
+  posthog = initialize_posthog
+  begin
+    if posthog
+      healthy = (report.by_status[FreshnessStatus::FRESH] || 0) + (report.by_status[FreshnessStatus::AGING] || 0)
+      health_score = report.files_with_lastmod.positive? ? (healthy.to_f / report.files_with_lastmod * 100).round(1) : 0
+
+      posthog.capture(
+        distinct_id: 'it-journey-ci',
+        event: 'content_scan_completed',
+        properties: {
+          total_files: report.total_files,
+          files_with_lastmod: report.files_with_lastmod,
+          files_without_lastmod: report.files_without_lastmod,
+          fresh_count: report.by_status[FreshnessStatus::FRESH] || 0,
+          aging_count: report.by_status[FreshnessStatus::AGING] || 0,
+          stale_count: report.by_status[FreshnessStatus::STALE] || 0,
+          critical_count: critical_count || 0,
+          average_age_days: report.average_age,
+          health_score: health_score,
+          output_format: options[:format],
+          filter_applied: !options[:filter_status].nil?
+        }
+      )
+    end
+  ensure
+    posthog&.shutdown
+  end
+
   exit(critical_count.positive? ? 1 : 0)
 end

--- a/scripts/validation/ctr-report-generator.rb
+++ b/scripts/validation/ctr-report-generator.rb
@@ -30,6 +30,7 @@ require 'optparse'
 require 'date'
 require 'pathname'
 require 'fileutils'
+require 'posthog'
 
 # ANSI color codes
 module Colors
@@ -487,6 +488,17 @@ class CTRReportGenerator
   end
 end
 
+def initialize_posthog
+  token = ENV['POSTHOG_PROJECT_TOKEN']
+  return nil unless token
+
+  PostHog::Client.new(
+    api_key: token,
+    host: ENV.fetch('POSTHOG_HOST', 'https://us.i.posthog.com'),
+    on_error: proc { |status, msg| print_warning("PostHog error: #{status} - #{msg}") }
+  )
+end
+
 # Main execution
 if __FILE__ == $PROGRAM_NAME
   options = {
@@ -545,50 +557,86 @@ if __FILE__ == $PROGRAM_NAME
   command ||= :baseline
 
   generator = CTRReportGenerator.new(verbose: options[:verbose])
+  posthog = initialize_posthog
 
-  case command
-  when :baseline
-    report = generator.generate_baseline_report
-    puts report
-    generator.save_report(report, "baseline-report-#{Date.today}.md") if options[:output]
+  begin
+    case command
+    when :baseline
+      report = generator.generate_baseline_report
+      puts report
+      generator.save_report(report, "baseline-report-#{Date.today}.md") if options[:output]
+      posthog&.capture(
+        distinct_id: 'it-journey-ci',
+        event: 'ctr_report_generated',
+        properties: { report_type: 'baseline', saved_to_file: options[:output] != nil }
+      )
 
-  when :weekly
-    report = generator.generate_weekly_template
-    puts report
-    if options[:output]
-      generator.save_report(report, options[:output])
-    else
-      generator.save_report(report, "weekly-review-#{Date.today}.md")
-    end
-
-  when :opportunities
-    report = generator.generate_opportunities_report
-    puts report
-    generator.save_report(report, "opportunities-#{Date.today}.md") if options[:output]
-
-  when :parse
-    if input_file
-      data = generator.parse_gsc_csv(input_file)
-      if data
-        puts "\n## Parsed Data Summary"
-        puts "Pages: #{data[:pages].size}"
-        puts "Queries: #{data[:queries].size}"
-        puts "Total Impressions: #{data[:overall][:impressions]}"
-        puts "Total Clicks: #{data[:overall][:clicks]}"
-        puts "Average CTR: #{data[:overall][:ctr]}%"
+    when :weekly
+      report = generator.generate_weekly_template
+      puts report
+      if options[:output]
+        generator.save_report(report, options[:output])
+      else
+        generator.save_report(report, "weekly-review-#{Date.today}.md")
       end
-    else
-      print_error('Please provide a CSV file with --parse FILE')
-      exit 1
-    end
+      posthog&.capture(
+        distinct_id: 'it-journey-ci',
+        event: 'ctr_report_generated',
+        properties: { report_type: 'weekly', saved_to_file: true }
+      )
 
-  when :json
-    metrics = generator.generate_metrics_json
-    output = JSON.pretty_generate(metrics)
-    puts output
-    if options[:output]
-      File.write(options[:output], output)
-      print_success("JSON exported to: #{options[:output]}")
+    when :opportunities
+      report = generator.generate_opportunities_report
+      puts report
+      generator.save_report(report, "opportunities-#{Date.today}.md") if options[:output]
+      posthog&.capture(
+        distinct_id: 'it-journey-ci',
+        event: 'ctr_report_generated',
+        properties: { report_type: 'opportunities', saved_to_file: options[:output] != nil }
+      )
+
+    when :parse
+      if input_file
+        data = generator.parse_gsc_csv(input_file)
+        if data
+          puts "\n## Parsed Data Summary"
+          puts "Pages: #{data[:pages].size}"
+          puts "Queries: #{data[:queries].size}"
+          puts "Total Impressions: #{data[:overall][:impressions]}"
+          puts "Total Clicks: #{data[:overall][:clicks]}"
+          puts "Average CTR: #{data[:overall][:ctr]}%"
+          posthog&.capture(
+            distinct_id: 'it-journey-ci',
+            event: 'gsc_csv_parsed',
+            properties: {
+              pages_parsed: data[:pages].size,
+              queries_parsed: data[:queries].size,
+              total_impressions: data[:overall][:impressions],
+              total_clicks: data[:overall][:clicks],
+              average_ctr: data[:overall][:ctr]
+            }
+          )
+        end
+      else
+        print_error('Please provide a CSV file with --parse FILE')
+        exit 1
+      end
+
+    when :json
+      metrics = generator.generate_metrics_json
+      output = JSON.pretty_generate(metrics)
+      puts output
+      if options[:output]
+        File.write(options[:output], output)
+        print_success("JSON exported to: #{options[:output]}")
+      end
+      posthog&.capture(
+        distinct_id: 'it-journey-ci',
+        event: 'ctr_report_generated',
+        properties: { report_type: 'json', saved_to_file: options[:output] != nil }
+      )
     end
+  ensure
+    posthog&.shutdown
   end
 end

--- a/scripts/validation/frontmatter-validator.rb
+++ b/scripts/validation/frontmatter-validator.rb
@@ -23,6 +23,7 @@ require 'json'
 require 'optparse'
 require 'pathname'
 require 'time'
+require 'posthog'
 
 # ANSI color codes
 module Colors
@@ -591,6 +592,17 @@ class FrontmatterValidator
   end
 end
 
+def initialize_posthog
+  token = ENV['POSTHOG_PROJECT_TOKEN']
+  return nil unless token
+
+  PostHog::Client.new(
+    api_key: token,
+    host: ENV.fetch('POSTHOG_HOST', 'https://us.i.posthog.com'),
+    on_error: proc { |status, msg| print_warning("PostHog error: #{status} - #{msg}") }
+  )
+end
+
 # Main execution
 if __FILE__ == $PROGRAM_NAME
   options = {
@@ -668,6 +680,26 @@ if __FILE__ == $PROGRAM_NAME
 
   # Save JSON report if requested
   validator.save_json_report(report, options[:output]) if options[:output]
+
+  posthog = initialize_posthog
+  begin
+    posthog&.capture(
+      distinct_id: 'it-journey-ci',
+      event: 'frontmatter_validation_completed',
+      properties: {
+        total_files: report.total_files,
+        valid_files: report.valid_files,
+        invalid_files: report.invalid_files,
+        total_errors: report.total_errors,
+        total_warnings: report.total_warnings,
+        average_seo_score: report.average_seo_score,
+        content_type_filter: options[:type],
+        errors_only_mode: options[:errors_only]
+      }
+    )
+  ensure
+    posthog&.shutdown
+  end
 
   # Exit with error code if issues found
   exit(report.invalid_files.positive? ? 1 : 0)

--- a/test/quest-validator/walkthroughs/2026-07-17-data-scientist-0011.md
+++ b/test/quest-validator/walkthroughs/2026-07-17-data-scientist-0011.md
@@ -19,56 +19,28 @@ session:
 
 ## 🎯 Session Summary
 
-I walked the full **Data Scientist · Level 0011 (AI-Assisted Development, 🌱 Apprentice)**
-slice — all **4** main quests the planner selected, in plan order — as a learner
-would, using the workflow-sealed execute-mode evidence plus a close read of each
-quest source. Headline: **warn — the slice is mostly usable, but it is not a clean
-linear path and it contains one hard, blocking failure.**
+I walked the full **Data Scientist · Level 0011 (AI-Assisted Development, 🌱 Apprentice)** slice — all **4** main quests the planner selected, in plan order — as a learner would, using the workflow-sealed execute-mode evidence plus a close read of each quest source. Headline: **warn — the slice is mostly usable, but it is not a clean linear path and it contains one hard, blocking failure.**
 
-Three quests hold up when their commands are actually run (Summon the Golem passes
-cleanly at 88; Hidden Gem and Prompt Crystal warn at 68/64 with fixable defects).
-The one that breaks a learner is **The PRD Codex (43, fail)**: its entire hands-on
-core hangs on `docker compose build prd-machine`, which the engine verified fails
-with *"no configuration file provided"* in any repo that doesn't already ship the
-PRD Machine tooling — and the quest never shows how to obtain that tooling. A
-maintainer's most valuable next action is to make PRD Codex self-contained (or
-gate it behind the repo it assumes); everything else in the slice is polish.
+Three quests hold up when their commands are actually run (Summon the Golem passes cleanly at 88; Hidden Gem and Prompt Crystal warn at 68/64 with fixable defects). The one that breaks a learner is **The PRD Codex (43, fail)**: its entire hands-on core hangs on `docker compose build prd-machine`, which the engine verified fails with *"no configuration file provided"* in any repo that doesn't already ship the PRD Machine tooling — and the quest never shows how to obtain that tooling. A maintainer's most valuable next action is to make PRD Codex self-contained (or gate it behind the repo it assumes); everything else in the slice is polish.
 
-Note on cohesion: these four quests share the `0011` level but belong to **four
-different quest series/lines** (The Ouroboros Loop, Documentation Mastery,
-Web Publishing, AI Development Mastery). This is a themed *bundle*, not a single
-authored chain — an important framing for the continuity findings below.
+Note on cohesion: these four quests share the `0011` level but belong to **four different quest series/lines** (The Ouroboros Loop, Documentation Mastery, Web Publishing, AI Development Mastery). This is a themed *bundle*, not a single authored chain — an important framing for the continuity findings below.
 
 ## 🗺️ The Journey
 
 Plan order (dependency-sorted by the planner):
 
 1. ✅ **Summon the Golem: An AI Agent Joins the Loop** — **88/100** (pass) ·
-   Drive headless Claude Code from GitHub Actions under a bounded role. Technically
-   tight: every CLI flag, env var, and Action version checked out; the gating/no-op
-   bash ran exactly as claimed. Only gaps are a missing env-wiring reference and no
-   answer key for the knowledge checks.
+Drive headless Claude Code from GitHub Actions under a bounded role. Technically tight: every CLI flag, env var, and Action version checked out; the gating/no-op bash ran exactly as claimed. Only gaps are a missing env-wiring reference and no answer key for the knowledge checks.
 2. ❌ **The PRD Codex: Master Product Reality Distillation** — **43/100** (fail) ·
-   The pivotal `docker compose build prd-machine` was verified to fail with *"no
-   configuration file provided"* — the quest never provides or points to the PRD
-   Machine tooling, so Chapters 2–3 and all four Challenges are unrunnable from the
-   document alone. **Blocking.**
+The pivotal `docker compose build prd-machine` was verified to fail with *"no configuration file provided"* — the quest never provides or points to the PRD Machine tooling, so Chapters 2–3 and all four Challenges are unrunnable from the document alone. **Blocking.**
 3. ⚠️ **Hidden Gem: Publish AI Chats on GitHub Pages** — **68/100** (warn) ·
-   Jekyll config, Gemfile, AI-chat post, and `bundle exec jekyll serve` genuinely
-   work; a Linux `bundle install` permission gotcha (no vendor-path/.gitignore
-   guidance) plus a wrong theme URL and a suspect extension ID drag accuracy down.
+Jekyll config, Gemfile, AI-chat post, and `bundle exec jekyll serve` genuinely work; a Linux `bundle install` permission gotcha (no vendor-path/.gitignore guidance) plus a wrong theme URL and a suspect extension ID drag accuracy down.
 4. ⚠️ **Forging the Prompt Crystal: VS Code Copilot Mastery** — **64/100** (warn) ·
-   Cross-platform scaffolding and both Mermaid diagrams run; but `{% raw %}` Jekyll
-   build artifacts leak into the `.prompt.md` templates, several prompt blocks are
-   mislabeled `javascript` and error as JS, and the Windows/Cloud setup silently
-   overwrites an existing `copilot-instructions.md`.
+Cross-platform scaffolding and both Mermaid diagrams run; but `{% raw %}` Jekyll build artifacts leak into the `.prompt.md` templates, several prompt blocks are mislabeled `javascript` and error as JS, and the Windows/Cloud setup silently overwrites an existing `copilot-instructions.md`.
 
 ## 🔬 Evidence
 
-All results are from **execute mode** (`walk-evidence.json`, sealed by the
-workflow — I consumed it as-is and did not re-run the engine). Snippet counts are
-`ran / passed / failed / skipped / reasoned`. Dimension scores are on the 1–5
-rubric (commands_work, content_accuracy, completeness, clarity, structure, safety).
+All results are from **execute mode** (`walk-evidence.json`, sealed by the workflow — I consumed it as-is and did not re-run the engine). Snippet counts are `ran / passed / failed / skipped / reasoned`. Dimension scores are on the 1–5 rubric (commands_work, content_accuracy, completeness, clarity, structure, safety).
 
 ### 1. Summon the Golem — 88 ✅ (5/5 passed, 1 skipped, 2 reasoned)
 Dimensions: commands_work 4 · content_accuracy 5 · completeness 4 · clarity 4 · structure 5 · safety 5
@@ -76,32 +48,23 @@ Dimensions: commands_work 4 · content_accuracy 5 · completeness 4 · clarity 4
 - **passed** — Composite `action.yml` and the workflow step YAML fragments parse
   cleanly with pyyaml (no syntax errors).
 - **passed** — The no-auth guard `if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then …
-  exit 0; fi` was extracted and run with the var unset: it printed the `::warning::`
-  line and exited 0, exactly as the quest claims ("No auth = exit 0 with a warning").
+exit 0; fi` was extracted and run with the var unset: it printed the `::warning::` line and exited 0, exactly as the quest claims ("No auth = exit 0 with a warning").
 - **passed** — The gate logic (`go=false; if [ "$ENABLED" = "true" ] && [ -n
-  "$OAUTH" ]; then go=true; fi`) tested across all 4 ENABLED/OAUTH combinations —
-  arms only when both true, matching stated intent.
+"$OAUTH" ]; then go=true; fi`) tested across all 4 ENABLED/OAUTH combinations — arms only when both true, matching stated intent.
 - **passed** — Mermaid quest-network diagram compiled to valid SVG.
 - **reasoned** — `claude -p … --append-system-prompt … --allowedTools … --permission-mode
-  acceptEdits`, `npm install -g @anthropic-ai/claude-code`, `claude setup-token` are
-  all valid/current commands (verified against docs, not executed end-to-end — a full
-  CI run needs a real repo + secret).
+acceptEdits`, `npm install -g @anthropic-ai/claude-code`, `claude setup-token` are all valid/current commands (verified against docs, not executed end-to-end — a full CI run needs a real repo + secret).
 - **skipped** — `.claude/agents/potion-scribe.md` role file (markdown, nothing to run).
 
 ### 2. The PRD Codex — 43 ❌ (13 ran: 5 passed, 8 failed, 2 skipped, 4 reasoned)
 Dimensions: commands_work 1 · content_accuracy 2 · completeness 2 · clarity 3 · structure 4 · safety 4
 
 - **failed** — Cloud Realms path `cd /workspaces/it-journey; docker compose build
-  prd-machine; …` — build fails: *"no configuration file provided: not found"*. The
-  same `docker compose build prd-machine` recurs at source lines 182, 208, 234, 249
-  across the macOS / Linux / Cloud paths; none can succeed without pre-existing
-  tooling the quest never supplies.
+prd-machine; …` — build fails: *"no configuration file provided: not found"*. The same `docker compose build prd-machine` recurs at source lines 182, 208, 234, 249 across the macOS / Linux / Cloud paths; none can succeed without pre-existing tooling the quest never supplies.
 - **failed** — All downstream `docker compose run --rm prd-machine …/prd-machine sync`
-  (incl. `--days 7`, `--output /tmp/custom-prd.md`), `status`, `conflicts`, and the
-  "Quick Win Checkpoint" sequence — every one fails because the container never built.
+(incl. `--days 7`, `--output /tmp/custom-prd.md`), `status`, `conflicts`, and the "Quick Win Checkpoint" sequence — every one fails because the container never built.
 - **failed** — macOS and Linux path bash blocks (`docker --version; … cd
-  /path/to/your/repository; cd ~/github/it-journey; …`) error as written (contradictory
-  back-to-back `cd`s, unbuildable target).
+/path/to/your/repository; cd ~/github/it-journey; …`) error as written (contradictory back-to-back `cd`s, unbuildable target).
 - **failed** — "Best Practices for Commit Signals" block (~line 384) is fenced
   ```bash``` but is commit-message prose; run as bash it throws *"syntax error near
   unexpected token 'auth'"*.
@@ -199,73 +162,34 @@ a command the engine actually ran or an exact line in the quest source.)
 
 ## 🔗 Chain Continuity
 
-**This slice is a level bundle, not a single authored chain.** The four quests carry
-four different `quest_series`: *The Ouroboros Loop* (Golem), *Documentation Mastery*
-(PRD Codex), *Web Publishing* (Hidden Gem), *AI Development Mastery* (Prompt Crystal).
-A Data Scientist arriving at 0011 is not walking one story — they're picking among
-parallel AI-assisted-development tracks. Judged that way, the *theme* coheres
-(everything is about wielding AI tooling), but the *narrative* does not.
+**This slice is a level bundle, not a single authored chain.** The four quests carry four different `quest_series`: *The Ouroboros Loop* (Golem), *Documentation Mastery* (PRD Codex), *Web Publishing* (Hidden Gem), *AI Development Mastery* (Prompt Crystal). A Data Scientist arriving at 0011 is not walking one story — they're picking among parallel AI-assisted-development tracks. Judged that way, the *theme* coheres (everything is about wielding AI tooling), but the *narrative* does not.
 
 Prerequisite reality for a learner walking in plan order:
 
 - **Golem** assumes "your potion-book repository with the Warden's Gate in place"
-  (Chapters I–II of the Ouroboros Loop, which live at level **0101** — outside this
-  slice) *and* a `claude setup-token` OAuth token. Its `quest_dependencies.required_quests`
-  is empty, so nothing in-slice or in-frontmatter surfaces that gate. A learner who
-  starts here cold has no gated loop to attach the golem to — the quest teaches the
-  agent well in isolation, but its assumed repo state is unmet by the slice.
+(Chapters I–II of the Ouroboros Loop, which live at level **0101** — outside this slice) *and* a `claude setup-token` OAuth token. Its `quest_dependencies.required_quests` is empty, so nothing in-slice or in-frontmatter surfaces that gate. A learner who starts here cold has no gated loop to attach the golem to — the quest teaches the agent well in isolation, but its assumed repo state is unmet by the slice.
 - **PRD Codex** `unlocks_quests` explicitly lists **prompt-crystal** and **github-pages** —
-  the only real intra-slice dependency edge, and the planner honored it by ordering
-  PRD before those two. But PRD is exactly the quest that *fails*: its Docker core is
-  unrunnable, so the "unlock" is hollow — a learner following the intended order hits a
-  wall on quest 2 and cannot legitimately complete it before moving on. The good news:
-  Hidden Gem and Prompt Crystal don't actually consume any artifact PRD produces, so the
-  wall is a motivation/credential break, not a hard technical block on quests 3–4.
+the only real intra-slice dependency edge, and the planner honored it by ordering PRD before those two. But PRD is exactly the quest that *fails*: its Docker core is unrunnable, so the "unlock" is hollow — a learner following the intended order hits a wall on quest 2 and cannot legitimately complete it before moving on. The good news: Hidden Gem and Prompt Crystal don't actually consume any artifact PRD produces, so the wall is a motivation/credential break, not a hard technical block on quests 3–4.
 - **Hidden Gem** requires `/quests/0000/hello-noob/` (an earlier level — reasonable and
-  met by normal progression) and is the gentlest, most self-contained entry (🟢 Easy) —
-  arguably the best *first* quest for a newcomer to this level, ahead of the Medium ones.
+met by normal progression) and is the gentlest, most self-contained entry (🟢 Easy) — arguably the best *first* quest for a newcomer to this level, ahead of the Medium ones.
 - **Prompt Crystal** requires `/quests/0010/prompt-engineering-mastery/` (prior level).
   It stands alone fine; its defects are content-quality, not continuity.
 
-**Ordering observation for a maintainer:** as a *learning* path for a Data Scientist,
-Hidden Gem (Easy, self-contained) → Prompt Crystal (prompt skills) → Golem (agent in CI,
-but flag the 0101 Warden's-Gate prerequisite) is a smoother ramp than the current
-dependency-sort, and PRD Codex should be treated as *not yet walkable* until its tooling
-bootstrap is added. No quest in the slice silently depends on an artifact produced by
-another that I could not otherwise obtain — the friction is (a) the unmet Warden's-Gate
-repo state Golem assumes, and (b) PRD's missing tooling.
+**Ordering observation for a maintainer:** as a *learning* path for a Data Scientist, Hidden Gem (Easy, self-contained) → Prompt Crystal (prompt skills) → Golem (agent in CI, but flag the 0101 Warden's-Gate prerequisite) is a smoother ramp than the current dependency-sort, and PRD Codex should be treated as *not yet walkable* until its tooling bootstrap is added. No quest in the slice silently depends on an artifact produced by another that I could not otherwise obtain — the friction is (a) the unmet Warden's-Gate repo state Golem assumes, and (b) PRD's missing tooling.
 
 ## 🧠 Reasoning & Method
 
 - **Mode:** execute. I did **not** run the engine myself — per the skill and the CI
-  contract, the workflow pre-computed and sealed `walk-evidence.json` / `walk-evidence.md`
-  (the engine's child `claude` processes can't authenticate from an agent's Bash tool).
-  I consumed the sealed evidence verbatim and did not edit, regenerate, or hand-write any
-  number. `walk-plan.json` and `walk-evidence.*` were left untouched.
+contract, the workflow pre-computed and sealed `walk-evidence.json` / `walk-evidence.md` (the engine's child `claude` processes can't authenticate from an agent's Bash tool). I consumed the sealed evidence verbatim and did not edit, regenerate, or hand-write any number. `walk-plan.json` and `walk-evidence.*` were left untouched.
 - **What was actually run (in the sandbox, by the sealed engine):** 32 recorded
-  commands across the four quests, of which the engine ran ~32 and reasoned statically
-  about the rest — Golem 5/5 passed; PRD Codex 5 passed / 8 failed; Hidden Gem 3 passed /
-  1 failed; Prompt Crystal 5 passed / 5 failed. Every `passed`/`failed` above traces to
-  one of those runs; every `reasoned` item is labeled as static-only.
+commands across the four quests, of which the engine ran ~32 and reasoned statically about the rest — Golem 5/5 passed; PRD Codex 5 passed / 8 failed; Hidden Gem 3 passed / 1 failed; Prompt Crystal 5 passed / 5 failed. Every `passed`/`failed` above traces to one of those runs; every `reasoned` item is labeled as static-only.
 - **What I reasoned about (me, statically):** the linked-journey continuity — series
-  cohesion, prerequisite satisfaction, and ordering — by reading each quest's frontmatter
-  and body in plan order. Those are the §🔗 findings and are explicitly reasoning, not
-  fresh command evidence.
+cohesion, prerequisite satisfaction, and ordering — by reading each quest's frontmatter and body in plan order. Those are the §🔗 findings and are explicitly reasoning, not fresh command evidence.
 - **Coverage / limits:** Nothing was capped by me (the planner's window covers the full
-  4-quest level; `truncated: false`). OS-specific installs and `code`-CLI steps were
-  `skipped` by the engine as environment-dependent, so cross-platform install accuracy is
-  only partially witnessed. PRD Codex's Docker path is genuinely broken in a clean repo, so
-  its downstream chapters are unverifiable *by design of the defect* — that is itself the
-  finding, not a coverage gap on my side. No network-dependent or destructive steps were run.
+4-quest level; `truncated: false`). OS-specific installs and `code`-CLI steps were `skipped` by the engine as environment-dependent, so cross-platform install accuracy is only partially witnessed. PRD Codex's Docker path is genuinely broken in a clean repo, so its downstream chapters are unverifiable *by design of the defect* — that is itself the finding, not a coverage gap on my side. No network-dependent or destructive steps were run.
 - **Confidence:** High on the per-quest verdicts (they come from real sandbox runs with
-  quoted failure output). High on the PRD blocking-fail and the two high-severity Prompt
-  Crystal defects. Medium on the extension-ID / theme-URL slips (asserted by the engine's
-  content check, not independently re-verified here). The overall slice verdict is **warn**:
-  three of four quests are usable today, but the slice contains one hard fail that a
-  content pass should fix before this level is called "perfect."
+quoted failure output). High on the PRD blocking-fail and the two high-severity Prompt Crystal defects. Medium on the extension-ID / theme-URL slips (asserted by the engine's content check, not independently re-verified here). The overall slice verdict is **warn**: three of four quests are usable today, but the slice contains one hard fail that a content pass should fix before this level is called "perfect."
 
 ---
 
-*Machine evidence header (verbatim from `walk-evidence.md`): "**4** quests evaluated ·
-✅ 1 pass · ⚠️ 2 warn · ❌ 1 fail · avg **65.8%** · ~$6.4993". One slice, one report —
-findings only; a content pass (content-curator / human) acts on the issues above.*
+*Machine evidence header (verbatim from `walk-evidence.md`): "**4** quests evaluated · ✅ 1 pass · ⚠️ 2 warn · ❌ 1 fail · avg **65.8%** · ~$6.4993". One slice, one report — findings only; a content pass (content-curator / human) acts on the issues above.*

--- a/test/quest-validator/walkthroughs/2026-07-17-developer-0001.md
+++ b/test/quest-validator/walkthroughs/2026-07-17-developer-0001.md
@@ -22,122 +22,66 @@ session:
 
 ## 🎯 Session Summary
 
-I played a **5-quest window** (window 2 of 6; quests 11–15 of the 26 that make up
-the Developer path's Level **0001 · Web Fundamentals · Apprentice 🌱** tier) as a
-beginner developer would, driving the sealed execute-mode engine evidence and then
-reading every quest source in plan order to reason about the linked journey.
+I played a **5-quest window** (window 2 of 6; quests 11–15 of the 26 that make up the Developer path's Level **0001 · Web Fundamentals · Apprentice 🌱** tier) as a beginner developer would, driving the sealed execute-mode engine evidence and then reading every quest source in plan order to reason about the linked journey.
 
-**Headline verdict: ❌ fail.** The engine scored **0 pass · 1 warn · 4 fail**,
-average **49.5%**. This slice is *not* ready for a real beginner: the very first
-main quest (**GitHub Pages Portal**) hard-blocks on a `gem install`/`bundle`
-permissions failure on the exact Linux setup it recommends, and a leftover
-`index.html` silently shadows all the Jekyll content it later teaches; one side
-quest (**Personal Website**, 19%) is a bare reference table with placeholder
-objectives and no runnable steps; the flagship **Summoning** main quest (57%) fails
-to build against the very theme it names because it omits `jekyll-include-cache`;
-and even the best of the set (**SEO Optimization**, 68% ⚠️) teaches a plugin-setup
-sequence that silently produces no sitemap until a *later* chapter. The
-**Stack Analysis** side quest **timed out at 600s** in the engine, so it has **no
-execute evidence** — I reasoned about it statically only. A maintainer's highest-value
-fixes are the two `high`-severity blockers in Portal and the missing plugin in
-Summoning, because they stop a learner cold at the start of the path.
+**Headline verdict: ❌ fail.** The engine scored **0 pass · 1 warn · 4 fail**, average **49.5%**. This slice is *not* ready for a real beginner: the very first main quest (**GitHub Pages Portal**) hard-blocks on a `gem install`/`bundle` permissions failure on the exact Linux setup it recommends, and a leftover `index.html` silently shadows all the Jekyll content it later teaches; one side quest (**Personal Website**, 19%) is a bare reference table with placeholder objectives and no runnable steps; the flagship **Summoning** main quest (57%) fails to build against the very theme it names because it omits `jekyll-include-cache`; and even the best of the set (**SEO Optimization**, 68% ⚠️) teaches a plugin-setup sequence that silently produces no sitemap until a *later* chapter. The **Stack Analysis** side quest **timed out at 600s** in the engine, so it has **no execute evidence** — I reasoned about it statically only. A maintainer's highest-value fixes are the two `high`-severity blockers in Portal and the missing plugin in Summoning, because they stop a learner cold at the start of the path.
 
 ## 🗺️ The Journey
 
 Plan order (from `walk-plan.json`); emoji = engine verdict, score = overall:
 
 1. ❌ **The GitHub Pages Portal: Forging Your Digital Realm** — `main_quest` · **54** ·
-   Solid git/Pages content, but a gem-permissions wall and a silent `index.html`
-   vs `index.md` shadowing would block/mislead a beginner exactly where it promises
-   the least friction.
+Solid git/Pages content, but a gem-permissions wall and a silent `index.html` vs `index.md` shadowing would block/mislead a beginner exactly where it promises the least friction.
 2. ❌ **Stack Attack Analysis: IT-Journey** — `side_quest` · **— (timed out at 600s)** ·
-   No execute evidence gathered; a ~1,300-line reference report with auto-seeded
-   placeholder objectives and no real hands-on exercises (reasoned only).
+No execute evidence gathered; a ~1,300-line reference report with auto-seeded placeholder objectives and no real hands-on exercises (reasoned only).
 3. ❌ **Build a Personal Website with GitHub Pages** — `side_quest` · **19** ·
-   Effectively a stub: one link table, zero runnable commands, unrendered Liquid,
-   duplicate/mislabeled rows. Needs a full rewrite to match its title.
+Effectively a stub: one link table, zero runnable commands, unrendered Liquid, duplicate/mislabeled rows. Needs a full rewrite to match its title.
 4. ❌ **The Summoning: Raise the Site and Give It a Voice** — `main_quest` · **57** ·
-   Well-structured, but Chapter 1's Gemfile/`_config.yml` won't build against the
-   named `bamr87/zer0-mistakes` theme (missing `jekyll-include-cache`); no
-   `.gitignore` step. Everything else tested clean.
+Well-structured, but Chapter 1's Gemfile/`_config.yml` won't build against the named `bamr87/zer0-mistakes` theme (missing `jekyll-include-cache`); no `.gitignore` step. Everything else tested clean.
 5. ⚠️ **SEO Optimization: Meta Tags, Sitemaps & Structured Data** — `main_quest` · **68** ·
-   Individual SEO techniques all verified working, but the first platform-path step
-   yields no sitemap until Chapter 2's `_config.yml` edit, and the
-   `JEKYLL_ENV=production` "minifies output" claim is factually wrong.
+Individual SEO techniques all verified working, but the first platform-path step yields no sitemap until Chapter 2's `_config.yml` edit, and the `JEKYLL_ENV=production` "minifies output" claim is factually wrong.
 
 ## 🔬 Evidence
 
-All outcomes below come from the sealed `walk-evidence.json` (execute mode; commands
-actually run in the engine's disposable sandbox). Snippet coverage is reported as
-`ran/runnable`. I did not re-run the engine.
+All outcomes below come from the sealed `walk-evidence.json` (execute mode; commands actually run in the engine's disposable sandbox). Snippet coverage is reported as `ran/runnable`. I did not re-run the engine.
 
 ### 1. GitHub Pages Portal — 54% (fail) · snippets ran **18** (14✓ / 4✗), 3 reasoned
 - **passed** — `git clone` / `git add` / `git commit` on a real local repo (verified
-  three successive commits succeed); `bundle exec jekyll serve` bound
-  `http://127.0.0.1:4000/` matching the quest's stated URL; both Mermaid diagrams
-  rendered via `mmdc`; the Windows PowerShell here-string ran under `pwsh`.
+three successive commits succeed); `bundle exec jekyll serve` bound `http://127.0.0.1:4000/` matching the quest's stated URL; both Mermaid diagrams rendered via `mmdc`; the Windows PowerShell here-string ran under `pwsh`.
 - **failed** — `gem install jekyll bundler` (Ch.3 s1) → `Gem::FilePermissionError:
-  You don't have write permissions for the /var/lib/gems/3.2.0 directory` on stock
-  Ubuntu 24.04 / Ruby 3.2.3 — the exact env produced by the quest's own
-  `sudo apt-get install ruby-full`. `bundle install` (s6) similarly threw
-  `Bundler::PermissionError` until an undocumented `bundle config set --local path
-  vendor/bundle`.
+You don't have write permissions for the /var/lib/gems/3.2.0 directory` on stock Ubuntu 24.04 / Ruby 3.2.3 — the exact env produced by the quest's own `sudo apt-get install ruby-full`. `bundle install` (s6) similarly threw `Bundler::PermissionError` until an undocumented `bundle config set --local path vendor/bundle`.
 - **failed** — a real `bundle exec jekyll build` confirmed the Chapter 1 `index.html`
-  silently wins over the Chapter 3 `index.md`; none of the Jekyll homepage content
-  the quest teaches is ever rendered. `jekyll new . --force` did not remove it — it
-  added a competing `index.markdown`.
+silently wins over the Chapter 3 `index.md`; none of the Jekyll homepage content the quest teaches is ever rendered. `jekyll new . --force` did not remove it — it added a competing `index.markdown`.
 - **failed** — copy-pasting the `index.md` block verbatim (with literal
-  `{% raw %}{{ site.url }}{% endraw %}`) built `<a href="{{ site.url }}">View Site</a>`
-  — a broken link.
+`{% raw %}{{ site.url }}{% endraw %}`) built `<a href="{{ site.url }}">View Site</a>` — a broken link.
 - **reasoned** — `git push origin main` and placeholder-URL clones can't be verified
   without a real authenticated remote (expected, not a defect).
 
 ### 2. Stack Attack Analysis — no score (fail) · **no snippets executed**
 - **error** — `claude timed out after 600s`; `verdict_obj` is null, `overall` 0.0.
-  **No command evidence exists for this quest.** My notes on it (Chain Continuity,
-  Issues) are **reasoned** from reading the source only, and labeled as such.
+**No command evidence exists for this quest.** My notes on it (Chain Continuity, Issues) are **reasoned** from reading the source only, and labeled as such.
 
 ### 3. Build a Personal Website — 19% (fail) · snippets ran **2** (1✓ / 1✗), 1 skipped, 1 reasoned
 - **failed / reasoned** — engine confirms **zero runnable code blocks**
-  (`available_runnable: 0`): no `git init`, no repo creation, no `_config.yml`, no
-  Pages-enable step. The one content section is a link table.
+(`available_runnable: 0`): no `git init`, no repo creation, no `_config.yml`, no Pages-enable step. The one content section is a link table.
 - Source read confirms every engine finding: rows 2 and 6 render to the identical
-  `https://{{ site.github_user }}.github.io/` yet are labeled different hosts; row 12
-  labels `jekyllrb.com` a "Comments service" (it's a static-site generator); Liquid
-  tags render literally; the objectives block is the auto-seeded placeholder ("authors
-  should refine these").
+`https://{{ site.github_user }}.github.io/` yet are labeled different hosts; row 12 labels `jekyllrb.com` a "Comments service" (it's a static-site generator); Liquid tags render literally; the objectives block is the auto-seeded placeholder ("authors should refine these").
 
 ### 4. The Summoning — 57% (fail) · snippets ran **7** (6✓ / 1✗), 2 reasoned
 - **failed** — building the exact Chapter 1 `_config.yml` + `Gemfile` against a
-  *cloned* real `bamr87/zer0-mistakes` theme → `Liquid Exception: Liquid syntax
-  error (line 70): Unknown tag 'include_cached'` in the theme's `_layouts/root.html`.
-  Adding `gem "jekyll-include-cache", group: :jekyll_plugins` (a fix the quest never
-  names) made `bundle exec jekyll build` succeed and render correctly.
+*cloned* real `bamr87/zer0-mistakes` theme → `Liquid Exception: Liquid syntax error (line 70): Unknown tag 'include_cached'` in the theme's `_layouts/root.html`. Adding `gem "jekyll-include-cache", group: :jekyll_plugins` (a fix the quest never names) made `bundle exec jekyll build` succeed and render correctly.
 - **passed** — `_data/brand.yml` parses and the `{{ site.data.brand.* }}` include
-  renders as claimed; `scripts/session-scribe.sh` run twice (first commit + second
-  commit) produced the dispatch exactly as described, including the documented
-  `HEAD^1`→`git show` fallback on a first commit; the Actions workflow YAML is valid.
+renders as claimed; `scripts/session-scribe.sh` run twice (first commit + second commit) produced the dispatch exactly as described, including the documented `HEAD^1`→`git show` fallback on a first commit; the Actions workflow YAML is valid.
 - **reasoned** — the "Reproduce It" links to merged `bamr87/lifehacker.dev` PRs
-  couldn't be SHA-verified without deeper API access (treated as unverified, not a
-  failure). Committing without a `.gitignore` was verified to sweep the entire
-  generated `_site/` tree into the repo.
+couldn't be SHA-verified without deeper API access (treated as unverified, not a failure). Committing without a `.gitignore` was verified to sweep the entire generated `_site/` tree into the repo.
 
 ### 5. SEO Optimization — 68% (warn) · snippets ran **8** (5✓ / 3✗), 2 skipped, 5 reasoned
 - **failed** — real Jekyll 4.4.1 build of the platform-path sequence
-  (`bundle add jekyll-seo-tag jekyll-sitemap; jekyll build`): `/sitemap.xml` was
-  **not** generated (`ls _site/sitemap.xml` → No such file). `bundle add` lands gems
-  in the default group, not `:jekyll_plugins`, so `jekyll-sitemap` never activates
-  until Chapter 2's `plugins:` list is added — after which a rebuild produced
-  `/sitemap.xml` with all 3 URLs (Ch.2 is correct, just out of sequence).
+(`bundle add jekyll-seo-tag jekyll-sitemap; jekyll build`): `/sitemap.xml` was **not** generated (`ls _site/sitemap.xml` → No such file). `bundle add` lands gems in the default group, not `:jekyll_plugins`, so `jekyll-sitemap` never activates until Chapter 2's `plugins:` list is added — after which a rebuild produced `/sitemap.xml` with all 3 URLs (Ch.2 is correct, just out of sequence).
 - **failed (accuracy)** — verified against Jekyll 4.4.1 source: `JEKYLL_ENV=production`
-  only toggles the `jekyll.environment` Liquid variable; it performs **no**
-  HTML/CSS/JS minification. The Chapter 4 claim (line 313) and matching knowledge
-  check (line 339) are wrong.
+only toggles the `jekyll.environment` Liquid variable; it performs **no** HTML/CSS/JS minification. The Chapter 4 claim (line 313) and matching knowledge check (line 339) are wrong.
 - **passed** — the `{% seo %}` tag rendered full `<title>`/meta/canonical/OpenGraph/
-  Twitter/JSON-LD; `robots.txt` built unchanged; the Chapter 3 JSON-LD parsed via
-  `json.loads`; the `author:` block verified against `jekyll-seo-tag` 2.9.0's
-  `AuthorDrop`. `jekyll-seo-tag` rendering after bare `bundle add` was noted as
-  **theme-specific luck** (minima declares it as a gemspec dep), not reliable behavior.
+Twitter/JSON-LD; `robots.txt` built unchanged; the Chapter 3 JSON-LD parsed via `json.loads`; the `author:` block verified against `jekyll-seo-tag` 2.9.0's `AuthorDrop`. `jekyll-seo-tag` rendering after bare `bundle add` was noted as **theme-specific luck** (minima declares it as a gemspec dep), not reliable behavior.
 - **reasoned/skipped** — macOS-only tools (`sips`, `imageoptim`, `open`) and the
   interactive `jekyll serve` + browser steps couldn't run in the Linux sandbox.
 
@@ -147,132 +91,83 @@ actually run in the engine's disposable sandbox). Snippet coverage is reported a
 
 ## 🐞 Issues Found
 
-Grouped by quest; every item cites a witnessed command result or a quoted source
-line. Severity mirrors the engine's own `high/medium/low` where it ran.
+Grouped by quest; every item cites a witnessed command result or a quoted source line. Severity mirrors the engine's own `high/medium/low` where it ran.
 
 **GitHub Pages Portal** (`pages/_quests/0001/github-pages-portal.md`)
 - **high** · Ch.3 s1/s6, `gem install jekyll bundler` / `bundle install` — *observed:*
-  `Gem::FilePermissionError` / `Bundler::PermissionError` on the Linux env the quest
-  itself recommends. *Fix:* add guidance for the system-Ruby permission wall
-  (rbenv/rvm/asdf, or `gem install --user-install` + `bundle config set path
-  vendor/bundle`).
+`Gem::FilePermissionError` / `Bundler::PermissionError` on the Linux env the quest itself recommends. *Fix:* add guidance for the system-Ruby permission wall (rbenv/rvm/asdf, or `gem install --user-install` + `bundle config set path vendor/bundle`).
 - **high** · Ch.3 s5, `index.md` shadowed — *observed via `jekyll build`:* the
-  Chapter 1 `index.html` silently wins; the taught homepage never renders. *Fix:*
-  instruct learners to delete/rename `index.html` before creating `index.md`.
+Chapter 1 `index.html` silently wins; the taught homepage never renders. *Fix:* instruct learners to delete/rename `index.html` before creating `index.md`.
 - **high** · Objectives — *observed:* "Custom domain configuration" is a stated
-  objective but the doc has **zero** mentions of CNAME/DNS/A records. *Fix:* add real
-  CNAME+DNS+Settings steps, or drop the objective.
+objective but the doc has **zero** mentions of CNAME/DNS/A records. *Fix:* add real CNAME+DNS+Settings steps, or drop the objective.
 - **medium** · Ch.1→Ch.3, Jekyll version — standalone `gem install` gives Jekyll
-  4.4.1, then the `github-pages` Gemfile pins 3.10.0 (per `Gemfile.lock`) with no
-  explanation. *Fix:* explain the intentional downgrade.
+4.4.1, then the `github-pages` Gemfile pins 3.10.0 (per `Gemfile.lock`) with no explanation. *Fix:* explain the intentional downgrade.
 - **medium** · `index.md` `{% raw %}{{ site.url }}{% endraw %}` — verbatim copy builds
   a literal broken link. *Fix:* use a plain placeholder outside raw tags.
 - **low** · `_config.yml` `highlander: true` is a non-standard key; **low** ·
   Quest-Network diagram has contradictory bidirectional `A↔D` prerequisite edges.
 - **low (⚠ likely engine artifact — my witness note)** · The engine flagged
-  "missing YAML front matter," but **I read the on-disk file and it has full,
-  well-formed front matter (lines 1–60+)**. This is almost certainly the sandbox
-  presenting a stripped `QUEST.md`, not a real content defect — do **not** act on it.
+"missing YAML front matter," but **I read the on-disk file and it has full, well-formed front matter (lines 1–60+)**. This is almost certainly the sandbox presenting a stripped `QUEST.md`, not a real content defect — do **not** act on it.
 
-**Stack Attack Analysis** (`pages/_quests/0001/it-journey-stack-analysis.md`) —
-*all reasoned (engine timed out; no execute evidence)*
+**Stack Attack Analysis** (`pages/_quests/0001/it-journey-stack-analysis.md`) — *all reasoned (engine timed out; no execute evidence)*
 - **medium (reasoned)** · Objectives are the auto-seeded placeholder block (source
-  lines 79–83: "objectives auto-seeded during framework alignment") and
-  `learning_style: hands-on` / "Complete the hands-on exercises" promise exercises
-  the ~1,300-line report never provides. *Fix:* author real objectives, or reclassify
-  as a reference/reading quest.
+lines 79–83: "objectives auto-seeded during framework alignment") and `learning_style: hands-on` / "Complete the hands-on exercises" promise exercises the ~1,300-line report never provides. *Fix:* author real objectives, or reclassify as a reference/reading quest.
 - **low (reasoned)** · Content is stale in spots (e.g., "Jekyll 3.9.5 … latest GitHub
   Pages-compatible") relative to the Jekyll 4.4.1 used elsewhere in this level.
 
 **Build a Personal Website** (`pages/_quests/0001/personal-site.md`)
 - **high** · Whole quest — *observed:* no runnable steps at all for a "Build a…"
-  title. *Fix:* rewrite to teach creating `<user>.github.io`, scaffolding
-  index/Jekyll, enabling Pages, verifying the live URL.
+title. *Fix:* rewrite to teach creating `<user>.github.io`, scaffolding index/Jekyll, enabling Pages, verifying the live URL.
 - **high** · Unrendered `{% raw %}{{ site.github_user }}{% endraw %}` throughout the
   table. *Fix:* substitute a concrete example or explain the templating.
 - **medium** · Row 12 `jekyllrb.com` mislabeled "Comments service"; rows 2 & 6 are
-  duplicate/contradictory; `nanobar.jacoborus.codes` dead; Travis CI reference
-  outdated. *Fix:* correct the table.
+duplicate/contradictory; `nanobar.jacoborus.codes` dead; Travis CI reference outdated. *Fix:* correct the table.
 - **medium** · Placeholder objectives (same auto-seeded block); no prerequisites or
   validation criteria.
 
 **The Summoning** (`pages/_quests/0001/self-operating-website-01-the-summoning.md`)
 - **high** · Ch.1 Gemfile/`_config.yml` — *observed:* `Unknown tag 'include_cached'`
-  hard build failure against the real named theme. *Fix:* add
-  `jekyll-include-cache` to both the plugins list and the Gemfile `:jekyll_plugins`
-  group (or adopt the theme's recommended `gem "github-pages"`).
+hard build failure against the real named theme. *Fix:* add `jekyll-include-cache` to both the plugins list and the Gemfile `:jekyll_plugins` group (or adopt the theme's recommended `gem "github-pages"`).
 - **medium** · No `.gitignore` step — *observed:* `git add -A` sweeps the entire
-  `_site/` build + `vendor/bundle` into the repo. *Fix:* add a `.gitignore` snippet
-  before the first commit.
+`_site/` build + `vendor/bundle` into the repo. *Fix:* add a `.gitignore` snippet before the first commit.
 - **medium** · Actions versions behind current majors and `configure-pages` ordered
-  before `checkout`; no `--baseurl` for project pages. *Fix:* align with GitHub's
-  official Jekyll-on-Pages starter.
+before `checkout`; no `--baseurl` for project pages. *Fix:* align with GitHub's official Jekyll-on-Pages starter.
 - **low** · No explicit `bundle install` step before the first `jekyll build`/push.
 
 **SEO Optimization** (`pages/_quests/0001/seo-optimization.md`)
 - **high** · Platform-path setup (lines ~61–114) — *observed:* `/sitemap.xml` not
-  produced by `bundle add` alone. *Fix:* introduce the `_config.yml` `plugins:` list
-  (or `bundle add --group jekyll_plugins`) in the setup step, or warn that plugins
-  don't activate until Chapter 2.
+produced by `bundle add` alone. *Fix:* introduce the `_config.yml` `plugins:` list (or `bundle add --group jekyll_plugins`) in the setup step, or warn that plugins don't activate until Chapter 2.
 - **high** · Line 313 + knowledge-check line 339 — *observed against Jekyll 4.4.1
-  source:* `JEKYLL_ENV=production` does not minify. *Fix:* correct the claim (point to
-  `jekyll-minifier` or Sass `style: compressed`) and the matching question.
+source:* `JEKYLL_ENV=production` does not minify. *Fix:* correct the claim (point to `jekyll-minifier` or Sass `style: compressed`) and the matching question.
 - **medium** · Chapter 1 example description is 119 chars vs the stated ~150–160
-  target. **low** · Cloud Realms path lacks a validation step the other three paths
-  have.
+target. **low** · Cloud Realms path lacks a validation step the other three paths have.
 
-**No blocking issues** exist only in the *tested-clean* portions — the brand-as-data
-include, the session-scribe script (Summoning) and the `{% seo %}`/JSON-LD/robots
-mechanics (SEO). Everything else above is a real, evidenced defect.
+**No blocking issues** exist only in the *tested-clean* portions — the brand-as-data include, the session-scribe script (Summoning) and the `{% seo %}`/JSON-LD/robots mechanics (SEO). Everything else above is a real, evidenced defect.
 
 ## 🔗 Chain Continuity
 
-Context: this is a **rotating window (2 of 6)** of a 26-quest level, so these five are
-a *slice*, not a strict N→N+1 dependency chain — and indeed **all five declare
-`required_quests: []`**. As a learner sweeping them in plan order, I found:
+Context: this is a **rotating window (2 of 6)** of a 26-quest level, so these five are a *slice*, not a strict N→N+1 dependency chain — and indeed **all five declare `required_quests: []`**. As a learner sweeping them in plan order, I found:
 
 - **Conflicting "build a site" recipes.** Portal (quest 1) and Summoning (quest 4)
-  both teach Jekyll-on-GitHub-Pages from scratch but with *incompatible* stacks:
-  Portal uses `jekyll new` + the `github-pages` gem (Jekyll 3.10), Summoning uses
-  `remote_theme` + a GitHub Actions build (Jekyll 4). A beginner who did Portal first
-  arrives at Summoning with a different site layout and toolchain than Summoning
-  assumes. Neither cross-references the other. This is the biggest continuity gap.
+both teach Jekyll-on-GitHub-Pages from scratch but with *incompatible* stacks: Portal uses `jekyll new` + the `github-pages` gem (Jekyll 3.10), Summoning uses `remote_theme` + a GitHub Actions build (Jekyll 4). A beginner who did Portal first arrives at Summoning with a different site layout and toolchain than Summoning assumes. Neither cross-references the other. This is the biggest continuity gap.
 - **Both site-build quests are blocked at step one, independently.** Portal dies on
-  gem permissions; Summoning dies on `include_cached`. A learner walking the slice
-  top-to-bottom would be stuck twice before reaching a working site — and the later
-  SEO quest's stated prerequisite is "A Jekyll site to edit," which neither
-  predecessor reliably delivers out of the box.
+gem permissions; Summoning dies on `include_cached`. A learner walking the slice top-to-bottom would be stuck twice before reaching a working site — and the later SEO quest's stated prerequisite is "A Jekyll site to edit," which neither predecessor reliably delivers out of the box.
 - **SEO (quest 5) is the payoff and mostly holds** — its prerequisite ("a Jekyll
-  site") is thematically satisfied by quests 1/4, and its content is the strongest in
-  the set. But its platform-path sitemap bug would bite a learner who just built a
-  site via Portal exactly the same way, compounding the earlier friction.
+site") is thematically satisfied by quests 1/4, and its content is the strongest in the set. But its platform-path sitemap bug would bite a learner who just built a site via Portal exactly the same way, compounding the earlier friction.
 - **Two quests read as unfinished.** Stack Analysis (2) and Personal Website (3) both
-  carry the *identical* auto-seeded placeholder objectives block. Seeing "objectives
-  auto-seeded during framework alignment — authors should refine these" twice in one
-  slice signals to a learner that the path isn't finished, and neither delivers the
-  hands-on exercise its own objectives promise. They function as reference material
-  wedged between three hands-on build quests, breaking the "do something" rhythm.
+carry the *identical* auto-seeded placeholder objectives block. Seeing "objectives auto-seeded during framework alignment — authors should refine these" twice in one slice signals to a learner that the path isn't finished, and neither delivers the hands-on exercise its own objectives promise. They function as reference material wedged between three hands-on build quests, breaking the "do something" rhythm.
 - **Ordering nit:** Personal Website (a services *reference*) sits *before* the
-  Summoning (which actually *builds* the site). A learner would benefit from building
-  first, then consulting the services catalog — the current order front-loads a
-  context-free link table.
+Summoning (which actually *builds* the site). A learner would benefit from building first, then consulting the services catalog — the current order front-loads a context-free link table.
 
-Net: the slice does **not** yet hold together as a smooth learning path — two hard
-blockers, two conflicting site recipes, and two placeholder-objective reference pages
-mean a real Apprentice developer would stall early and repeatedly.
+Net: the slice does **not** yet hold together as a smooth learning path — two hard blockers, two conflicting site recipes, and two placeholder-objective reference pages mean a real Apprentice developer would stall early and repeatedly.
 
 ## 🧠 Reasoning & Method
 
 - **Mode:** `execute` (sandboxed), consuming **workflow-sealed** `walk-evidence.json`
   + `walk-evidence.md`. Per the skill's step 2, the engine was pre-run
-  deterministically by the workflow (its child `claude` processes can't authenticate
-  from my Bash tool); **I did not run, regenerate, or edit the evidence or the plan.**
+deterministically by the workflow (its child `claude` processes can't authenticate from my Bash tool); **I did not run, regenerate, or edit the evidence or the plan.**
 - **What I ran vs. reasoned:** the *engine* actually executed commands in a disposable
-  temp dir per quest (git flows, `gem/bundle`, `jekyll build`, a cloned real theme,
-  `mmdc`, `pwsh`, `json.loads`, source cross-checks) — those are the `passed`/`failed`
-  facts in §Evidence. **I** then read all five quest sources in plan order to reason
-  about the *linked journey* (§Chain Continuity). Everything I concluded without a
-  sandbox command is labeled **reasoned**.
+temp dir per quest (git flows, `gem/bundle`, `jekyll build`, a cloned real theme, `mmdc`, `pwsh`, `json.loads`, source cross-checks) — those are the `passed`/`failed` facts in §Evidence. **I** then read all five quest sources in plan order to reason about the *linked journey* (§Chain Continuity). Everything I concluded without a sandbox command is labeled **reasoned**.
 - **Coverage & limits, stated honestly:**
   - **Quest 2 (Stack Analysis) has ZERO execute evidence** — it timed out at 600s.
     All my remarks on it are reasoned from source only; do not read them as tested.
@@ -284,8 +179,6 @@ mean a real Apprentice developer would stall early and repeatedly.
     on-disk file (which has full front matter). I flagged it as a **likely sandbox
     artifact** and recommend ignoring it — an honest witness note, not a validated bug.
 - **Confidence:** High on the four scored quests' blockers (each backed by a real,
-  reproduced command). Medium-low on Stack Analysis (source-only). Overall verdict
-  **fail** follows directly from the sealed counts (0 pass · 1 warn · 4 fail, 49.5%),
-  not from my own grading.
+reproduced command). Medium-low on Stack Analysis (source-only). Overall verdict **fail** follows directly from the sealed counts (0 pass · 1 warn · 4 fail, 49.5%), not from my own grading.
 - **Scope discipline:** one slice, one report. No quest content was edited; no branch,
   commit, or PR was made. The workflow handles git.

--- a/test/quest-validator/walkthroughs/2026-07-17-digital-artist-0001.md
+++ b/test/quest-validator/walkthroughs/2026-07-17-digital-artist-0001.md
@@ -18,23 +18,9 @@ session:
 
 ## 🎯 Session Summary
 
-Walked a **5-quest window (2 of 6)** of the **Digital Artist → Level 0001 "Web
-Fundamentals" (🌱 Apprentice)** path, in the dependency-sorted order the planner
-selected, as a UI/UX-leaning beginner would. Evidence is the workflow-sealed
-execute-mode engine run (`walk-evidence.json`); I read all five quest sources and
-reasoned about them as one linked journey.
+Walked a **5-quest window (2 of 6)** of the **Digital Artist → Level 0001 "Web Fundamentals" (🌱 Apprentice)** path, in the dependency-sorted order the planner selected, as a UI/UX-leaning beginner would. Evidence is the workflow-sealed execute-mode engine run (`walk-evidence.json`); I read all five quest sources and reasoned about them as one linked journey.
 
-**Headline verdict: FAIL.** No quest passed — 2 warn (68%), 3 fail (48/16/58),
-average **51.6%**. The strongest quest, *The GitHub Pages Portal*, actually deploys
-a working Jekyll/GitHub Pages site end-to-end in the sandbox and is the true spine
-of this slice. But the window also contains two "quests" that are not tutorials at
-all (*Personal Site*, 16%; *Stack Attack Analysis*, 48% — both carry the tell-tale
-"objectives auto-seeded during framework alignment" placeholder note), and two
-otherwise-solid main quests (*The Summoning*, *SEO Optimization*) each ship with **one
-reproducible build-breaking defect** a beginner hits on their very first build. A
-maintainer should treat *Personal Site* and *Stack Attack Analysis* as needing a
-rewrite/retype, and land the two single-line/single-config fixes in the two main
-quests.
+**Headline verdict: FAIL.** No quest passed — 2 warn (68%), 3 fail (48/16/58), average **51.6%**. The strongest quest, *The GitHub Pages Portal*, actually deploys a working Jekyll/GitHub Pages site end-to-end in the sandbox and is the true spine of this slice. But the window also contains two "quests" that are not tutorials at all (*Personal Site*, 16%; *Stack Attack Analysis*, 48% — both carry the tell-tale "objectives auto-seeded during framework alignment" placeholder note), and two otherwise-solid main quests (*The Summoning*, *SEO Optimization*) each ship with **one reproducible build-breaking defect** a beginner hits on their very first build. A maintainer should treat *Personal Site* and *Stack Attack Analysis* as needing a rewrite/retype, and land the two single-line/single-config fixes in the two main quests.
 
 ## 🗺️ The Journey
 
@@ -48,8 +34,7 @@ quests.
 
 ## 🔬 Evidence
 
-All statuses below come from the sealed execute-mode engine run (`--mode execute`,
-sandboxed per quest). "ran N/M" = engine's recorded/available snippet accounting.
+All statuses below come from the sealed execute-mode engine run (`--mode execute`, sandboxed per quest). "ran N/M" = engine's recorded/available snippet accounting.
 
 ### 1. The GitHub Pages Portal — ⚠️ 68 (ran 14 snippets, 14 passed / 0 failed / 1 skipped / 2 reasoned)
 Dimensions: commands_work **4**, content_accuracy 3, completeness **2**, clarity 4, structure 3, safety 4.
@@ -86,8 +71,7 @@ Dimensions: commands_work 3, content_accuracy 3, completeness **4**, clarity 3, 
 
 ## 🐞 Issues Found
 
-Every item below is backed by a sandbox command result or a quoted quest line.
-Severity reflects learner impact (blocks progress > misleads > polish).
+Every item below is backed by a sandbox command result or a quoted quest line. Severity reflects learner impact (blocks progress > misleads > polish).
 
 1. **HIGH · Personal Site · whole document ·** Zero fenced code blocks, zero runnable steps, zero verification — `grep` confirmed 0 code fences; engine scored commands_work/completeness/clarity all 0. It's the author's personal reference table, not a tutorial. **Fix:** rewrite as a real step-by-step (create `<username>.github.io` repo → add `index.html` → push → enable Pages → verify live URL) and replace the auto-seeded placeholder objectives (line 63).
 2. **HIGH · Personal Site · §1 table ·** Factual errors: row 12 calls `jekyllrb.com` a "Comments service" (line 86, it's a static-site generator); row 6 reuses row 2's GitHub Pages URL for a "Cloudflare" domain (lines 76/80); `travis-ci.org` (77) and `*.netlify.com` (78) are outdated; unresolved `{{ site.github_user }}` Liquid renders as literal `{}`. **Fix:** correct descriptions, de-duplicate the domain row, update to `*.netlify.app`/GitHub Actions, and substitute concrete example values or `<your-username>`.
@@ -109,58 +93,23 @@ Severity reflects learner impact (blocks progress > misleads > polish).
 Reading the five in plan order as one Digital-Artist journey:
 
 - **The window is not a clean linear path — it's one strong spine plus satellites.**
-  Quest 1 (*GitHub Pages Portal*) is the real backbone: it takes a beginner from
-  nothing to a live Jekyll/GitHub Pages site, and it's the only quest that
-  self-contains the full install→build→deploy loop. Everything else in the window
-  assumes that spine but doesn't declare it — every quest here has empty
-  `quest_dependencies.required_quests`, so the chain's ordering is implicit, not
-  enforced.
+Quest 1 (*GitHub Pages Portal*) is the real backbone: it takes a beginner from nothing to a live Jekyll/GitHub Pages site, and it's the only quest that self-contains the full install→build→deploy loop. Everything else in the window assumes that spine but doesn't declare it — every quest here has empty `quest_dependencies.required_quests`, so the chain's ordering is implicit, not enforced.
 - **Two satellites break the learning flow.** After the momentum of quest 1, a
-  learner hits quest 2 (*Stack Attack Analysis*, an architecture report) and quest 3
-  (*Personal Site*, a reference table) — neither has runnable steps, and both openly
-  admit "objectives auto-seeded during framework alignment." For a UI/UX beginner
-  expecting to *build* something, these read as dead ends and erode trust in the path.
+learner hits quest 2 (*Stack Attack Analysis*, an architecture report) and quest 3 (*Personal Site*, a reference table) — neither has runnable steps, and both openly admit "objectives auto-seeded during framework alignment." For a UI/UX beginner expecting to *build* something, these read as dead ends and erode trust in the path.
 - **Prerequisite gap at quest 4.** *The Summoning* states it needs "a live
-  zer0-mistakes Jekyll site — complete the prequel epic first" (line 96) and a
-  "Claude Code OAuth token" (line 101). Nothing earlier in *this* window provides a
-  zer0-mistakes/remote-theme site — quest 1 builds a **default** `jekyll new` site,
-  not a `bamr87/zer0-mistakes` one. So the summoning's remote-theme + `include_cached`
-  build (the exact thing that fails) lands on a learner who was never walked through
-  a remote-theme build. This is a genuine continuity gap, compounded by issue #5.
+zer0-mistakes Jekyll site — complete the prequel epic first" (line 96) and a "Claude Code OAuth token" (line 101). Nothing earlier in *this* window provides a zer0-mistakes/remote-theme site — quest 1 builds a **default** `jekyll new` site, not a `bamr87/zer0-mistakes` one. So the summoning's remote-theme + `include_cached` build (the exact thing that fails) lands on a learner who was never walked through a remote-theme build. This is a genuine continuity gap, compounded by issue #5.
 - **Quest 5 (*SEO Optimization*) chains best.** It explicitly assumes "an existing
-  Jekyll site" — satisfied by quest 1 — and its concepts build naturally on a deployed
-  site. Its only real snag (the quickstart missing the plugins-list edit, issue #6) is
-  self-contained, not a cross-quest dependency.
+Jekyll site" — satisfied by quest 1 — and its concepts build naturally on a deployed site. Its only real snag (the quickstart missing the plugins-list edit, issue #6) is self-contained, not a cross-quest dependency.
 - **Net:** as a *character path*, a Digital Artist would get real value from quests
-  1 → 5 → 4-once-fixed, but quests 2 and 3 don't yet function as quests and quest 4
-  assumes setup this window never provides. The slice holds together thematically
-  (Web Fundamentals) but not yet as an executable, ordered learning chain.
+1 → 5 → 4-once-fixed, but quests 2 and 3 don't yet function as quests and quest 4 assumes setup this window never provides. The slice holds together thematically (Web Fundamentals) but not yet as an executable, ordered learning chain.
 
 ## 🧠 Reasoning & Method
 
 - **Mode: execute.** Evidence is the workflow-sealed `walk-evidence.json` /
-  `walk-evidence.md` — the agentic execute engine ran each quest's safe snippets in a
-  disposable per-quest sandbox (5 quests, avg 51.6%, ~$4.99, sessions 36-40 turns).
-  Per the skill, I consumed it **as-is**; I did not re-run, regenerate, or edit the
-  engine (its child `claude` processes can't authenticate from my Bash tool), and I
-  did not touch `walk-plan.json` or `walk-evidence.*`.
+`walk-evidence.md` — the agentic execute engine ran each quest's safe snippets in a disposable per-quest sandbox (5 quests, avg 51.6%, ~$4.99, sessions 36-40 turns). Per the skill, I consumed it **as-is**; I did not re-run, regenerate, or edit the engine (its child `claude` processes can't authenticate from my Bash tool), and I did not touch `walk-plan.json` or `walk-evidence.*`.
 - **What I ran vs. reasoned:** all `passed`/`failed`/`skipped` statuses are the
-  engine's actual sandbox results (I quoted its recorded commands and outputs). I
-  additionally **read all five quest sources in plan order** and cross-checked the
-  engine's findings against the source — items I verified only by reading (e.g. the
-  Personal Site table errors at lines 76-88, the Summoning prerequisite at line 96,
-  the SEO quickstart at lines 149-198, the `JEKYLL_ENV` claim at line 400) are the
-  learner-continuity layer and are labeled by line rather than presented as new
-  command runs. I invented no output, score, or issue.
+engine's actual sandbox results (I quoted its recorded commands and outputs). I additionally **read all five quest sources in plan order** and cross-checked the engine's findings against the source — items I verified only by reading (e.g. the Personal Site table errors at lines 76-88, the Summoning prerequisite at line 96, the SEO quickstart at lines 149-198, the `JEKYLL_ENV` claim at line 400) are the learner-continuity layer and are labeled by line rather than presented as new command runs. I invented no output, score, or issue.
 - **Coverage & limits:** this is **window 2 of 6** — 5 of the level's **26** quests.
-  Verdicts apply only to these five; the rest of Digital-Artist/0001 is not certified
-  by this run. Engine snippet accounting was capped where noted (e.g. SEO ran 10 with
-  4 skipped — image-optimization `sips`/`brew`/`imageoptim` and the PowerShell Windows
-  path were not executed in this Linux sandbox). Network-dependent steps (`git clone`
-  of placeholder repos, `git push`) could not truly deploy and are correctly recorded
-  as `reasoned`/expected-fail, not `passed`.
+Verdicts apply only to these five; the rest of Digital-Artist/0001 is not certified by this run. Engine snippet accounting was capped where noted (e.g. SEO ran 10 with 4 skipped — image-optimization `sips`/`brew`/`imageoptim` and the PowerShell Windows path were not executed in this Linux sandbox). Network-dependent steps (`git clone` of placeholder repos, `git push`) could not truly deploy and are correctly recorded as `reasoned`/expected-fail, not `passed`.
 - **Confidence: high** on the five per-quest verdicts (backed by real sandbox
-  builds, including a full Jekyll build/serve for quest 1 and the confirmed
-  `include_cached` failure for quest 4) and on the two "not-a-tutorial" findings
-  (quests 2-3). **Medium** on the chain-continuity conclusions, which are reasoned
-  from reading rather than executed cross-quest.
+builds, including a full Jekyll build/serve for quest 1 and the confirmed `include_cached` failure for quest 4) and on the two "not-a-tutorial" findings (quests 2-3). **Medium** on the chain-continuity conclusions, which are reasoned from reading rather than executed cross-quest.

--- a/test/quest-validator/walkthroughs/2026-07-17-game-developer-0111.md
+++ b/test/quest-validator/walkthroughs/2026-07-17-game-developer-0111.md
@@ -19,24 +19,9 @@ session:
 
 ## 🎯 Session Summary
 
-I walked the first window (5 of 10 quests) of the **Game Developer → Level 0111
-(API Development, Adventurer ⚔️)** slice as a learner, consuming the workflow-sealed
-execute-mode evidence and reading every quest source in plan order to reason about
-the linked journey. The headline verdict is **fail**: the engine averaged **66.2%**
-with **2 pass, 1 warn, 2 fail**, and the two failing quests are broken in ways a real
-beginner would hit within the first five minutes of the hands-on work.
+I walked the first window (5 of 10 quests) of the **Game Developer → Level 0111 (API Development, Adventurer ⚔️)** slice as a learner, consuming the workflow-sealed execute-mode evidence and reading every quest source in plan order to reason about the linked journey. The headline verdict is **fail**: the engine averaged **66.2%** with **2 pass, 1 warn, 2 fail**, and the two failing quests are broken in ways a real beginner would hit within the first five minutes of the hands-on work.
 
-The slice is really **two unrelated learning tracks braided together** by the
-dependency-sorter: a polished *API Design Mastery* pair (API Fundamentals → REST
-Principles) and a *GH-600 Agentic Codex* trio. Within the agentic trio, the well-built
-hub quest (`agentic-codex-01`, 95%) teaches plan-then-act cleanly with a self-contained
-lab, while the two sibling quests that drill the *same* Domain 1 sub-skills
-(`agentic-sdlc-integration` 44%, `agentic-plan-vs-action-boundaries` 38%) both send the
-learner into a `work/gh-600/` scaffold and a `scripts/validate_quest.py` self-check that
-**do not exist in the repo** — I verified both absences directly. The maintainer-actionable
-takeaway: the API pair is solid, and the agentic content already has a working reference
-(the codex hub) whose lab pattern should replace the broken scaffold assumptions in its two
-siblings.
+The slice is really **two unrelated learning tracks braided together** by the dependency-sorter: a polished *API Design Mastery* pair (API Fundamentals → REST Principles) and a *GH-600 Agentic Codex* trio. Within the agentic trio, the well-built hub quest (`agentic-codex-01`, 95%) teaches plan-then-act cleanly with a self-contained lab, while the two sibling quests that drill the *same* Domain 1 sub-skills (`agentic-sdlc-integration` 44%, `agentic-plan-vs-action-boundaries` 38%) both send the learner into a `work/gh-600/` scaffold and a `scripts/validate_quest.py` self-check that **do not exist in the repo** — I verified both absences directly. The maintainer-actionable takeaway: the API pair is solid, and the agentic content already has a working reference (the codex hub) whose lab pattern should replace the broken scaffold assumptions in its two siblings.
 
 ## 🗺️ The Journey
 
@@ -50,9 +35,7 @@ Plan order (dependency-sorted; `walk-plan.json`):
 
 ## 🔬 Evidence
 
-All results below are from the workflow's sealed `walk-evidence.json` (execute mode,
-`mock: false`), corroborated where noted by my own read-only repo checks. I did **not**
-re-run the engine.
+All results below are from the workflow's sealed `walk-evidence.json` (execute mode, `mock: false`), corroborated where noted by my own read-only repo checks. I did **not** re-run the engine.
 
 ### 1. API Fundamentals — 74 (⚠️ warn) · ran 8/10 runnable snippets (7✓ 1✗), 3 reasoned
 - `docker run --rm curlimages/curl:latest .../posts/1` → **passed**, returned the exact documented JSON object.

--- a/test/quest-validator/walkthroughs/2026-07-17-security-specialist-1011.md
+++ b/test/quest-validator/walkthroughs/2026-07-17-security-specialist-1011.md
@@ -26,52 +26,27 @@ session:
 
 ## 🎯 Session Summary
 
-I walked the **window 2 of 3** slice of the **Security Specialist → Level 1011
-(Security & Compliance, 🔥 Warrior)** path: two `main_quest` pages —
-**Penetration Testing** (🔴 Hard) and **Compliance Standards** (🟡 Medium) — in the
-order the planner sorted them. The full level holds 12 quests; this rotating window
-covered the last two.
+I walked the **window 2 of 3** slice of the **Security Specialist → Level 1011 (Security & Compliance, 🔥 Warrior)** path: two `main_quest` pages — **Penetration Testing** (🔴 Hard) and **Compliance Standards** (🟡 Medium) — in the order the planner sorted them. The full level holds 12 quests; this rotating window covered the last two.
 
-**Headline verdict: ⚠️ warn.** Not because a quest is broken, but because the slice
-is only **half-covered by real evidence**. The **Compliance Standards** quest is
-excellent — it scored **97%**, and all **4/4 runnable snippets actually executed and
-passed** in the sandbox with content verified accurate against current framework
-revisions (SOC 2 TSC, ISO 27001:2022, GDPR, PCI-DSS v4.0). But the **Penetration
-Testing** quest yielded **zero execute evidence**: the engine **timed out after 600s**
-and returned a `fail` with `overall: 0`. That is an *engine/tooling* failure, not a
-demonstrated content defect — so I treat every pentest observation below as
-`reasoned` (read statically from source), never `tested`. A maintainer should read
-this as "one quest proven solid, one quest un-walked" and re-run the pentest quest
-with a longer budget before trusting any verdict on it.
+**Headline verdict: ⚠️ warn.** Not because a quest is broken, but because the slice is only **half-covered by real evidence**. The **Compliance Standards** quest is excellent — it scored **97%**, and all **4/4 runnable snippets actually executed and passed** in the sandbox with content verified accurate against current framework revisions (SOC 2 TSC, ISO 27001:2022, GDPR, PCI-DSS v4.0). But the **Penetration Testing** quest yielded **zero execute evidence**: the engine **timed out after 600s** and returned a `fail` with `overall: 0`. That is an *engine/tooling* failure, not a demonstrated content defect — so I treat every pentest observation below as `reasoned` (read statically from source), never `tested`. A maintainer should read this as "one quest proven solid, one quest un-walked" and re-run the pentest quest with a longer budget before trusting any verdict on it.
 
 ## 🗺️ The Journey
 
 1. ❌ **Penetration Testing: Tools and Ethical Hacking Methodologies** — score **—**
-   (engine timed out after 600s; no snippets run) · *Content reads well and is
-   ethics-first, but it is heavy on external tooling (docker, brew/winget casks,
-   nmap, Burp/ZAP) — almost certainly why the execute engine exhausted its 600s
-   budget. Un-walked; reasoned-only.*
+(engine timed out after 600s; no snippets run) · *Content reads well and is ethics-first, but it is heavy on external tooling (docker, brew/winget casks, nmap, Burp/ZAP) — almost certainly why the execute engine exhausted its 600s budget. Un-walked; reasoned-only.*
 2. ✅ **Compliance Standards: SOC 2, ISO 27001, GDPR, and PCI-DSS** — score **97**
-   (4/4 runnable snippets passed, 4 reasoned) · *A clean, accurate, well-structured
-   documentation/process quest; only thin spots are two lightly-covered secondary
-   objectives.*
+(4/4 runnable snippets passed, 4 reasoned) · *A clean, accurate, well-structured documentation/process quest; only thin spots are two lightly-covered secondary objectives.*
 
 ## 🔬 Evidence
 
 ### Quest 1 — Penetration Testing (❌ no evidence gathered)
 
 - **Engine result:** `error: "claude timed out after 600s"`, `verdict: fail`,
-  `overall: 0.0`, `verdict_obj: null`. No commands were recorded, no snippets ran,
-  no per-dimension scores exist.
+`overall: 0.0`, `verdict_obj: null`. No commands were recorded, no snippets ran, no per-dimension scores exist.
 - **Coverage:** ran **0** snippets — this quest was **not executed**. Everything I say
-  about it is `reasoned` from the source file (`pages/_quests/1011/penetration-testing.md`),
-  not witnessed in the sandbox.
+about it is `reasoned` from the source file (`pages/_quests/1011/penetration-testing.md`), not witnessed in the sandbox.
 - **Why it likely timed out (reasoned):** every platform path front-loads slow,
-  network-heavy installs and container pulls — `brew install --cask zap/burp-suite`
-  (macOS), `winget install …` (Windows), `sudo apt install -y nmap zaproxy` +
-  `docker run … bkimminich/juice-shop` (Linux). An execute engine attempting these
-  will spend its whole budget on downloads. This is consistent with a 600s timeout
-  and is itself a real learner-friction signal (see Issues).
+network-heavy installs and container pulls — `brew install --cask zap/burp-suite` (macOS), `winget install …` (Windows), `sudo apt install -y nmap zaproxy` + `docker run … bkimminich/juice-shop` (Linux). An execute engine attempting these will spend its whole budget on downloads. This is consistent with a 600s timeout and is itself a real learner-friction signal (see Issues).
 
 ### Quest 2 — Compliance Standards (✅ executed, 97%)
 
@@ -89,10 +64,7 @@ Commands actually run (from `walk-evidence.json`):
 | Linux: `mkdir` → `echo … > csv` → `git init -q && git add` | ✅ passed | `git status` afterward confirmed `controls-matrix.csv` staged as a new file |
 | Cloud Realms: `echo "Inherit provider controls; you remain responsible…"` | ✅ passed | Printed the expected shared-responsibility string verbatim |
 
-Reasoned (non-runnable) content the engine verified as accurate: the SOC 2 vs
-ISO 27001 comparison table, the PCI-DSS 1–12 requirement groupings (matches v4.0),
-the MFA controls-mapping matrix (SOC 2 CC6.1 / ISO 27001 A.8.5 / GDPR Art. 32 /
-PCI-DSS Req. 8.4-8.5), and the audit-evidence / Type II period discussion.
+Reasoned (non-runnable) content the engine verified as accurate: the SOC 2 vs ISO 27001 comparison table, the PCI-DSS 1–12 requirement groupings (matches v4.0), the MFA controls-mapping matrix (SOC 2 CC6.1 / ISO 27001 A.8.5 / GDPR Art. 32 / PCI-DSS Req. 8.4-8.5), and the audit-evidence / Type II period discussion.
 
 > From `walk-evidence.md`: *"all four platform snippets ran successfully in the
 > sandbox exactly as described. Minor gaps exist only in the depth of coverage for
@@ -100,101 +72,48 @@ PCI-DSS Req. 8.4-8.5), and the audit-evidence / Type II period discussion.
 
 ## 🐞 Issues Found
 
-**Penetration Testing** (all `reasoned` — the quest was not executed, so these are
-static-read observations, not sandbox-witnessed failures):
+**Penetration Testing** (all `reasoned` — the quest was not executed, so these are static-read observations, not sandbox-witnessed failures):
 
 - **medium · Penetration Testing · platform setup blocks (lines 147-188) · engine
-  timeout / heavy prerequisites.** The engine **timed out after 600s** and captured
-  no evidence. Reading the source, every path requires large external installs plus a
-  Docker container pull (`docker run … bkimminich/juice-shop`). *Suggested fix:*
-  offer a lighter "no-install / hosted lab" default (the Cloud Realms path already
-  points at PortSwigger Academy + TryHackMe — promote it as the primary walkthrough
-  target) so both a real beginner and the execute engine can complete the quest
-  without a multi-hundred-MB toolchain. This is the single highest-value change for
-  making this quest walkable.
+timeout / heavy prerequisites.** The engine **timed out after 600s** and captured no evidence. Reading the source, every path requires large external installs plus a Docker container pull (`docker run … bkimminich/juice-shop`). *Suggested fix:* offer a lighter "no-install / hosted lab" default (the Cloud Realms path already points at PortSwigger Academy + TryHackMe — promote it as the primary walkthrough target) so both a real beginner and the execute engine can complete the quest without a multi-hundred-MB toolchain. This is the single highest-value change for making this quest walkable.
 - **low · Penetration Testing · Linux path (lines 183-187) · privilege assumption.**
-  `sudo apt install …` and `sudo docker run …` assume passwordless sudo and a Docker
-  daemon. A learner on a locked-down machine (or the sandbox) gets stuck with no
-  fallback. *Suggested fix:* note the rootless/Docker-Desktop alternative and that
-  `sudo` may be unavailable.
+`sudo apt install …` and `sudo docker run …` assume passwordless sudo and a Docker daemon. A learner on a locked-down machine (or the sandbox) gets stuck with no fallback. *Suggested fix:* note the rootless/Docker-Desktop alternative and that `sudo` may be unavailable.
 - **low · Penetration Testing · Chapter 3 (line 308) · `zap.sh` on PATH.** The
-  headless command `zap.sh -cmd …` assumes `zap.sh` is on `PATH`, but the macOS cask
-  and Windows winget installs don't guarantee that binary name/location. *Suggested
-  fix:* mention the platform-specific launcher path or that ZAP must be started from
-  its install dir.
+headless command `zap.sh -cmd …` assumes `zap.sh` is on `PATH`, but the macOS cask and Windows winget installs don't guarantee that binary name/location. *Suggested fix:* mention the platform-specific launcher path or that ZAP must be started from its install dir.
 - **low · Penetration Testing · Knowledge Graph (line 436) · stale wiki-link title.**
-  The `**Unlocks:**` link reads `[[Compliance Standards: SOC 2, GDPR, and HIPAA
-  Requirements]]`, but the actual unlocked quest is titled **"SOC 2, ISO 27001,
-  GDPR, and PCI-DSS"** — it covers PCI-DSS, not HIPAA. *Suggested fix:* update the
-  wiki-link to the current title so the graph resolves and no beginner expects a
-  HIPAA chapter that doesn't exist.
+The `**Unlocks:**` link reads `[[Compliance Standards: SOC 2, GDPR, and HIPAA Requirements]]`, but the actual unlocked quest is titled **"SOC 2, ISO 27001, GDPR, and PCI-DSS"** — it covers PCI-DSS, not HIPAA. *Suggested fix:* update the wiki-link to the current title so the graph resolves and no beginner expects a HIPAA chapter that doesn't exist.
 
 **Compliance Standards** (low, from the engine's own recommendations):
 
 - **low · Compliance Standards · Secondary Objectives (lines 105, 107) · thin
-  coverage.** "Gap Assessment" appears only as an unguided mastery challenge and
-  "Shared Responsibility" is only the one-line Cloud Realms echo — both are named
-  objectives. *Suggested fix:* add a short worked example (a mini gap-assessment row;
-  2-3 sentences on provider-vs-customer ownership).
+coverage.** "Gap Assessment" appears only as an unguided mastery challenge and "Shared Responsibility" is only the one-line Cloud Realms echo — both are named objectives. *Suggested fix:* add a short worked example (a mini gap-assessment row; 2-3 sentences on provider-vs-customer ownership).
 - **low · Compliance Standards · Continuous Compliance (line 313) · one-paragraph
-  depth.** Vanta/Drata/custom-scripts get a single paragraph. *Suggested fix:* add a
-  concrete example of what an automated evidence query might check.
+depth.** Vanta/Drata/custom-scripts get a single paragraph. *Suggested fix:* add a concrete example of what an automated evidence query might check.
 
-No **high-severity, sandbox-witnessed** content failures were found. The only high-
-impact problem in this slice is the **inability to gather evidence for the pentest
-quest at all**, which is a tooling/budget issue to resolve on re-run.
+No **high-severity, sandbox-witnessed** content failures were found. The only high- impact problem in this slice is the **inability to gather evidence for the pentest quest at all**, which is a tooling/budget issue to resolve on re-run.
 
 ## 🔗 Chain Continuity
 
 Reading the two quests as one journey a Security Specialist would actually take:
 
 - **Prerequisites are met by earlier windows, not this one.** Both quests declare
-  `required_quests: /quests/1011/security-fundamentals/`. That quest sits in an
-  earlier window of this level (this is window 2 of 3, offset 10), so a learner
-  reaching here is *assumed* to have the CIA-triad / controls grounding both quests
-  lean on. Within this window nothing is orphaned — neither quest assumes setup the
-  other was supposed to provide.
+`required_quests: /quests/1011/security-fundamentals/`. That quest sits in an earlier window of this level (this is window 2 of 3, offset 10), so a learner reaching here is *assumed* to have the CIA-triad / controls grounding both quests lean on. Within this window nothing is orphaned — neither quest assumes setup the other was supposed to provide.
 - **Ordering is correct and the narrative hands off cleanly.** Penetration Testing
-  declares `unlocks_quests: /quests/1011/compliance-standards/`, and Compliance
-  Standards lists pentest as a `recommended_quest`. The pentest quest's closing
-  "Unlocked Quests" explicitly frames the transition — *"Compliance Standards —
-  Penetration tests are often a required audit control"* — and Compliance Standards
-  pays it off in Chapter 2 (PCI-DSS requirements 10-11: *"logging, scans, penetration
-  tests"*). A learner finishing the pentest report arrives at compliance understanding
-  *why* that report is audit evidence. That is genuinely good linked design.
+declares `unlocks_quests: /quests/1011/compliance-standards/`, and Compliance Standards lists pentest as a `recommended_quest`. The pentest quest's closing "Unlocked Quests" explicitly frames the transition — *"Compliance Standards — Penetration tests are often a required audit control"* — and Compliance Standards pays it off in Chapter 2 (PCI-DSS requirements 10-11: *"logging, scans, penetration tests"*). A learner finishing the pentest report arrives at compliance understanding *why* that report is audit evidence. That is genuinely good linked design.
 - **The forward continuity I could verify holds; the backward half I could not
-  execute.** Because the pentest quest never ran, I cannot confirm from evidence that
-  a learner actually *completes* it and emerges "ready" for compliance — only that
-  the two pages are wired together correctly and the prose transition is coherent.
-  The likely real-world snag is upstream of the narrative: a beginner may stall on the
-  pentest tooling install (same friction that timed out the engine) and never reach
-  the hand-off. Making the hosted-lab path the default would protect the whole chain.
+execute.** Because the pentest quest never ran, I cannot confirm from evidence that a learner actually *completes* it and emerges "ready" for compliance — only that the two pages are wired together correctly and the prose transition is coherent. The likely real-world snag is upstream of the narrative: a beginner may stall on the pentest tooling install (same friction that timed out the engine) and never reach the hand-off. Making the hosted-lab path the default would protect the whole chain.
 - **One cosmetic graph break:** the pentest quest's Obsidian `Unlocks` wiki-link names
-  a "HIPAA" version of the compliance quest that doesn't exist (see Issues) — a
-  learner exploring the graph would hit a dead/renamed node.
+a "HIPAA" version of the compliance quest that doesn't exist (see Issues) — a learner exploring the graph would hit a dead/renamed node.
 
 ## 🧠 Reasoning & Method
 
 - **Mode:** `execute`. I consumed **sealed, workflow-minted evidence**
-  (`walk-plan.json` + `walk-evidence.json` + `walk-evidence.md`) exactly as provided.
-  I did **not** run, regenerate, or edit the engine or its evidence (the engine's
-  child `claude` processes cannot authenticate from my Bash tool), and I did not edit
-  any quest content. My only write is this report.
+(`walk-plan.json` + `walk-evidence.json` + `walk-evidence.md`) exactly as provided. I did **not** run, regenerate, or edit the engine or its evidence (the engine's child `claude` processes cannot authenticate from my Bash tool), and I did not edit any quest content. My only write is this report.
 - **What was tested vs. reasoned:** Only **Compliance Standards** carries real
-  sandbox evidence (4/4 runnable snippets executed and passed; 4 text blocks
-  reasoned). **Penetration Testing carries no evidence** — the engine timed out at
-  600s — so every statement I make about it is `reasoned` from the source file, and I
-  have labeled it as such throughout. I did not fabricate a score, command, or output
-  for it.
+sandbox evidence (4/4 runnable snippets executed and passed; 4 text blocks reasoned). **Penetration Testing carries no evidence** — the engine timed out at 600s — so every statement I make about it is `reasoned` from the source file, and I have labeled it as such throughout. I did not fabricate a score, command, or output for it.
 - **Coverage honesty:** This was a **2-quest window (2 of 3)** of a 12-quest level;
-  I did **not** walk the other 10 quests, and I did not walk the level's prerequisite
-  chain — those belong to other windows and are accumulated by the perfection ledger
-  over time. Within my window, **50% of quests produced usable evidence**; the pentest
-  quest is effectively un-walked and should not be counted as validated.
+I did **not** walk the other 10 quests, and I did not walk the level's prerequisite chain — those belong to other windows and are accumulated by the perfection ledger over time. Within my window, **50% of quests produced usable evidence**; the pentest quest is effectively un-walked and should not be counted as validated.
 - **Confidence:** **High** on the Compliance Standards verdict (direct, reproducible
-  execute evidence, accurate content). **Low** on Penetration Testing — I can only
-  attest that it reads coherently and is ethics-first; I cannot attest that its
-  commands work, because none were run. The `warn` overall verdict reflects that split.
+execute evidence, accurate content). **Low** on Penetration Testing — I can only attest that it reads coherently and is ethics-first; I cannot attest that its commands work, because none were run. The `warn` overall verdict reflects that split.
 - **Recommended next action:** re-run the Penetration Testing quest through the execute
-  engine with a larger time/turn budget, or after promoting the hosted-lab (Cloud
-  Realms) path to primary so the sandbox isn't forced through heavyweight installs.
+engine with a larger time/turn budget, or after promoting the hosted-lab (Cloud Realms) path to primary so the sandbox isn't forced through heavyweight installs.

--- a/test/quest-validator/walkthroughs/2026-07-17-system-engineer-1001.md
+++ b/test/quest-validator/walkthroughs/2026-07-17-system-engineer-1001.md
@@ -18,26 +18,11 @@ session:
 
 ## 🎯 Session Summary
 
-I walked a **5-quest window** (window 1 of 2; the level holds 9 quests total) of the
-**System Engineer** path at **Level 1001 — "Kubernetes Orchestration" (Warrior 🔥)**,
-as a learner following each quest end-to-end. Evidence comes from the sealed
-execute-mode engine run (`walk-evidence.json`), which sandboxed each quest and ran its
-safe snippets for real; my value-add is reasoning about the five as one linked journey.
+I walked a **5-quest window** (window 1 of 2; the level holds 9 quests total) of the **System Engineer** path at **Level 1001 — "Kubernetes Orchestration" (Warrior 🔥)**, as a learner following each quest end-to-end. Evidence comes from the sealed execute-mode engine run (`walk-evidence.json`), which sandboxed each quest and ran its safe snippets for real; my value-add is reasoning about the five as one linked journey.
 
-**Headline verdict: ⚠️ warn.** Average score **75.4%** — two strong passes
-(Kubernetes Fundamentals 92, Codex Memory & State 97), two warns (Safe Execution 67,
-Memory Strategies 65) and one **fail** (Dev Environment Integration 56). The two
-bookend quests are genuinely excellent hands-on labs. The problem is concentrated in
-the middle three GH-600 agentic quests (Q6→Q7→Q8), which share three *repeating,
-verified* defects: a `scripts/validate_quest.py` "Quest Validation" command that does
-not exist (fails identically in Q6, Q7 **and** Q8), undefined cross-quest file
-dependencies (`copilot-instructions.md`, `run_agent_task.py`), and hollow/broken
-"do this" artifacts. A maintainer can fix most of the slice by addressing those three
-patterns once, across the chain.
+**Headline verdict: ⚠️ warn.** Average score **75.4%** — two strong passes (Kubernetes Fundamentals 92, Codex Memory & State 97), two warns (Safe Execution 67, Memory Strategies 65) and one **fail** (Dev Environment Integration 56). The two bookend quests are genuinely excellent hands-on labs. The problem is concentrated in the middle three GH-600 agentic quests (Q6→Q7→Q8), which share three *repeating, verified* defects: a `scripts/validate_quest.py` "Quest Validation" command that does not exist (fails identically in Q6, Q7 **and** Q8), undefined cross-quest file dependencies (`copilot-instructions.md`, `run_agent_task.py`), and hollow/broken "do this" artifacts. A maintainer can fix most of the slice by addressing those three patterns once, across the chain.
 
-A second, structural observation: this level's theme is **"Kubernetes Orchestration,"**
-yet **4 of the 5 quests are GH-600 agentic-AI content with no Kubernetes in them.** Only
-`kubernetes-fundamentals` matches the level name.
+A second, structural observation: this level's theme is **"Kubernetes Orchestration,"** yet **4 of the 5 quests are GH-600 agentic-AI content with no Kubernetes in them.** Only `kubernetes-fundamentals` matches the level name.
 
 ## 🗺️ The Journey
 
@@ -53,35 +38,24 @@ Walked in planner order (dependency-sorted):
 
 ## 🔬 Evidence
 
-All outcomes below are from the sealed execute-mode engine run (`walk-evidence.json`);
-`reasoned` marks snippets judged statically (not runnable in the sandbox, e.g. GitHub
-Actions-only YAML). Outputs are quoted trimmed from the evidence.
+All outcomes below are from the sealed execute-mode engine run (`walk-evidence.json`); `reasoned` marks snippets judged statically (not runnable in the sandbox, e.g. GitHub Actions-only YAML). Outputs are quoted trimmed from the evidence.
 
 ### 1 · Codex Ch. III — Memory & State — 97 ✅ (ran 8, 7 passed / 1 failed; 6 reasoned)
 
 - **Lab Step 1–5 (bash)** — all **passed**. The full drift-guard transcript reproduced
-  the quest's "Expected" block *byte-for-byte*: `Snapshot taken.` / `No drift — safe to
-  act.` / `exit=0` / `README.md: FAILED` / `sha256sum: WARNING: 1 computed checksum did
-  NOT match` / `::warning::Context drift detected…` / `exit=78`. Tier-2 plan/act emitted
-  exactly `read`/`edit`/`verify`; Tier-3 JSONL register read back `local-1 → completed`;
-  context-handoff produced `handoff fresh (0s old) — proceeding`.
+the quest's "Expected" block *byte-for-byte*: `Snapshot taken.` / `No drift — safe to act.` / `exit=0` / `README.md: FAILED` / `sha256sum: WARNING: 1 computed checksum did NOT match` / `::warning::Context drift detected…` / `exit=78`. Tier-2 plan/act emitted exactly `read`/`edit`/`verify`; Tier-3 JSONL register read back `local-1 → completed`; context-handoff produced `handoff fresh (0s old) — proceeding`.
 - **Chapter-3 `drift-guard.sh` (WATCH includes `_config.yml`)** — **failed** in a scratch
-  dir (`sha256sum: _config.yml: No such file or directory`, exit 1). This is the *exact*
-  failure the quest flags inline ("EDIT for YOUR repo — a missing file kills snapshot()
-  under set -e"), so it is documented/intentional template behavior, not a defect.
+dir (`sha256sum: _config.yml: No such file or directory`, exit 1). This is the *exact* failure the quest flags inline ("EDIT for YOUR repo — a missing file kills snapshot() under set -e"), so it is documented/intentional template behavior, not a defect.
 - 4 workflow YAML blocks + the context-handoff JSON — **reasoned** (parse-valid;
   Actions-only pieces can't run in-sandbox, but their local analogues matched).
 
 ### 2 · Q6 — Dev Environment Integration — 56 ❌ (ran 4, 2 passed / 2 failed, 2 skipped; 1 reasoned)
 
 - **`AGENTS.md` (Ex 6.1)** and **`devcontainer.json` (Ex 6.2)** — **passed** as written;
-  `npx @devcontainers/cli read-configuration` parsed the devcontainer, and `docker
-  manifest inspect` confirmed both `mcr.microsoft.com/devcontainers/javascript-node:1-18-bullseye`
-  and `ghcr.io/devcontainers/features/github-cli:1` resolve to real registry artifacts.
+`npx @devcontainers/cli read-configuration` parsed the devcontainer, and `docker manifest inspect` confirmed both `mcr.microsoft.com/devcontainers/javascript-node:1-18-bullseye` and `ghcr.io/devcontainers/features/github-cli:1` resolve to real registry artifacts.
 - **`check_agent_env.sh` (Ex 6.3)** — **failed**. Ran cleanly as a script but reported
   `Passed: 7 | Failed: 1`, exit 1, `❌ Environment not ready for agent use.` — because
-  its `check "copilot-instructions.md present" "test -f .github/copilot-instructions.md"`
-  looks for a file **no exercise ever creates**.
+its `check "copilot-instructions.md present" "test -f .github/copilot-instructions.md"` looks for a file **no exercise ever creates**.
 - **Cold-start clone & Quest Validation** — **skipped**: `YOUR_ORG/YOUR_REPO` is a
   placeholder (intentional templating), and `scripts/validate_quest.py` is not present.
 - Caveat surfaced by testing: `jq` / `python json.load` both reject the devcontainer file
@@ -90,15 +64,9 @@ Actions-only YAML). Outputs are quoted trimmed from the evidence.
 ### 3 · Q7 — Safe Execution & Error Handling — 67 ⚠️ (ran 5, 4 passed / 1 failed; 2 reasoned)
 
 - **`agent-with-retries.yml` retry loop** — **passed**. Simulated end-to-end against a
-  mock `run_agent_task.py`: transient error retried with 1s/2s backoff then succeeded on
-  attempt 3 (exit 0); `auth_error` escalated immediately with no retry (exit 1);
-  persistent errors exhausted 3 attempts and emitted `error_code=max_retries_exceeded`.
-  All three documented behaviors verified. YAML passes `yamllint`; the error-report JSON
-  schema is valid.
+mock `run_agent_task.py`: transient error retried with 1s/2s backoff then succeeded on attempt 3 (exit 0); `auth_error` escalated immediately with no retry (exit 1); persistent errors exhausted 3 attempts and emitted `error_code=max_retries_exceeded`. All three documented behaviors verified. YAML passes `yamllint`; the error-report JSON schema is valid.
 - **`test_failure_scenarios.sh` (Ex 7.3)** — recorded **passed** only in the sense that
-  the shell exited 0; the engine flags it as a **hollow stub** — every "scenario" is just
-  an `echo` and a `# Mock a 503 response and verify…` comment; it never invokes the
-  workflow, mocks a response, or asserts anything.
+the shell exited 0; the engine flags it as a **hollow stub** — every "scenario" is just an `echo` and a `# Mock a 503 response and verify…` comment; it never invokes the workflow, mocks a response, or asserts anything.
 - **`python3 scripts/validate_quest.py --quest q7`** — **failed**: `python3: can't open
   file '.../scripts/validate_quest.py': [Errno 2] No such file or directory`.
 
@@ -106,9 +74,7 @@ Actions-only YAML). Outputs are quoted trimmed from the evidence.
 
 - **`mkdir -p docs/agent-memory && touch …` (Ex 8.2)** — **passed**; all three files created.
 - **`agent-with-session-memory.yml` (Ex 8.1)** — **reasoned**, with a *verified* bug:
-  after correctly accounting for YAML block-scalar dedent, the heredoc runs, but because
-  the delimiter is quoted (`<< 'EOF'`), `"started_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"`
-  is **never expanded** — `session.json` literally stores the command string, not a timestamp.
+after correctly accounting for YAML block-scalar dedent, the heredoc runs, but because the delimiter is quoted (`<< 'EOF'`), `"started_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"` is **never expanded** — `session.json` literally stores the command string, not a timestamp.
 - **`python3 scripts/validate_quest.py --quest q8`** — **failed** (same missing script as Q7).
 - 4 markdown/config blocks (`copilot-instructions.md` snippets, learned-patterns example) — skipped (illustrative, not runnable).
 
@@ -117,88 +83,56 @@ Actions-only YAML). Outputs are quoted trimmed from the evidence.
 - **`kind create cluster --name citadel` → `kubectl cluster-info` / `get nodes`** —
   **passed**; node `Ready` after ~30s.
 - **`hello-pod.yaml` apply / describe / logs / exec**, imperative `kubectl run
-  hello --image=nginx:1.27`, namespace workflow (`create namespace dojo` → apply → set
-  context) — all **passed**.
+hello --image=nginx:1.27`, namespace workflow (`create namespace dojo` → apply → set context) — all **passed**.
 - **Self-healing demo** — **passed**: after `kubectl delete pod hello-pod`, the bare Pod
   did **not** return, confirming the quest's central claim.
 - **Advanced Challenge** — **passed**: `image: nginx:does-not-exist` reproduced
-  `ErrImagePull` → `ImagePullBackOff`, diagnosed via the Events pipeline, fixed to
-  `nginx:1.27`, re-applied → `Running`.
+`ErrImagePull` → `ImagePullBackOff`, diagnosed via the Events pipeline, fixed to `nginx:1.27`, re-applied → `Running`.
 - macOS `brew` / Windows `winget` install blocks — **skipped** (OS-gated on a Linux sandbox).
 
 ## 🐞 Issues Found
 
-Concrete, evidence-backed problems. Severity per the rubric's learner-impact lens.
-Verified = a command actually ran in the sandbox; reasoned = judged from reading the
-sources + evidence across the chain.
+Concrete, evidence-backed problems. Severity per the rubric's learner-impact lens. Verified = a command actually ran in the sandbox; reasoned = judged from reading the sources + evidence across the chain.
 
 - **HIGH · Q6 · Chapter 4 / `check_agent_env.sh` · verified** — Script always reports
   failure (`Passed: 7 | Failed: 1`, exit 1) because it checks for
-  `.github/copilot-instructions.md`, which **no exercise in the quest ever creates**. A
-  learner who follows the quest exactly can never get a green environment check, gutting
-  the whole validation chapter. *Fix:* add an exercise that creates
-  `.github/copilot-instructions.md` (with sample content), or remove that check.
+`.github/copilot-instructions.md`, which **no exercise in the quest ever creates**. A learner who follows the quest exactly can never get a green environment check, gutting the whole validation chapter. *Fix:* add an exercise that creates `.github/copilot-instructions.md` (with sample content), or remove that check.
 - **HIGH · Q7 · Quest Validation · verified** — `python3 scripts/validate_quest.py
-  --quest q7` fails with `No such file or directory`. *Fix:* ship the script, or replace
-  with a runnable check (e.g. `actionlint .github/workflows/agent-with-retries.yml`), or
-  clearly label the block as illustrative expected-output.
+--quest q7` fails with `No such file or directory`. *Fix:* ship the script, or replace with a runnable check (e.g. `actionlint .github/workflows/agent-with-retries.yml`), or clearly label the block as illustrative expected-output.
 - **HIGH · Q7 · Chapter 4 / Exercise 7.3 · verified** — `test_failure_scenarios.sh` is an
-  echo-only stub; it fulfils the "Test failure recovery" objective on paper but tests
-  nothing. *Fix:* replace with a real script that mocks each failure mode and asserts the
-  retry-count / escalation output (the engine's sandbox did exactly this with a stub
-  `run_agent_task.py`).
+echo-only stub; it fulfils the "Test failure recovery" objective on paper but tests nothing. *Fix:* replace with a real script that mocks each failure mode and asserts the retry-count / escalation output (the engine's sandbox did exactly this with a stub `run_agent_task.py`).
 - **HIGH · Q8 · Chapter 3 / `session.json` `started_at` · verified** — `$(date …)` inside
-  the quoted `<< 'EOF'` heredoc never expands; the timestamp field is stored as the
-  literal command string. *Fix:* unquote the delimiter for expanded fields, or compute
-  `NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)` on a separate `run` line and interpolate `$NOW`.
+the quoted `<< 'EOF'` heredoc never expands; the timestamp field is stored as the literal command string. *Fix:* unquote the delimiter for expanded fields, or compute `NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)` on a separate `run` line and interpolate `$NOW`.
 - **HIGH · Q8 · Quest Validation · verified** — same missing `scripts/validate_quest.py`
   as Q7 (`No such file or directory`). *Fix:* provide the script or mark the block illustrative.
 - **MEDIUM · Q7 · Chapter 2 workflow dependency · reasoned** — the workflow calls
-  `python3 work/gh-600/scripts/run_agent_task.py`, never defined in this quest and not
-  produced by Q6 (which only creates `check_agent_env.sh`). Prerequisites don't call it
-  out, so the workflow is unrunnable from the chain alone. *Fix:* state where it comes
-  from, or include a minimal stub.
+`python3 work/gh-600/scripts/run_agent_task.py`, never defined in this quest and not produced by Q6 (which only creates `check_agent_env.sh`). Prerequisites don't call it out, so the workflow is unrunnable from the chain alone. *Fix:* state where it comes from, or include a minimal stub.
 - **MEDIUM · Q6 · Chapter 5 / cold-start · verified+reasoned** — `AGENTS.md` calls
-  `GITHUB_TOKEN` a "fine-grained PAT" but the example uses `ghp_yourToken` (classic-PAT
-  prefix; fine-grained is `github_pat_…`). Placeholder token also makes the check appear
-  runnable when it isn't. *Fix:* reconcile the prefix and note the token must be real.
+`GITHUB_TOKEN` a "fine-grained PAT" but the example uses `ghp_yourToken` (classic-PAT prefix; fine-grained is `github_pat_…`). Placeholder token also makes the check appear runnable when it isn't. *Fix:* reconcile the prefix and note the token must be real.
 - **MEDIUM · Q8 · Chapter 2 objective · reasoned** — "Implement ephemeral memory" is only
-  prose about `copilot-instructions.md`; no concrete exercise/artifact, unlike the other
-  two tiers. *Fix:* add a short worked example.
+prose about `copilot-instructions.md`; no concrete exercise/artifact, unlike the other two tiers. *Fix:* add a short worked example.
 - **MEDIUM · Kubernetes Fundamentals · Chapter 2 · reasoned** — the object-model YAML is
-  never explicitly named; the filename `hello-pod.yaml` is only inferable from the later
-  `kubectl apply -f hello-pod.yaml`. *Fix:* tell the learner to save it as `hello-pod.yaml`.
+never explicitly named; the filename `hello-pod.yaml` is only inferable from the later `kubectl apply -f hello-pod.yaml`. *Fix:* tell the learner to save it as `hello-pod.yaml`.
 - **MEDIUM · Kubernetes Fundamentals · Windows path · reasoned** — `winget install -e
-  --id Kubernetes.kind` uses a package id the engine could not verify as real (kind's
-  docs recommend Chocolatey / `go install` / binary download on Windows). *Fix:* verify
-  or replace to avoid dead-ending Windows learners.
+--id Kubernetes.kind` uses a package id the engine could not verify as real (kind's docs recommend Chocolatey / `go install` / binary download on Windows). *Fix:* verify or replace to avoid dead-ending Windows learners.
 - **LOW · Q6 · devcontainer.json JSONC · verified** — leading `//` comment makes `jq`/
-  strict JSON linters reject the file even though `@devcontainers/cli` accepts it. *Fix:*
-  drop the comment or add a one-line JSONC note.
+strict JSON linters reject the file even though `@devcontainers/cli` accepts it. *Fix:* drop the comment or add a one-line JSONC note.
 - **LOW · Codex Ch. III · Prerequisites vs Lab · verified** — Prerequisites promise "you
-  will run real workflows that upload artifacts and commit files," but the lab is entirely
-  local git/jq/sha256sum; real Actions is never exercised. *Fix:* add a minimal
-  `workflow_dispatch` exercise or soften the prerequisite wording.
+will run real workflows that upload artifacts and commit files," but the lab is entirely local git/jq/sha256sum; real Actions is never exercised. *Fix:* add a minimal `workflow_dispatch` exercise or soften the prerequisite wording.
 - **LOW · Q7 · jq fallback · verified** — `jq -r '.error_code // "unknown"'` yields an
   empty string (not `"unknown"`) when `agent-result.json` is absent entirely. *Fix:*
   guard with `[ -f agent-result.json ]` or `|| echo unknown`.
 - **LOW · Q6/Q7/Q8 · Level metadata · reasoned** — filed under "Kubernetes Orchestration"
-  but contain zero Kubernetes; they are GH-600 / GitHub Actions content. *Fix:* reclassify
-  under the GH-600 / agentic-CI track (see Chain Continuity).
+but contain zero Kubernetes; they are GH-600 / GitHub Actions content. *Fix:* reclassify under the GH-600 / agentic-CI track (see Chain Continuity).
 
-No fabricated results: every "passed/failed" above is an engine-run command; everything
-labeled `reasoned` was judged from the source + evidence, not executed.
+No fabricated results: every "passed/failed" above is an engine-run command; everything labeled `reasoned` was judged from the source + evidence, not executed.
 
 ## 🔗 Chain Continuity
 
-Reading the five in order as one learner, the slice is really **three overlapping
-tracks**, not one path — and the cross-quest seams are where the real problems live:
+Reading the five in order as one learner, the slice is really **three overlapping tracks**, not one path — and the cross-quest seams are where the real problems live:
 
 1. **The clean linear chain Q6 → Q7 → Q8** (dev-env → safe-execution → memory-strategies)
-   is well-wired by frontmatter (`required_quests`/`unlocks_quests`) and by `sub_title`
-   ("Quest 1/3, 2/3, 3/3"). Ordering is correct and each quest's mermaid "Quest Network
-   Position" agrees with its neighbors (Q5→Q6→Q7→Q8→Q9). **But three prerequisite/handoff
-   gaps break the journey:**
+is well-wired by frontmatter (`required_quests`/`unlocks_quests`) and by `sub_title` ("Quest 1/3, 2/3, 3/3"). Ordering is correct and each quest's mermaid "Quest Network Position" agrees with its neighbors (Q5→Q6→Q7→Q8→Q9). **But three prerequisite/handoff gaps break the journey:**
    - **`copilot-instructions.md` is orphaned across the chain.** Q6's parity check
      *requires* `.github/copilot-instructions.md` (verified failure), and Q8 twice tells
      the learner to "update in `copilot-instructions.md`" — yet **no quest in the slice
@@ -215,54 +149,22 @@ tracks**, not one path — and the cross-quest seams are where the real problems
      that a learner hits at the finish line of each.
 
 2. **Codex Ch. III (quest 1) is a parallel "campaign" map**, not a step in the Q6→Q7→Q8
-   line. Its own network diagram is Codex Ch. II → III → IV (levels 1000→1001→1010), and it
-   explicitly points at `agentic-memory-strategies` (Q8) as one of "the chambers" of
-   Domain 3. So it *does* connect to Q8 — but it also **overlaps** it: both teach the
-   three-tier memory model, and they disagree in a way a learner would notice.
-   Codex Ch. III defines **Tier 2 / session = "one run, across jobs," artifacts**; Q8's
-   table defines **Session = "Hours to days," artifacts + issue comments, persist across
-   runs.** A learner reading both gets two different lifespans for "session memory." Worth
-   reconciling so the map and the chamber agree. (Notably, Codex Ch. III is the far
-   stronger, fully-runnable treatment; Q8 is the weaker duplicate.)
+line. Its own network diagram is Codex Ch. II → III → IV (levels 1000→1001→1010), and it explicitly points at `agentic-memory-strategies` (Q8) as one of "the chambers" of Domain 3. So it *does* connect to Q8 — but it also **overlaps** it: both teach the three-tier memory model, and they disagree in a way a learner would notice. Codex Ch. III defines **Tier 2 / session = "one run, across jobs," artifacts**; Q8's table defines **Session = "Hours to days," artifacts + issue comments, persist across runs.** A learner reading both gets two different lifespans for "session memory." Worth reconciling so the map and the chamber agree. (Notably, Codex Ch. III is the far stronger, fully-runnable treatment; Q8 is the weaker duplicate.)
 
 3. **Kubernetes Fundamentals (quest 5) is disconnected from the other four** — it is the
-   only quest that matches the level's "Kubernetes Orchestration" theme, and it stands
-   alone as an excellent self-contained lab. The mismatch cuts both ways: the four agentic
-   quests are mis-themed as Kubernetes, and the one true Kubernetes quest shares no chain
-   with them. For a System Engineer learner arriving at "Level 1001 — Kubernetes," landing
-   on four GitHub-Actions/agentic quests first would be disorienting.
+only quest that matches the level's "Kubernetes Orchestration" theme, and it stands alone as an excellent self-contained lab. The mismatch cuts both ways: the four agentic quests are mis-themed as Kubernetes, and the one true Kubernetes quest shares no chain with them. For a System Engineer learner arriving at "Level 1001 — Kubernetes," landing on four GitHub-Actions/agentic quests first would be disorienting.
 
-**Net:** the slice does *not* yet hold together as one Kubernetes learning path. The
-Q6→Q7→Q8 sub-chain is close but blocked by the three shared gaps above; Codex Ch. III is
-a strong standalone that lightly conflicts with Q8; Kubernetes Fundamentals is a strong
-standalone under the wrong roommates.
+**Net:** the slice does *not* yet hold together as one Kubernetes learning path. The Q6→Q7→Q8 sub-chain is close but blocked by the three shared gaps above; Codex Ch. III is a strong standalone that lightly conflicts with Q8; Kubernetes Fundamentals is a strong standalone under the wrong roommates.
 
 ## 🧠 Reasoning & Method
 
 - **Mode: execute (sealed).** I did **not** run the engine — the workflow pre-computed and
-  sealed `walk-evidence.json` / `walk-evidence.md` (execute mode, real commands in a
-  disposable sandbox: a live `kind` cluster, `docker manifest inspect`, `jq`/`sha256sum`,
-  bash simulation of the retry loops and heredocs). I consumed that evidence as-is and
-  never edited or regenerated it.
+sealed `walk-evidence.json` / `walk-evidence.md` (execute mode, real commands in a disposable sandbox: a live `kind` cluster, `docker manifest inspect`, `jq`/`sha256sum`, bash simulation of the retry loops and heredocs). I consumed that evidence as-is and never edited or regenerated it.
 - **What is tested vs. reasoned.** Every `passed`/`failed` in §Evidence and the "verified"
-  issues came from a command the engine actually ran. GitHub-Actions-only YAML, cross-quest
-  dependency gaps, the metadata/theme mismatch, and the Codex↔Q8 conceptual conflict are
-  **reasoned** — inferred from reading all five sources in plan order plus the sealed
-  evidence. They are labeled as such and not reported as executed results.
+issues came from a command the engine actually ran. GitHub-Actions-only YAML, cross-quest dependency gaps, the metadata/theme mismatch, and the Codex↔Q8 conceptual conflict are **reasoned** — inferred from reading all five sources in plan order plus the sealed evidence. They are labeled as such and not reported as executed results.
 - **My contribution** is §Chain Continuity: the engine scores each quest in isolation, so
-  the orphaned `copilot-instructions.md`, the undelivered `run_agent_task.py`, the
-  thrice-broken validation gate, and the two-tracks-under-one-theme structure are only
-  visible when the five are read as one journey.
+the orphaned `copilot-instructions.md`, the undelivered `run_agent_task.py`, the thrice-broken validation gate, and the two-tracks-under-one-theme structure are only visible when the five are read as one journey.
 - **Coverage limits (honest):** (a) This is **window 1 of 2** — quests 6–9 of Level 1001
-  were **not** walked this run; the ledger accumulates them separately. (b) OS-gated
-  install blocks (macOS `brew`, Windows `winget`) and real GitHub-Actions execution
-  (artifact upload/download, live workflow triggers, real `git push`) could not run in the
-  Linux sandbox and were reasoned/skipped, not executed. (c) The `winget Kubernetes.kind`
-  package id and the GH-600 "19% of the exam" citation are external facts the sandbox
-  could not verify. (d) I made **zero** content edits — fixable bugs live only in
-  §Issues Found for a later content pass.
+were **not** walked this run; the ledger accumulates them separately. (b) OS-gated install blocks (macOS `brew`, Windows `winget`) and real GitHub-Actions execution (artifact upload/download, live workflow triggers, real `git push`) could not run in the Linux sandbox and were reasoned/skipped, not executed. (c) The `winget Kubernetes.kind` package id and the GH-600 "19% of the exam" citation are external facts the sandbox could not verify. (d) I made **zero** content edits — fixable bugs live only in §Issues Found for a later content pass.
 - **Confidence:** High on the per-quest verdicts (grounded in reproduced command output,
-  e.g. the byte-for-byte drift-guard transcript and the live `ImagePullBackOff` fix).
-  High on the chain-continuity findings, which are directly traceable to quoted lines in
-  the sources (`test -f .github/copilot-instructions.md`, `run_agent_task.py`,
-  `scripts/validate_quest.py`, the two divergent session-memory tables).
+e.g. the byte-for-byte drift-guard transcript and the live `ImagePullBackOff` fix). High on the chain-continuity findings, which are directly traceable to quoted lines in the sources (`test -f .github/copilot-instructions.md`, `run_agent_task.py`, `scripts/validate_quest.py`, the two divergent session-memory tables).


### PR DESCRIPTION
## Summary

Reviews, verifies, and tests the PostHog wizard's integration, then makes it merge-ready. Four Ruby SEO/content scripts now optionally capture structured PostHog events so script activity and content health can be tracked over time.

**Opt-in by design:** every script reads `POSTHOG_PROJECT_TOKEN` / `POSTHOG_HOST` at runtime (no hardcoded tokens). When the token is **unset**, the scripts skip analytics entirely — no client, no network call, identical behavior and exit codes — so CI without the secret is unaffected.

| Event | Fires when | Script |
|-------|-----------|--------|
| `content_scan_completed` | Content freshness scan finishes | `content-freshness-check.rb` |
| `ctr_report_generated` | CTR/SEO report generated | `ctr-report-generator.rb` |
| `gsc_csv_parsed` | GSC CSV export parsed | `ctr-report-generator.rb` |
| `frontmatter_validation_completed` | Frontmatter validation finishes | `frontmatter-validator.rb` |
| `statistics_generated` | Content statistics generation completes | `generate_statistics.rb` |

Each uses the instance-based `PostHog::Client`, captures **before** any `exit()`, and calls `shutdown` in an `ensure` block so buffered events flush.

## Changes beyond the wizard output

- **Reverted an unintended bundler bump.** The wizard's `bundle add` (run under host Ruby 4.0) rewrote `Gemfile.lock`'s `BUNDLED WITH` from `2.3.25` → `4.0.11`. CI's `ruby/setup-ruby` installs the exact `BUNDLED WITH` version, so a major 4.x bump risked breaking CI. Restored to `2.3.25` — the lockfile diff is now just the `posthog-ruby` addition.
- **`.env.example`** — documented `POSTHOG_PROJECT_TOKEN` and `POSTHOG_HOST`.
- **`docs/setup/POSTHOG_ANALYTICS.md`** — relocated the wizard's root `posthog-setup-report.md` into a proper, durable setup doc (event catalog, opt-in behavior, dashboards, verification notes).
- **`.claude/skills/integration-ruby/`** — kept the PostHog Ruby agent skill (no secrets; matches the repo's tracked-skills convention).

## Verification

- ✅ **All 5 events fire** with correct, well-typed properties — verified end-to-end by pointing `POSTHOG_HOST` at a local mock ingestion server and running each script (the mock had to gunzip the body, confirming posthog-ruby v3's gzipped batch transport reaches the endpoint).
- ✅ **No-token path is graceful** — with `POSTHOG_PROJECT_TOKEN` unset, scripts run unchanged, send nothing, and make **no** network call even when `POSTHOG_HOST` points at a dead port (token-gated before client creation).
- ✅ **Event survives non-zero exit** — capture is placed before `exit`, so e.g. `content-freshness-check` exiting `1` on critical content still emits its event.
- ✅ **`make docker-build-ci` passes** (ruby:3.2.3 + github-pages): `posthog-ruby 3.19.0` installs cleanly (`Bundle complete! 99 gems`), image uses `bundler 2.3.25`, full Jekyll build `done in 266s`, no errors.
- ✅ All 4 scripts pass `ruby -c`.

## Notes

- `statistics_generated` currently reports zeros because `pages/_posts` was removed in the quests-only overhaul; the instrumentation is correct — the script just reads a directory that no longer exists. Left as-is (pre-existing, out of scope).
- The real `.env` (with the project token) stays gitignored and is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
