### PR TITLE
🔧 Quest fix: system-engineer/0101

### DIFF
--- a/pages/_quests/0101/docker-mastery-example.md
+++ b/pages/_quests/0101/docker-mastery-example.md
@@ -140,8 +140,7 @@ docker run --rm hello-world
 
 ### 🐧 Linux Territory Path
 
-Use Docker's official convenience script, then add your user to the `docker` group so you
-can run the CLI without `sudo`:
+Use Docker's official convenience script, then add your user to the `docker` group so you can run the CLI without `sudo`:
 
 ```bash
 # Install Docker Engine (works on most distributions)
@@ -167,8 +166,7 @@ docker run --rm hello-world
 
 ### 📱 Universal Web Path
 
-Prefer a browser? Use [Play with Docker](https://labs.play-with-docker.com/) — a free,
-throwaway Docker playground that runs entirely in your browser:
+Prefer a browser? Use [Play with Docker](https://labs.play-with-docker.com/) — a free, throwaway Docker playground that runs entirely in your browser:
 
 ```text
 1. Open https://labs.play-with-docker.com/ and sign in with a Docker Hub account.
@@ -234,14 +232,11 @@ Hello from your first Docker container!
 
 ## 🧙‍♂️ Chapter 2: Compose, Secure, and Ship Your Containers
 
-*Chapter 1 built a single image. Real devops work runs several services together, hardens
-them, and ships them to a registry. This chapter delivers the Docker Compose, security, and
-deployment skills promised in the Quest Objectives.*
+*Chapter 1 built a single image. Real devops work runs several services together, hardens them, and ships them to a registry. This chapter delivers the Docker Compose, security, and deployment skills promised in the Quest Objectives.*
 
 ### 🧩 Multi-Container Apps with Docker Compose
 
-Create a file named `docker-compose.yml` beside your `Dockerfile`. This example runs a small
-web app alongside a Redis cache — two services wired together by Compose:
+Create a file named `docker-compose.yml` beside your `Dockerfile`. This example runs a small web app alongside a Redis cache — two services wired together by Compose:
 
 ```yaml
 # docker-compose.yml — a two-service app defined declaratively
@@ -271,9 +266,7 @@ docker compose down
 
 ### 🛡️ Security Best Practices: Non-Root + Multi-Stage Builds
 
-Running containers as `root` and shipping build tooling in the final image are common
-vulnerabilities. A multi-stage build keeps the runtime image small, and a dedicated
-non-root `USER` limits blast radius:
+Running containers as `root` and shipping build tooling in the final image are common vulnerabilities. A multi-stage build keeps the runtime image small, and a dedicated non-root `USER` limits blast radius:
 
 ```dockerfile
 # Stage 1: build with the full toolchain
@@ -304,8 +297,7 @@ trivy image my-first-image
 
 ### ☁️ Deploy: Push to a Container Registry
 
-Deployment starts by publishing your image to a registry so a cloud service can pull it.
-Push to Docker Hub (swap `YOUR_USERNAME` for your account):
+Deployment starts by publishing your image to a registry so a cloud service can pull it. Push to Docker Hub (swap `YOUR_USERNAME` for your account):
 
 ```bash
 # Log in, tag the image for your registry namespace, then push
@@ -314,8 +306,7 @@ docker tag my-first-image YOUR_USERNAME/my-first-image:latest
 docker push YOUR_USERNAME/my-first-image:latest
 ```
 
-Any cloud runtime that pulls container images (AWS ECS, Azure Container Apps, Google Cloud
-Run, Fly.io) can now deploy `YOUR_USERNAME/my-first-image:latest` directly from the registry.
+Any cloud runtime that pulls container images (AWS ECS, Azure Container Apps, Google Cloud Run, Fly.io) can now deploy `YOUR_USERNAME/my-first-image:latest` directly from the registry.
 
 ## 🎮 Docker Mastery Challenges
 

--- a/pages/_quests/0101/docker-mastery-example.md
+++ b/pages/_quests/0101/docker-mastery-example.md
@@ -111,42 +111,69 @@ This 🟡 Medium quest expects:
 
 ### 🍎 macOS Kingdom Path
 
-```bash
-# macOS-specific commands and setup
-```
+Install Docker Desktop with Homebrew, then start it and confirm the CLI is working:
 
