### PR TITLE
feat(analytics): enable client-side PostHog on it-journey.dev

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -111,6 +111,33 @@ author:
 
 google_analytics         : 'G-ZBDKNMC168'
 
+# PostHog product analytics (client-side). Rendered by the theme's
+# _includes/analytics/posthog.html, which loads ONLY in production
+# (jekyll.environment == "production") and respects Do Not Track.
+# api_key is a public project key (phc_…), safe to commit — like google_analytics above.
+posthog:
+  enabled                : true
+  api_key                : 'phc_m67mGNKMoTphbLFXDN3Kxrv6RZaCQz2wiFwZ9CGeLVg7'
+  api_host               : 'https://us.i.posthog.com'
+  person_profiles        : 'identified_only'  # 'always' | 'identified_only' | 'never'
+  autocapture            : true
+  capture_pageview       : true
+  capture_pageleave      : true
+  session_recording      : false   # keep off unless we intend to record sessions
+  disable_cookie         : false
+  respect_dnt            : true     # honor the visitor's Do Not Track setting
+  secure_cookie          : true
+  persistence            : 'localStorage+cookie'
+  custom_events:
+    track_downloads      : true
+    track_external_links : true
+    track_search         : true
+    track_scroll_depth   : true
+  privacy:
+    mask_all_text        : false
+    mask_all_inputs      : true
+    ip_anonymization     : false
+
 ## Site verification #############################################################
 
 google_site_verification : null


### PR DESCRIPTION
## Summary

Enables client-side PostHog product analytics on it-journey.dev by adding a `posthog:` block to `_config.yml`. The zer0-mistakes theme renders `_includes/analytics/posthog.html` from `site.posthog.*` — Jekyll does not read a remote theme's own `_config.yml`, so the config must live here (exactly like `google_analytics` above it).

Pairs with the theme PR that wires `posthog.html` into `head.html` (bamr87/zer0-mistakes). Both are required for events to fire; the theme change reaches it-journey.dev automatically via the unpinned `remote_theme`.

## Config

- `enabled: true`, `api_key: phc_m67mGN…` (public project key for PostHog project 517639 — safe to commit, same class as the committed GA ID), `api_host: https://us.i.posthog.com`.
- Privacy-forward defaults: production-only (enforced by the theme include), **respects Do Not Track**, session recording **off**, form inputs masked.

## Behavior

- **Production only** — the theme gates the include on `jekyll.environment == "production"`, so local/dev builds send nothing.
- Complements the server-side Ruby-script instrumentation (PR #517) with real visitor analytics on the site frontend.

## Verification

Production Docker build (`JEKYLL_ENV=production`) with the theme's updated `head.html`/`posthog.html`: the generated `_site` HTML contains the PostHog init snippet with this key and host. A development build emits nothing (correctly gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
