### PR TITLE
🔧 Quest fix: system-engineer/1001

### DIFF
--- a/pages/_quests/1001/k8s-pods-workloads.md
+++ b/pages/_quests/1001/k8s-pods-workloads.md
@@ -241,11 +241,16 @@ spec:
 ```
 
 ```bash
-# Apply it, then delete a Pod and watch the ReplicaSet replace it instantly
+# Apply it, then delete the matching Pods and watch the ReplicaSet recreate them instantly
 kubectl apply -f web-rs.yaml
 kubectl get pods -l app=web
-kubectl delete pod -l app=web --wait=false
-kubectl get pods -l app=web --watch   # a fresh Pod appears - this is self-healing
+kubectl delete pod -l app=web --wait=false   # this deletes ALL Pods carrying app=web
+kubectl get pods -l app=web --watch   # fresh Pods appear - this is self-healing
+
+# Clean up the ReplicaSet before Chapter 2. Its `app: web` selector would otherwise
+# collide with the Deployment you build next, doubling the Pod count under `-l app=web`
+# and throwing off the replica checkpoints.
+kubectl delete -f web-rs.yaml
 ```
 
 ### 🔍 Knowledge Check: Pods and ReplicaSets
@@ -374,6 +379,9 @@ spec:
       containers:
         - name: postgres
           image: postgres:16
+          env:
+            - name: POSTGRES_PASSWORD   # required, or the Pod CrashLoopBackOffs on first boot
+              value: changeme           # demo only - move this to a Secret in the next quest
           ports:
             - containerPort: 5432
           volumeMounts:

--- a/pages/_quests/1001/k8s-services-networking.md
+++ b/pages/_quests/1001/k8s-services-networking.md
@@ -286,9 +286,11 @@ Kubernetes runs an internal DNS service (CoreDNS). Every Service is resolvable a
 From a Pod in the same namespace, the short name `web` is enough. Prove it:
 
 ```bash
-# Launch a throwaway Pod and resolve the Service by name
+# Launch a throwaway Pod and resolve the Service by name.
+# Use ';' (not '&&'): busybox nslookup exits non-zero after probing the standard
+# search domains even when the short name resolves, which would skip the wget.
 kubectl run netcheck --rm -it --image=busybox:1.36 --restart=Never -- \
-  sh -c "nslookup web && wget -qO- http://web"
+  sh -c "nslookup web; wget -qO- http://web"
 
 # Full FQDN works across namespaces:
 kubectl run netcheck --rm -it --image=busybox:1.36 --restart=Never -- \
@@ -342,9 +344,35 @@ spec:
 kubectl apply -f web-ingress.yaml
 kubectl get ingress web-ingress
 
-# Test it (kind maps the controller to localhost). Send the Host header:
+# Test it. Send the Host header:
 curl -H "Host: app.local" http://localhost/
 ```
+
+> **kind users - map the host ports first.** A default `kind create cluster` maps only
+> the API server to your host, so nothing listens on `localhost:80` and the curl above
+> fails with *connection refused*. Create (or recreate) the cluster with `extraPortMappings`
+> and the `ingress-ready` node label **before** installing the ingress-nginx controller, per
+> [kind's ingress guide](https://kind.sigs.k8s.io/docs/user/ingress/):
+>
+> ```bash
+> kind create cluster --config - <<'EOF'
+> kind: Cluster
+> apiVersion: kind.x-k8s.io/v1alpha4
+> nodes:
+>   - role: control-plane
+>     kubeadmConfigPatches:
+>       - |
+>         kind: InitConfiguration
+>         nodeRegistration:
+>           kubeletExtraArgs:
+>             node-labels: "ingress-ready=true"
+>     extraPortMappings:
+>       - containerPort: 80
+>         hostPort: 80
+>       - containerPort: 443
+>         hostPort: 443
+> EOF
+> ```
 
 One Ingress can route `app.local/` to the web Service and `app.local/api` to an API Service - many backends behind one gate.
 


### PR DESCRIPTION
## 🔧 Quest fix — `system-engineer/1001`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: system-engineer/1001

Evidence gate (M7) passed: `mode==execute`, non-truncated, `errored==0`, every result `executed==true`. Two quests verdict `fail` (in scope); two `pass` (skipped). Both edited quests are non-vendored. Tier-1 numbers are read straight from `quest_validator.py`.

**pages/_quests/1001/k8s-pods-workloads.md** — tier-1 score_pct 100 → 100 (held), brand clean.
- Fixed failed command `db-statefulset.yaml (StatefulSet, postgres:16)` (`commands[].status=failed`: Pods CrashLoopBackOff — "Database is uninitialized and superuser password is not specified") + high rec (area: Chapter 3 StatefulSet manifest). Added `env: POSTGRES_PASSWORD` to the postgres container so the StatefulSet becomes Ready. ✅ kept.
- Fixed failed command `web-deployment.yaml` label collision (`commands[].status=failed`: Chapter 1 ReplicaSet `app: web` selector still live, doubling Pod count) + high rec (area: Chapter 1 → Chapter 2 transition). Added `kubectl delete -f web-rs.yaml` cleanup before Chapter 2 so `-l app=web` checkpoints stay accurate; also corrected the low-rec self-healing comment that implied a single-Pod delete (the command deletes all matching Pods). ✅ kept.

**pages/_quests/1001/k8s-services-networking.md** — tier-1 score_pct 100 → 100 (held), brand clean.
- Fixed failed command `kubectl run netcheck ... sh -c "nslookup web && wget -qO- http://web"` (`commands[].status=failed`: busybox nslookup returns non-zero after probing search suffixes, so `&&` skips wget and the Pod shows Error) + high rec (area: Chapter 2 DNS proof snippet). Replaced `&&` with `;` and documented why. ✅ kept.
- Fixed failed command `curl -H "Host: app.local" http://localhost/` (`commands[].status=failed`: a plain `kind create cluster` maps only the API server, so nothing listens on host port 80 → connection refused) + high rec (area: Chapter 3 / Advanced Challenge Ingress). Added the required `kind create cluster --config` step with `extraPortMappings` (80/443) and `ingress-ready=true` node label before the Ingress test. ✅ kept.

_Left (not applied this pass — below the small per-slice cap, all lower-priority; deferrable to a later daily run):_
- k8s-pods-workloads.md: medium rec (add `kubectl delete namespace legions` cleanup section); low rec (add or de-list CronJob in the decision table).
- k8s-services-networking.md: medium rec (add a hands-on troubleshooting step for the mismatched-selector Endpoints objective); low recs (add `kubectl wait` to the Linux/kind tab for consistency; note `kubectl get endpoints` deprecation vs `endpointslices` on k8s 1.33+).
- Two `pass` quests (`k8s-config-secrets.md`, `self-operating-website-04-the-sigils-of-trust.md`) skipped — not warn/fail, out of scope.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/29916378064)._