-*[Detailed instructions including Homebrew installations, Terminal usage, and macOS-specific tools]*
+```bash
+# Install Docker Desktop via Homebrew Cask
+brew install --cask docker
+
+# Launch Docker Desktop (starts the background engine)
+open -a Docker
+
+# Verify the install once the whale icon is running
+docker --version
+docker run --rm hello-world
+```
 
 ### 🪟 Windows Empire Path
 
-```powershell
-# PowerShell and Windows-specific commands
-```
+Install Docker Desktop with Chocolatey (WSL 2 backend is enabled by default):
 
-*[Windows-specific instructions including Chocolatey, WSL options, and Windows tools]*
+```powershell
+# Install Docker Desktop via Chocolatey
+choco install docker-desktop -y
+
+# After Docker Desktop finishes starting, verify from PowerShell
+docker --version
+docker run --rm hello-world
+```
 
 ### 🐧 Linux Territory Path
 
-```bash
-# Linux distribution-specific commands
-```
+Use Docker's official convenience script, then add your user to the `docker` group so you
+can run the CLI without `sudo`:
 
-*[Linux instructions with alternatives for different distributions]*
+```bash
+# Install Docker Engine (works on most distributions)
+curl -fsSL https://get.docker.com | sh
+
+# Allow the current user to run docker without sudo (log out/in to apply)
+sudo usermod -aG docker "$USER"
+
+# Verify
+docker --version
+docker run --rm hello-world
+```
 
 ### ☁️ Cloud Realms Path
 
-*[Cloud platform instructions for AWS, Azure, GCP when applicable]* *[Container-based approaches using Docker/Podman]*
+No local install needed — use a cloud shell or dev environment that ships Docker preinstalled:
 
 ```bash
-# Cloud platform commands and configurations
+# GitHub Codespaces / cloud dev containers already include Docker — just verify:
+docker --version
+docker run --rm hello-world
 ```
 
 ### 📱 Universal Web Path
 
