### PR TITLE
fix(config): repair broken image paths + dead sidebar nav mode

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -62,7 +62,7 @@ url                      : &url 'https://it-journey.dev' # the base hostname & p
 public_folder            : "assets"
 port                     : 4002 # Jekyll Serve Dev port
 dg_port                  : 4001 # TODO: Doppelganger site. Use this if you want to switch between parallel deployments
-og_image                 : '/images/wizard-on-journey.png'
+og_image                 : '/assets/images/wizard-on-journey.png'
 
 ### Owner Information -------------------------------------------------------------
 
@@ -88,8 +88,14 @@ local_git                : [ *home, 'github' ]
 logo                     : /assets/images/gravatar-small.png  # path of logo image to display in the masthead, e.g. "/assets/images/88x88.png"
 logo_link                : [ *url, *baseurl ] # URL to link the logo to, e.g. "/"
 
-teaser                   : /images/favicon_gpt_computer_retro.png # path of fallback teaser image, e.g. "/assets/images/500x300.png"
-info_banner              : /images/info-banner-mountain-wizard.png # path of fallback teaser image, e.g. "/assets/images/500x300.png"
+teaser                   : /assets/images/favicon_gpt_computer_retro.png # path of fallback teaser image, e.g. "/assets/images/500x300.png"
+info_banner              : /assets/images/info-banner-mountain-wizard.png # path of fallback teaser image, e.g. "/assets/images/500x300.png"
+
+# Favicon / browser identity — rendered by the theme's core/favicon.html
+# (explicit tags replace the browser's implicit /favicon.ico probe).
+favicon:
+  ico                    : /favicon.ico
+  apple_touch            : /assets/images/favicon_gpt_computer_retro.png
 breadcrumbs              : true # true, false (default)
 words_per_minute         : 200
 _posts_file_structure    : "year-month-day-title.md"
@@ -344,7 +350,7 @@ defaults:
       related: true
       toc_sticky: true
       sidebar:
-        nav: searchCats
+        nav: auto
     permalink: /:path/:name/
 
   # pages/_about


### PR DESCRIPTION
Part of the cross-repo theme-consistency review (theme PR: bamr87/zer0-mistakes#327).

## What

- **`og_image`, `teaser`, `info_banner` pointed at `/images/...`**, which doesn't exist — the assets live at `/assets/images/...` (all three files are present locally). The bad `og_image` was masked by an upstream theme bug that dropped the site-wide og:image fallback entirely (fixed in theme PR #327); once that ships, these paths must resolve or every page's `og:image` would 404.
- **`sidebar.nav: searchCats`** (pages scope) is a pre-1.x theme mode the sidebar resolver no longer recognizes (matches no `_data/navigation` file, silently disables the sidebar). Replaced with `auto`.
- **`favicon:` config block** added for the theme's new `core/favicon.html` include (theme PR #327) — ico + the local 1024px retro icon as apple-touch. The site tracks theme `main` unpinned, so it lights up on the next build after the theme merges.

## Screenshots / evidence

No before/after screenshots: CI-parity builds (`_config.yml,_config_ci.yml`) before vs after this change differ **only** in build-timestamp cache-busters — zero rendered-markup change on the current theme (the og:image fix only changes head meta once the theme PR ships; the dead nav value matched nothing that renders). No viewport regressed because no markup changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrhTG57oDiATRiSsC2nK6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrhTG57oDiATRiSsC2nK6h)_