### PR TITLE
🔧 Quest fix: security-specialist/1011

### DIFF
--- a/pages/_quests/1011/agentic-behavior-tuning.md
+++ b/pages/_quests/1011/agentic-behavior-tuning.md
@@ -113,6 +113,8 @@ RUN_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 echo "=== Agent Behaviour Baseline Measurement ==="
 
+RECORDED=0
+
 # For each test task, record:
 # - Did the agent open a PR? (success signal 1)
 # - Did all tests pass? (success signal 2)
@@ -136,9 +138,16 @@ for TASK_NUM in 1 2 3; do
     cat >> "$RESULTS_FILE" << EOF
 {"date":"$RUN_DATE","task":$TASK_NUM,"run_id":"$RUN_ID","pr_opened":$([ "$PR_OPENED" -gt 0 ] && echo true || echo false),"tests_passed":$([ "$TESTS_PASSED" = "success" ] && echo true || echo false)}
 EOF
+    RECORDED=$((RECORDED + 1))
 done
 
-echo "✅ Baseline recorded in $RESULTS_FILE"
+if [ "$RECORDED" -eq 0 ]; then
+    echo "❌ No tasks were recorded — no agent-task.yml runs exist yet, so $RESULTS_FILE was not created."
+    echo "   Trigger at least one agent run for tasks 1–3, then re-run this script."
+    exit 1
+fi
+
+echo "✅ Baseline recorded ($RECORDED task(s)) in $RESULTS_FILE"
 ```
 
 ---

--- a/pages/_quests/1011/agentic-multi-agent-observability.md
+++ b/pages/_quests/1011/agentic-multi-agent-observability.md
@@ -138,6 +138,13 @@ jobs:
           path: "trace-analysis-${% raw %}{{ env.CORRELATION_ID }}{% endraw %}.jsonl"
 ```
 
+> **`traced_subtask.py` is a thin wrapper you author around `trace_writer.py`.**
+> The workflow above calls `work/gh-600/scripts/traced_subtask.py`, which is not a
+> separate tool — it runs your sub-task and emits trace entries using the
+> `trace_writer.py` module defined in Chapter 2. If you'd rather keep the example
+> fully self-contained, call `trace_writer.py` directly instead. Either way the
+> script must exist under `work/gh-600/scripts/` before the workflow runs.
+
 ---
 
 ### Chapter 2 — Structured Trace Entry Format

--- a/pages/_quests/1011/agentic-multi-agent-orchestration-patterns.md
+++ b/pages/_quests/1011/agentic-multi-agent-orchestration-patterns.md
@@ -107,7 +107,7 @@ graph LR
 
 > **Exercise 14.1:** Create an orchestrator workflow that fans out to parallel sub-agents.
 
