### PR TITLE
🔧 Quest fix: security-specialist/1011

### DIFF
--- a/pages/_quests/1011/agentic-multi-agent-failure-recovery.md
+++ b/pages/_quests/1011/agentic-multi-agent-failure-recovery.md
@@ -216,6 +216,18 @@ import os
 from pathlib import Path
 
 
+# The five compensation strategy types from Chapter 1's failure classification.
+# Documenting them here keeps the coordinator's recovery vocabulary explicit so
+# every failure class maps to a concrete strategy.
+COMPENSATION_STRATEGIES = {
+    "transient": "retry_with_backoff",      # retry the task with exponential backoff
+    "idempotent": "retry_from_checkpoint",  # resume from the last saved checkpoint
+    "non_idempotent": "rollback_fallback",  # roll back, then fall back to re-delegation
+    "permanent": "escalate_to_human",       # escalate to a human reviewer
+    "cascade": "compensate_and_continue",   # compensate and continue with partial results
+}
+
+
 def assess_and_recover(
     results_dir: str,
     task_id: str,
@@ -279,6 +291,9 @@ def assess_and_recover(
     if github_output:
         with open(github_output, "a") as gh_out:
             gh_out.write(f"needs_redelegation={str(needs_redelegation).lower()}\n")
+            # Emit the failed agents so the workflow's re-delegate step can read
+            # `steps.assess.outputs.failed_tasks` (passed to --failed-tasks).
+            gh_out.write(f"failed_tasks={','.join(failed_agents)}\n")
     
     return recovery_plan
 
@@ -310,8 +325,8 @@ Validate your work with these standalone checks — run each from your quest wor
 test -f orchestrator-with-recovery.yml && echo "orchestrator-with-recovery.yml present"
 # ✅ Recovery coordinator present
 test -f recovery_coordinator.py && echo "recovery_coordinator.py present"
-# ✅ Compensation strategies documented (expect a count of 5)
-grep -c -iE "retry|fallback|escalat|compensat|checkpoint" recovery_coordinator.py
+# ✅ All five compensation strategy types documented (expect a count of 5)
+grep -oiE "retry|fallback|escalat|compensat|checkpoint" recovery_coordinator.py | tr '[:upper:]' '[:lower:]' | sort -u | wc -l
 ```
 
 Manual completion checklist:

--- a/pages/_quests/1011/ai-feature-pipeline-architect.md
+++ b/pages/_quests/1011/ai-feature-pipeline-architect.md
@@ -127,7 +127,7 @@ You'll know you've truly mastered this quest when you can:
 brew install node python3 docker docker-compose git
 
 # Install AI development tools
-brew install --cask github-copilot-cli
+brew install copilot-cli
 pip3 install langchain anthropic openai
 
 # Set up MCP development environment
@@ -217,11 +217,13 @@ const aiPipeline = {
 
 **Step 1: Set up your AI orchestration environment**
 
-```python
+```bash
 # Install the AI orchestration framework
 # (the Model Context Protocol package on PyPI is `mcp`, not `mcp-client`)
 pip install langchain anthropic openai mcp
+```
 
+```python
 # Create your first AI agent for requirement processing
 import os
 from anthropic import Anthropic

--- a/pages/_quests/1011/secure-coding.md
+++ b/pages/_quests/1011/secure-coding.md
@@ -347,6 +347,12 @@ echo ".env" >> .gitignore
 
 # Scan a repository for accidentally committed secrets before pushing
 pip install detect-secrets
+
+# detect-secrets scans files tracked by git (via `git ls-files`). Outside a git
+# repo it silently scans nothing and produces a clean-looking baseline, so make
+# sure your files are in git first.
+git init -q
+git add .
 detect-secrets scan > .secrets.baseline
 ```
 


### PR DESCRIPTION
## 🔧 Quest fix — `security-specialist/1011`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: security-specialist/1011

Evidence honest & in-scope: all 5 results `mode==execute`, `executed==true`, non-truncated, fully scored (avg 71.4). Acted on the 3 non-pass quests (2 fail, 1 warn); the 2 `pass` quests were left untouched.

**Kept edits (deterministic gate: tier-1 held-or-rose AND brand_lint clean):**

- **pages/_quests/1011/ai-feature-pipeline-architect.md** — fixed failed command `pip install langchain anthropic openai mcp` (verified: `commands[].status=failed`, `SyntaxError` — shell line inside a `python` fence). Split the `pip install` into its own ```bash``` fence so the Python block copy-pastes cleanly. Also addresses the paired high recommendation (area: *Chapter 1, Step 1 code fence*). tier-1 score 71/74 (95.9%) → 71/74 (95.9%) (held), brand clean. ✅ kept.
- **pages/_quests/1011/ai-feature-pipeline-architect.md** — addressed medium recommendation (area: *macOS setup path*): `brew install --cask github-copilot-cli` cask does not exist. Replaced with the real cask `brew install copilot-cli`. tier-1 71/74 → 71/74 (held), brand clean. ✅ kept.
- **pages/_quests/1011/agentic-multi-agent-failure-recovery.md** — fixed failed command `grep -c -iE "retry|fallback|escalat|compensat|checkpoint" recovery_coordinator.py` (verified: `status=failed` — reference code documented only 2 of the 5 strategy types, so the check returned 4 not the claimed 5). Added a `COMPENSATION_STRATEGIES` map to the reference coordinator so all five Chapter-1 strategy types (retry/checkpoint/fallback/escalate/compensate) are genuinely documented, and switched the brittle line-count `grep -c` to a distinct-keyword count that now deterministically returns **5** (measured). Addresses the paired high recommendation (area: *Quest Validation grep check*). Code re-verified with `py_compile`. tier-1 58/74 (78.4%) → 58/74 (78.4%) (held), brand clean. ✅ kept.
- **pages/_quests/1011/agentic-multi-agent-failure-recovery.md** — addressed high recommendation (area: *Objective: Implement re-delegation*): the workflow reads `steps.assess.outputs.failed_tasks` but the coordinator only emitted `needs_redelegation`. Added a `failed_tasks` `$GITHUB_OUTPUT` emission so the re-delegate step's input is actually set. tier-1 58/74 → 58/74 (held), brand clean, `py_compile` OK. ✅ kept.
- **pages/_quests/1011/secure-coding.md** — addressed high recommendation (area: *Chapter 3 — Never Commit Secrets / detect-secrets*): `detect-secrets scan` relies on `git ls-files` and silently scans nothing outside a git repo, letting the validation pass trivially. Added `git init -q` + `git add .` before the scan with a note on why. tier-1 74/74 (100%) → 74/74 (100%) (held), brand clean. ✅ kept.

**Left (not fixed), with reasons:**

- **agentic-multi-agent-failure-recovery.md — failed command / high rec re: `${% raw %}{{ ... }}{% endraw %}` YAML tags (×6).** Left as a **false positive**: the engine read the raw Markdown source and saw the literal `{% raw %}` guards, but on the published Jekyll site these render to correct `${{ steps.run.outputs.status }}` GH Actions syntax. Removing the raw guards would make Jekyll interpret `{{ }}` as Liquid and blank the values — a real regression for the learner. No safe content-only fix; not a defect on the rendered page.
- **agentic — medium/low recs** (show explicit exponential-backoff loop code; add an artifact-upload step to `sub-agent-2`; note that `subtask.py`/`save_checkpoint.py` are inherited from Quest 15). Deferred: lower priority and larger authoring; left to keep this PR small (loop runs daily).
- **ai-feature-pipeline-architect.md — high rec "mark Chapters 2–5 snippets as illustrative or supply the missing agent classes."** Deferred: a substantial authoring task, not a smallest-edit; out of this pass's small cap. Also left: model-id currency (medium), `langchain` unused-dep removal (low), `iex`/`usermod` caution notes (low).
- **secure-coding.md — medium/low recs** (note `%s` placeholder is driver-specific; add CSP/HSTS + CI scan example or downgrade objectives; confirm OWASP Top 10 edition year). Deferred: lower priority; left for a follow-up pass.

No quest frontmatter was modified, so no `_data/quests/**` regeneration was required. No vendored quests present in this slice (none carry `source_repo:`/`source_url:`).

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/29916378064)._
