### PR TITLE
ci(markdown-oneline): exclude machine-generated quest reports

### DIFF
--- a/.github/workflows/markdown-oneline.yml
+++ b/.github/workflows/markdown-oneline.yml
@@ -31,6 +31,14 @@ jobs:
           python-version: "3.x"
       - name: Check one paragraph per line
         run: |
+          # Excludes: SCHEMA.md / CHANGELOG.md are generated; pages/_quest-reports/
+          # and test/quest-validator/walkthroughs/ are machine-authored session
+          # reports emitted by the quest-perfection loop (author "Quest Perfection
+          # Loop") — they regularly carry soft-wrapped prose and are not
+          # hand-authored, so the one-paragraph-per-line rule does not apply. See
+          # .github/workflows/quest-perfection.yml + scripts/quest/build_reports_site.py.
           python3 tools/unwrap-prose.py --check \
             --exclude '(^|/)SCHEMA\.md$' --exclude '(^|/)CHANGELOG\.md$' \
+            --exclude '(^|/)pages/_quest-reports/' \
+            --exclude '(^|/)test/quest-validator/walkthroughs/' \
           || { echo "::error::Wrapped markdown prose found. Run: python3 tools/unwrap-prose.py --write"; exit 1; }


### PR DESCRIPTION
## Problem

`markdown-oneline` (`tools/unwrap-prose.py --check`) scans the **whole repo** and fails on any wrapped prose. The quest-perfection loop writes soft-wrapped prose into `pages/_quest-reports/` and `test/quest-validator/walkthroughs/` (author `Quest Perfection Loop`), so:

- **main is red** — the #513 enforcement commit's own push run failed on these files.
- **every markdown PR is blocked**, since the check is repo-wide (this is what #517 had to work around by hand-unwrapping 12 generated files).
- hand-unwrapping is **temporary** — the next loop run regenerates them wrapped and main breaks again.

## Fix

Exclude the two machine-generated directories from the check, exactly like the existing `SCHEMA.md` / `CHANGELOG.md` exclusions:

```
--exclude '(^|/)pages/_quest-reports/'
--exclude '(^|/)test/quest-validator/walkthroughs/'
```

The one-paragraph-per-line rule targets **hand-authored** prose; machine-authored session reports are out of scope (same rationale as the existing exclusions).

## Verified

- With the new excludes, the check **passes on main's tree** (where all 12 generated files are still wrapped) — exit 0.
- A wrapped file **outside** the excluded dirs **still fails** (exit 1) — enforcement for hand-authored prose is intact.
- Every wrapped file currently on main is inside these two dirs (nothing else is affected).
- Workflow YAML validates.

## Note

The check workflow is hub-seeded (`tools/fanout.sh --kit prose`). If you re-fanout the prose kit from the hub, mirror these two it-journey-specific excludes in the hub template (or have fanout preserve repo-local excludes) so they aren't overwritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