-
+{% raw %}
 ```yaml
 # .github/workflows/orchestrator-fan-out.yml
 name: Multi-Agent Orchestrator (Fan-Out)
@@ -121,7 +121,7 @@ jobs:
     if: contains(github.event.label.name, 'multi-agent-task')
     runs-on: ubuntu-latest
     outputs:
-      subtasks: ${% raw %}{{ steps.plan.outputs.subtasks }}{% endraw %}
+      subtasks: ${{ steps.plan.outputs.subtasks }}
     steps:
       - uses: actions/checkout@v4
 
@@ -130,7 +130,7 @@ jobs:
         run: |
           # Orchestrator determines how to split the task
           python3 work/gh-600/scripts/partition_task.py \
-            --issue "${% raw %}{{ github.event.issue.number }}{% endraw %}" \
+            --issue "${{ github.event.issue.number }}" \
             --max-subtasks 4 \
             --output partition.json
           
@@ -143,26 +143,26 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        subtask: ${% raw %}{{ fromJSON(needs.orchestrate.outputs.subtasks) }}{% endraw %}
+        subtask: ${{ fromJSON(needs.orchestrate.outputs.subtasks) }}
       max-parallel: 4
     steps:
       - uses: actions/checkout@v4
 
       - name: Execute sub-task
         run: |
-          echo "=== Sub-Agent executing: ${% raw %}{{ matrix.subtask.id }}{% endraw %} ==="
-          echo "Task: ${% raw %}{{ matrix.subtask.description }}{% endraw %}"
+          echo "=== Sub-Agent executing: ${{ matrix.subtask.id }} ==="
+          echo "Task: ${{ matrix.subtask.description }}"
           
           python3 work/gh-600/scripts/run_subtask.py \
-            --subtask-id "${% raw %}{{ matrix.subtask.id }}{% endraw %}" \
-            --description "${% raw %}{{ matrix.subtask.description }}{% endraw %}" \
-            --output "subtask-${% raw %}{{ matrix.subtask.id }}{% endraw %}-result.json"
+            --subtask-id "${{ matrix.subtask.id }}" \
+            --description "${{ matrix.subtask.description }}" \
+            --output "subtask-${{ matrix.subtask.id }}-result.json"
 
       - name: Upload sub-task result
         uses: actions/upload-artifact@v4
         with:
-          name: subtask-result-${% raw %}{{ matrix.subtask.id }}{% endraw %}
-          path: "subtask-${% raw %}{{ matrix.subtask.id }}{% endraw %}-result.json"
+          name: subtask-result-${{ matrix.subtask.id }}
+          path: "subtask-${{ matrix.subtask.id }}-result.json"
 
   aggregate:
     needs: sub-agents
@@ -181,7 +181,7 @@ jobs:
         run: |
           python3 work/gh-600/scripts/aggregate_results.py \
             --results-dir ./subtask-results/ \
-            --issue "${% raw %}{{ github.event.issue.number }}{% endraw %}" \
+            --issue "${{ github.event.issue.number }}" \
             --output final-report.json
 
       - name: Post aggregated report
@@ -196,7 +196,16 @@ jobs:
               body: `## Multi-Agent Task Complete\n\n${report.summary}\n\n${report.details}`
             });
 ```
+{% endraw %}
 
+> **Helper scripts are learner-authored placeholders.** This workflow invokes
+> `work/gh-600/scripts/partition_task.py`, `run_subtask.py`, and
+> `aggregate_results.py`. These are **not provided by the quest** — they are stubs
+> you author for your own task domain. Until you create them the workflow will fail
+> on first run with `No such file or directory`. Start with a minimal
+> `partition_task.py` that reads the issue and writes a `partition.json` containing a
+> `subtasks` array, then flesh out `run_subtask.py` and `aggregate_results.py` the
+> same way.
 
 ---
 
@@ -204,6 +213,7 @@ jobs:
 
 > **Exercise 14.2:** Create a sequential chain where research feeds into implementation.
 
+{% raw %}
 ```yaml
 # .github/workflows/orchestrator-chain.yml
 name: Multi-Agent Chain (Research → Plan → Implement)
@@ -219,7 +229,7 @@ jobs:
   research-agent:
     runs-on: ubuntu-latest
     outputs:
-      findings: ${% raw %}{{ steps.research.outputs.findings }}{% endraw %}
+      findings: ${{ steps.research.outputs.findings }}
     steps:
       - uses: actions/checkout@v4
       - name: Research phase
@@ -235,14 +245,14 @@ jobs:
     needs: research-agent
     runs-on: ubuntu-latest
     outputs:
-      plan: ${% raw %}{{ steps.plan.outputs.plan }}{% endraw %}
+      plan: ${{ steps.plan.outputs.plan }}
     steps:
       - uses: actions/checkout@v4
       - name: Planning phase
         id: plan
         run: |
           # Plan agent uses research findings to create implementation plan
-          FINDINGS='${% raw %}{{ needs.research-agent.outputs.findings }}{% endraw %}'
+          FINDINGS='${{ needs.research-agent.outputs.findings }}'
           echo "Planning agent working from research: $FINDINGS"
           PLAN=$(echo '{"steps": [{"action": "modify", "file": "src/api.js"}]}')
           echo "plan=$PLAN" >> "$GITHUB_OUTPUT"
@@ -254,10 +264,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Implementation phase
         run: |