-*[Browser-based or platform-agnostic approaches when available]*
+Prefer a browser? Use [Play with Docker](https://labs.play-with-docker.com/) — a free,
+throwaway Docker playground that runs entirely in your browser:
 
-```javascript
-// Cross-platform web technologies
+```text
+1. Open https://labs.play-with-docker.com/ and sign in with a Docker Hub account.
+2. Click "ADD NEW INSTANCE" to get a terminal with Docker preinstalled.
+3. Run: docker run --rm hello-world
 ```
 
 ## 🧙‍♂️ Chapter 1: Docker Foundation - Setting Up Your Digital Workshop
@@ -204,6 +231,91 @@ Hello from your first Docker container!
 - [ ] **Setup Complete**: docker environment is ready for development
 - [ ] **First Success**: Successfully executed your first docker implementation
 - [ ] **Understanding Gained**: Can explain key concepts to another person
+
+## 🧙‍♂️ Chapter 2: Compose, Secure, and Ship Your Containers
+
+*Chapter 1 built a single image. Real devops work runs several services together, hardens
+them, and ships them to a registry. This chapter delivers the Docker Compose, security, and
+deployment skills promised in the Quest Objectives.*
+
+### 🧩 Multi-Container Apps with Docker Compose
+
+Create a file named `docker-compose.yml` beside your `Dockerfile`. This example runs a small
+web app alongside a Redis cache — two services wired together by Compose:
+
+```yaml
+# docker-compose.yml — a two-service app defined declaratively
+services:
+  web:
+    build: .            # build the image from the local Dockerfile
+    ports:
+      - "8080:8080"     # map host port 8080 to the container
+    depends_on:
+      - cache
+  cache:
+    image: redis:7-alpine
+```
+
+Start the whole stack (and stop it) with a single command each:
+
+```bash
+# Build images if needed and start all services in the background
+docker compose up -d
+
+# See the running services
+docker compose ps
+
+# Tear everything down when finished
+docker compose down
+```
+
+### 🛡️ Security Best Practices: Non-Root + Multi-Stage Builds
+
+Running containers as `root` and shipping build tooling in the final image are common
+vulnerabilities. A multi-stage build keeps the runtime image small, and a dedicated
+non-root `USER` limits blast radius:
+
+```dockerfile
+# Stage 1: build with the full toolchain
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Stage 2: minimal runtime image, run as an unprivileged user
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/node_modules ./node_modules
+# Create and switch to a non-root user
+RUN addgroup -S app && adduser -S app -G app
+USER app
+CMD ["node", "dist/server.js"]
+```
+
+Scan the resulting image for known vulnerabilities before you ship it:
+
+```bash
+# Scan with Trivy (or `docker scout cves <image>` on newer Docker Desktop)
+trivy image my-first-image
+```
+
+### ☁️ Deploy: Push to a Container Registry
+
+Deployment starts by publishing your image to a registry so a cloud service can pull it.
+Push to Docker Hub (swap `YOUR_USERNAME` for your account):
+
+```bash
+# Log in, tag the image for your registry namespace, then push
+docker login
+docker tag my-first-image YOUR_USERNAME/my-first-image:latest
+docker push YOUR_USERNAME/my-first-image:latest
+```
+
+Any cloud runtime that pulls container images (AWS ECS, Azure Container Apps, Google Cloud
+Run, Fly.io) can now deploy `YOUR_USERNAME/my-first-image:latest` directly from the registry.
 
 ## 🎮 Docker Mastery Challenges
 

--- a/pages/_quests/0101/github-actions-basics.md
+++ b/pages/_quests/0101/github-actions-basics.md
@@ -197,6 +197,8 @@ mkdir -p .github/workflows
 gh run list   # see your workflow runs without leaving the terminal
 ```
 
+> **Heads up:** `gh run list` only works from inside an authenticated repo context (a Codespace, or after `gh auth login` locally). Run it elsewhere and it exits with `gh: To use GitHub CLI ... set the GH_TOKEN environment variable.` — that's an auth issue, not a broken command.
+
 > The runner that executes your workflow IS the cloud realm - GitHub spins up an `ubuntu-latest`, `windows-latest`, or `macos-latest` VM per job and destroys it when finished.
 
 </details>

--- a/pages/_quests/0101/the-lazytex-of-building-a-curriculum-vitae.md
+++ b/pages/_quests/0101/the-lazytex-of-building-a-curriculum-vitae.md
@@ -119,10 +119,7 @@ which latexmk && latexmk --version
 Notes:
 
 - If you prefer a smaller footprint: `brew install --cask basictex` then
-  `sudo tlmgr update --self && sudo tlmgr install latexmk enumitem titlesec fontawesome5 CormorantGaramond`.
-  BasicTeX ships only a minimal package set, so `enumitem` and `titlesec` (used by the
-  Chapter 2 template) must be installed explicitly or the build fails with a
-  `File \`enumitem.sty' not found` error.
+`sudo tlmgr update --self && sudo tlmgr install latexmk enumitem titlesec fontawesome5 CormorantGaramond`. BasicTeX ships only a minimal package set, so `enumitem` and `titlesec` (used by the Chapter 2 template) must be installed explicitly or the build fails with a `File \`enumitem.sty' not found` error.
 
 ### 🪟 Windows Empire Path
 

--- a/pages/_quests/0101/the-lazytex-of-building-a-curriculum-vitae.md
+++ b/pages/_quests/0101/the-lazytex-of-building-a-curriculum-vitae.md
@@ -119,7 +119,10 @@ which latexmk && latexmk --version
 Notes:
 
 - If you prefer a smaller footprint: `brew install --cask basictex` then
-  `sudo tlmgr update --self && sudo tlmgr install latexmk fontawesome5 CormorantGaramond`.
+  `sudo tlmgr update --self && sudo tlmgr install latexmk enumitem titlesec fontawesome5 CormorantGaramond`.
+  BasicTeX ships only a minimal package set, so `enumitem` and `titlesec` (used by the
+  Chapter 2 template) must be installed explicitly or the build fails with a
+  `File \`enumitem.sty' not found` error.
 
 ### 🪟 Windows Empire Path
 
@@ -173,7 +176,7 @@ latexmk -pdf cv.tex
 
 ## 🧙‍♂️ Chapter 2: Summon the Template (Create cv.tex)
 
-Your core artifact is `cv.tex`. Create it now: make a `cv/` folder, then save the starter below as `cv/cv.tex`. It is self‑contained—it uses only base TeX Live packages and defines the custom commands (`\resumeSubheading`, `\resumeItem`, and the list helpers) that you will use in Chapter 3, so it compiles cleanly with a stock LaTeX install.
+Your core artifact is `cv.tex`. Create it now: make a `cv/` folder, then save the starter below as `cv/cv.tex`. It is self‑contained—it defines the custom commands (`\resumeSubheading`, `\resumeItem`, and the list helpers) that you will use in Chapter 3. It relies on the `enumitem` and `titlesec` packages, which are included in a full TeX Live/MacTeX install; on a minimal BasicTeX install you must add them first (see the BasicTeX note above) or the build fails with a `File \`enumitem.sty' not found` error.
 
 {% raw %}
 ```latex


### PR DESCRIPTION
## 🔧 Quest fix — `system-engineer/0101`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: system-engineer/0101

Honest run confirmed (all 5 results `mode==execute`, `executed==true`, non-truncated,
`errored==0`). Acted only on the 3 non-pass quests; each kept edit passed the deterministic
gate (tier-1 `quest_validator.py score_pct` held-or-rose AND `brand_lint` clean).

- **pages/_quests/0101/docker-mastery-example.md** (verdict: fail) — filled the empty
  placeholder code fences in the "Choose Your Adventure Platform" section with real install
  commands for macOS/Windows/Linux/Cloud/Web (verified: high-priority recommendation, area
  *Choose Your Adventure Platform section* — "empty placeholder code fences … should never
  ship"). tier-1 score_pct 95.9 → 95.9 (held, 71/74), brand clean. ✅ kept.
- **pages/_quests/0101/docker-mastery-example.md** (verdict: fail) — added a runnable
  "Chapter 2: Compose, Secure, and Ship" delivering Docker Compose (`docker compose up`),
  security best practices (multi-stage build + non-root `USER` + `trivy` scan), and registry
  push/cloud deploy (verified: high-priority recommendation, area *Completeness / Objectives
  mismatch* — objectives promised Compose/security/cloud the content didn't teach). Used the
  "add real content" arm, not the weakening "remove objectives" arm. tier-1 score_pct
  95.9 → 95.9 (held, 71/74), brand clean. ✅ kept.
- **pages/_quests/0101/the-lazytex-of-building-a-curriculum-vitae.md** (verdict: warn) —
  corrected the false claim that the template "uses only base TeX Live packages … compiles
  cleanly with a stock LaTeX install," and added `enumitem`/`titlesec` to the BasicTeX
  `tlmgr install` command (verified: high-priority recommendation, area *Chapter 2 / macOS
  BasicTeX Notes* — the template `\usepackage{enumitem,titlesec}` but the install line omitted
  them, so a BasicTeX learner hits `enumitem.sty not found`). tier-1 score_pct 91.9 → 91.9
  (held, 68/74), brand clean. ✅ kept.
- **pages/_quests/0101/github-actions-basics.md** (verdict: warn) — added a note that
  `gh run list` needs an authenticated repo/Codespace context and its `GH_TOKEN` error is an
  auth issue, not a broken command (verified: medium-priority recommendation, area *Cloud
  Realms path / gh run list*). tier-1 score_pct 100.0 → 100.0 (held, 74/74), brand clean.
  ✅ kept.

_Left (not fixed, with reason):_

- **github-actions-basics.md — high recommendation to "strip the Jekyll `{% raw %}` tags"
  from the Secrets/Matrix YAML: NOT applied (false positive).** The source
  `${% raw %}{{ secrets.DEPLOY_TOKEN }}{% endraw %}` renders in Jekyll to `${{ secrets.DEPLOY_TOKEN }}`
  — valid GitHub Actions syntax. The two "failed command" details analyzed the raw `.md`
  source, not the rendered page. Stripping the `{% raw %}` guards would make Jekyll interpret
  `{{ … }}` as Liquid and render it empty, **breaking** the published workflow examples. Fixing
  this would weaken correct content, so it was left as-is.
- docker-mastery-example.md — medium (Chapter 1 steps restate titles) and low (base image
  freshness) recommendations: left, below the per-slice cap after fixing the two high-priority
  defects.
- the-lazytex-of-building-a-curriculum-vitae.md — medium (duplicate Chapter 3 example) and two
  low recommendations (stale Knowledge-Graph "Level hub" link, extra troubleshooting note):
  left, below the per-slice cap after fixing the high-priority factual error.
- github-actions-basics.md — low recommendation (clarify the secret-deletion failure surfaces
  as HTTP 401): left, low priority.

No quest frontmatter was modified, so no `_data/quests/**` regeneration is required. No
vendored quests were present in this slice.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/29826801543)._
