### PR TITLE
🔧 Quest fix: developer/0001

### DIFF
--- a/pages/_quests/0001/barodybroject-stack-analysis.md
+++ b/pages/_quests/0001/barodybroject-stack-analysis.md
@@ -71,17 +71,23 @@ mermaid: true
 
 By the end of this quest, you will be able to:
 
-- [ ] Understand the core concepts introduced in this quest
-- [ ] Complete the hands-on exercises and verify the results
-- [ ] Apply what you learned to a follow-up scenario of your own design
-
-> *Note: objectives auto-seeded during framework alignment — authors should refine these to reflect this quest's specific skills.*
+- [ ] Identify each layer of a Django + Azure stack (frontend, backend, data, infrastructure)
+- [ ] Evaluate dependency risk for a Python project using `pip-audit`
+- [ ] Assess whether a claimed stack analysis still matches the live repository
+- [ ] Read a technology stack table and map each entry to its configuration location
 
 > **Repository**: [https://github.com/bamr87/barodybroject](https://github.com/bamr87/barodybroject)  
 > **Analysis Date**: November 2, 2025  
 > **Primary Language**: Python  
 > **Project Type**: Web Application - AI-Powered Parody News Generator  
 > **Analyzed By**: Stack Attack Protocol v1.0
+
+> ⚠️ **Point-in-time snapshot.** This analysis reflects the repository as of the
+> Analysis Date above and *will drift* as the project evolves. Version numbers
+> (e.g. the Django version), file layout, and dependency claims below may no
+> longer match `main` — the live repo has since moved to a newer Django release
+> and split `settings.py`/`views.py` into packages. Always re-verify against the
+> current repository before relying on any specific figure here.
 
 ## 📊 Executive Summary
 
@@ -214,7 +220,7 @@ src/parodynews/templates/
 - **AWS Secrets Manager**: Production secret management with boto3
 
 **Backend Structure**:
-```python
+```text
 src/barodybroject/
 ├── settings.py           # 1,101 lines of enterprise-grade configuration
 ├── urls.py              # URL routing with namespace support
@@ -285,6 +291,7 @@ else:
     # Development: PostgreSQL (Docker) or SQLite fallback
     if DB_CHOICE == "postgres":
         # Docker PostgreSQL configuration
+        ...
     else:
         # SQLite fallback for simple development
         DATABASES = {
@@ -437,7 +444,7 @@ src/pages/
 ### Python Dependencies
 
 **Core Framework** (requirements.txt):
-```python
+```text
 # Web Framework
 Django==4.2.20                      # Mature, stable LTS version
 djangorestframework                 # REST API toolkit
@@ -478,7 +485,7 @@ dkimpy                              # DKIM signing
 ```
 
 **Development Dependencies** (pyproject.toml):
-```python
+```toml
 [project.optional-dependencies]
 dev = [
     # Testing
@@ -661,6 +668,9 @@ python3 -m venv .venv
 source .venv/bin/activate
 pip install -r src/requirements.txt
 cd src
+# The project defaults to PostgreSQL (DB_CHOICE=postgres). For a quick local run
+# with no database server, use SQLite instead so `migrate` works out of the box:
+export DB_CHOICE=sqlite
 python manage.py migrate
 python manage.py runserver
 
@@ -726,7 +736,7 @@ python manage.py createsuperuser
 
 **Code Quality**:
 1. 🔄 **Split Large Views**: Break views.py (2,400+ lines) into smaller modules
-   ```python
+   ```text
    src/parodynews/
    ├── views/
    │   ├── __init__.py

--- a/pages/_quests/0001/building-testing-git-init-script.md
+++ b/pages/_quests/0001/building-testing-git-init-script.md
@@ -63,12 +63,14 @@ Why this matters:
 - Headless behavior must be non-destructive and reliable; interactive commands can't be used in CI loops.
 - Creating files via programmatic scaffolding must be done with a clear contract and test coverage.
 
-## Objectives
+## 🎯 Quest Objectives
 
-- Verify script syntax with `bash -n` and lint with `shellcheck`.
-- Add Bats tests to confirm `--headless` operations do not push.
-- Ensure easy to run `--no-push` for local tests.
-- Add CI step instructions for running tests.
+By the end of this quest, you will be able to:
+
+- [ ] Verify script syntax with `bash -n` and lint with `shellcheck`.
+- [ ] Add Bats tests to confirm `--headless` operations do not push.
+- [ ] Ensure it is easy to run `--no-push` for local tests.
+- [ ] Add CI step instructions for running tests.
 
 ## Tests and Tools
 
@@ -92,7 +94,7 @@ teardown() {
 }
 
 @test "headless mode creates a repo and does not push" {
-  run bash /path/to/scripts/git_init.sh --headless -n sample-test --no-push
+  run bash "$BATS_TEST_DIRNAME/../../scripts/git_init.sh" --headless -n sample-test --no-push
   [ "$status" -eq 0 ]
   [ -d "$HOME/github/sample-test/.git" ]
 }
@@ -100,13 +102,24 @@ teardown() {
 
 ### ShellCheck linting
 
-Install with `brew install shellcheck` on macOS and run `shellcheck scripts/git_init.sh`.
+Install with `brew install shellcheck` on macOS, or `sudo apt-get install -y shellcheck` on Linux (Ubuntu / GitHub Actions runners), then run `shellcheck scripts/git_init.sh`.
 
 ### Syntax check
 
 Use `bash -n scripts/git_init.sh` to detect syntax issues early.
 
 ## Try it locally
+
+> **Get the script first.** Every command below expects `scripts/git_init.sh` to
+> exist in your working directory. It ships in the IT-Journey repository — clone it
+> (or download the single file) before running anything else:
+>
+> ```bash
+> git clone https://github.com/bamr87/it-journey.git
+> cd it-journey
+> # the initializer lives at scripts/git_init.sh
+> chmod +x scripts/git_init.sh
+> ```
 
 1. Syntax check
 
@@ -123,25 +136,22 @@ bash scripts/git_init.sh --headless -n test-quest-sample --no-push --gitignore p
 3. Run Bats tests
 
 ```bash
-# install bats-core
-
-## 🎯 Quest Objectives
-
-By the end of this quest, you will be able to:
-
-- [ ] Understand the core concepts introduced in this quest
-- [ ] Complete the hands-on exercises and verify the results
-- [ ] Apply what you learned to a follow-up scenario of your own design
-
-> *Note: objectives auto-seeded during framework alignment — authors should refine these to reflect this quest's specific skills.*
+# install bats-core (macOS)
 brew install bats-core
+# install bats-core (Linux / Ubuntu, e.g. GitHub Actions runners)
+sudo apt-get update && sudo apt-get install -y bats
+
 bats tests/bats
 ```
 
 4. Run ShellCheck
 
 ```bash
+# macOS
 brew install shellcheck
+# Linux / Ubuntu (e.g. GitHub Actions runners)
+sudo apt-get install -y shellcheck
+
 shellcheck scripts/git_init.sh
 ```
 


### PR DESCRIPTION
## 🔧 Quest fix — `developer/0001`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: developer/0001

Evidence honest & verified (M7): `mode==execute`, not truncated, 0 errored, all
results `executed==true`. Acted on the 2 non-pass quests (`fail`); the 3 `pass`
quests had no in-scope issues. Neither edited quest is vendored (no
`source_repo:`/`source_url:`). Every before→after below is read straight from
`quest_validator.py`; each edit kept only because tier-1 held-or-rose **and**
brand_lint stayed clean (never the agentic `overall`).

#### `pages/_quests/0001/building-testing-git-init-script.md` — tier-1 **58/74 (78.4%) → 58/74 (78.4%)** held, brand ✔

- **Fixed corrupted bash fence** (verified: `commands[].status=failed` on the "Run
  Bats tests" block — unmatched apostrophe → `unexpected EOF`; high rec "Corrupted
  code block"). Removed the auto-seeded `## 🎯 Quest Objectives` stub pasted inside
  the fence; the block is now just the install + `bats tests/bats` commands. ✅ kept.
- **Restored a real `## 🎯 Quest Objectives` section** by converting the plain
  `## Objectives` heading into quest-specific checkboxes (low rec "duplicate
  objectives"). *Note:* the validator counts this as a **required section** — simply
  deleting the stub, as the raw rec suggested, dropped tier-1 78.4%→67.6% (PASS→FAIL);
  relocating it out of the fence instead fixes the corruption **and** holds structure. ✅ kept.
- **Added a "Get the script first" clone step** (verified: `bash -n scripts/git_init.sh`
  and the headless-run command both `status=failed`, exit 127 "No such file"; high rec
  "Missing core asset"). ✅ kept.
- **Fixed Bats example path** `/path/to/scripts/git_init.sh` →
  `"$BATS_TEST_DIRNAME/../../scripts/git_init.sh"` (medium rec). ✅ kept.
- **Added Linux `apt-get` install** for `bats` and `shellcheck` alongside `brew`
  (medium rec "Install instructions / OS mismatch" — CI runs on Ubuntu). ✅ kept.

#### `pages/_quests/0001/barodybroject-stack-analysis.md` — tier-1 **53/74 (71.6%) → 53/74 (71.6%)** held, brand ✔

- **Relabeled mislabeled `python` fences** → `text`/`toml` at the Backend-Structure
  tree, the `requirements.txt` excerpt (`Django==4.2.20`), the `pyproject.toml`
  `[project.optional-dependencies]` excerpt, and the `views/` split tree (verified:
  four `commands[].status=failed` with SyntaxError/NameError; high rec "Mislabeled
  code fences"). ✅ kept.
- **Fixed the IndentationError** in the Database Configuration Strategy snippet: added
  a `...` body to the empty `if DB_CHOICE == "postgres":` branch (verified: failed
  command IndentationError; medium rec). ✅ kept.
- **Added `export DB_CHOICE=sqlite` guidance** to the Quick Setup block so
  `manage.py migrate` works out of the box instead of failing on a missing Postgres
  (verified: Quick Setup command `status=failed`, connection refused; high rec). ✅ kept.
- **Added a point-in-time drift disclaimer** near the analysis metadata (high rec
  "Core stack facts stale" — Django version + settings/views package split). ✅ kept.
- **Replaced auto-seeded placeholder objectives** with stack-analysis-specific
  checkboxes, keeping the required `## 🎯 Quest Objectives` heading (medium rec). ✅ kept.

_Left (not fixed):_
- **barodybroject, low rec — Security "None identified" vs 34 CVEs:** needs a fresh
  `pip-audit`-grounded security re-verification; deferred to human authoring rather
  than asserting new numbers I can't verify from this evidence.
- **barodybroject, high rec — full re-analysis of every stale version/table figure:**
  addressed conservatively with the drift disclaimer; a complete data re-run of the
  stack tables is substantive authoring left for a human.
- **git-init, low rec — sample GitHub Actions YAML for the CI objective:** left to keep
  this PR small/reviewable under the per-slice cap; can be added next pass.
- No edit was reverted by the M1 gate except the initial stub-deletion approach noted
  above, which was replaced (not kept) by the relocate-and-preserve fix.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/29826801543)._