-          PLAN='${% raw %}{{ needs.planning-agent.outputs.plan }}{% endraw %}'
+          PLAN='${{ needs.planning-agent.outputs.plan }}'
           echo "Implementation agent executing plan: $PLAN"
           # Agent modifies the specified files
 ```
+{% endraw %}
 
 ---
 


### PR DESCRIPTION
## 🔧 Quest fix — `security-specialist/1011`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: security-specialist/1011

Evidence honest & actionable: all 5 results `mode==execute`, `truncated` not set,
`errored==0`, every `verdict_obj.executed==true`. Fixed the VERIFIED issues on the
warn/fail quests only; the two `pass` quests were left untouched.

- **pages/_quests/1011/agentic-multi-agent-orchestration-patterns.md** (fail) —
  fixed failed commands `Write .github/workflows/orchestrator-fan-out.yml` and
  `Write .github/workflows/orchestrator-chain.yml` (verified: `commands[].status==failed`;
  high-priority rec "Chapter 2 & 3 YAML code blocks"). Leaked Jekyll
  `{% raw %}`/`{% endraw %}` tags were interleaved *inside* each `${{ ... }}` expression
  (`${% raw %}{{ ... }}{% endraw %}`), which is invalid GitHub Actions syntax. Stripped
  the interleaved tags to restore valid `${{ ... }}` and wrapped each whole fenced yaml
  block with `{% raw %}`/`{% endraw %}` at the Liquid level. tier-1 score 58/74 (78.4%) →
  58/74 (78.4%) held, brand clean, 0 interleaved tags remain. ✅ kept.
- **pages/_quests/1011/agentic-multi-agent-orchestration-patterns.md** (fail) —
  addressed failed command `python3 work/gh-600/scripts/partition_task.py ...`
  (`No such file or directory`) and high-priority rec "Fan-out workflow dependencies":
  added a callout marking `partition_task.py`, `run_subtask.py`, `aggregate_results.py`
  as learner-authored placeholders (why the workflow fails on first run), instead of
  leaving them silently missing. tier-1 58/74 (78.4%) held, brand clean. ✅ kept.
- **pages/_quests/1011/agentic-behavior-tuning.md** (fail) — fixed failed command
  `bash work/gh-600/scripts/measure_agent_baseline.sh` and the dependent
  `Quest Validation self-check` (verified: 2× `commands[].status==failed`; high-priority
  rec "Exercise 13.1 / measure_agent_baseline.sh"). Root cause: the `continue` in the
  no-RUN_ID branch skipped every heredoc write, but the final `✅ Baseline recorded`
  echo was unconditional, so the script exited 0 while `baseline-results.jsonl` was never
  created. Added a `RECORDED` counter, incremented on each written row, and made the
  script print a clear failure and `exit 1` when nothing was recorded. Verified by
  extraction + `bash -n` (syntax OK) and a functional run with no agent runs present
  (now exits 1, no false success). tier-1 58/74 (78.4%) held, brand clean. ✅ kept.
- **pages/_quests/1011/agentic-multi-agent-observability.md** (warn) — addressed
  high-priority rec "Chapter 1 workflow — traced_subtask.py" (invoked at line 130 but
  never defined): added a note clarifying `traced_subtask.py` is a learner-authored thin
  wrapper around the `trace_writer.py` module already defined in Chapter 2 (with the
  option to call `trace_writer.py` directly for a self-contained example). tier-1
  58/74 (78.4%) held, brand clean. ✅ kept.

_Left (not fixed):_
- **agentic-multi-agent-observability.md** carries the same interleaved
  `${% raw %}{{ ... }}{% endraw %}` leak, but it was **not** in this quest's evidence
  (no failed command, no recommendation names it) — **out of scope** under the
  verified-only rule (M7). Flagged for a future walk.
- Medium/low recommendations across the three quests (event-driven worked exercise,
  standalone aggregation-test exercise, RCA-tie-in, explicit 13.2/13.3 shell commands,
  re-run-baseline comparison, missing aggregation job, inter-agent failure example,
  Python 3.10+ note) — deferred; the slice can be improved again on the next daily pass.
- No frontmatter was modified, so `_data/quests/**` needs no regeneration.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/29826801543)._
