### PR TITLE
🔧 Quest fix: developer/0001

### DIFF
--- a/pages/_quests/0001/github-pages-portal.md
+++ b/pages/_quests/0001/github-pages-portal.md
@@ -362,8 +362,13 @@ git push origin main
    # Windows: Download from rubyinstaller.org
    
    # Install Jekyll and Bundler
-   gem install jekyll bundler
+   # On a standard Linux install, a bare `gem install` hits
+   # Gem::FilePermissionError (no write access to the system gem dir).
+   # Install into your user gem path instead:
+   gem install --user-install jekyll bundler
    ```
+
+   > If you manage Ruby with `rbenv`/`rvm`, or prefer per-project gems (`bundle config set path vendor/bundle`), you can drop the `--user-install` flag — those setups already write to a user-owned location.
 
 2. **Create Jekyll Site**
    ```bash
@@ -394,7 +399,6 @@ git push origin main
    
    # Build settings
    markdown: kramdown
-   highlander: true
    plugins:
      - jekyll-feed
      - jekyll-sitemap
@@ -402,7 +406,7 @@ git push origin main
    ```
 
 5. **Create Content**
-   Update `index.md`:
+   Update `index.markdown` (the file `jekyll new` generates — not `index.md`):
    ```markdown
    ---
    layout: default

--- a/pages/_quests/0001/it-journey-stack-analysis.md
+++ b/pages/_quests/0001/it-journey-stack-analysis.md
@@ -340,7 +340,7 @@ services:
 - **Content Processing**: Various utility scripts
 
 **Key Dependencies**:
-```python
+```text
 # requirements.txt (inferred from usage)
 requests>=2.31.0      # HTTP library for link checking
 openai>=1.0.0         # OpenAI API integration
@@ -540,8 +540,13 @@ CMD ["python3", "/app/test/quest-validator/quest_validator.py"]
 #### Local Development
 
 ```bash
+# Clone the repo first — every command below runs from its root
+git clone https://github.com/bamr87/it-journey && cd it-journey
+
 # Quick Start with Docker
-docker-compose up
+# Use `docker compose` (v2 plugin). `docker-compose` (v1, hyphenated) is EOL and
+# may not exist on newer installs.
+docker compose up
 
 # Manual Jekyll Development
 bundle install
@@ -560,7 +565,7 @@ python3 test/quest-validator/quest_validator.py
 - **Link Checking**: Lychee for site-wide link validation
 
 **Pre-commit Hooks** (recommended):
-```bash
+```yaml
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -579,7 +584,7 @@ repos:
 
 ### Ruby Dependencies
 
-```ruby
+```text
 # Core Dependencies (from Gemfile.lock)
 jekyll (3.9.5)
   - Safe HTML rendering
@@ -613,7 +618,7 @@ webrick (1.8)
 
 ### Python Dependencies
 
-```python
+```text
 # Inferred from script usage
 requests (>=2.31.0)
   - HTTP library for API calls

--- a/pages/_quests/0001/personal-site.md
+++ b/pages/_quests/0001/personal-site.md
@@ -75,15 +75,15 @@ My personal website can be accessed through following domains. These sites are a
  1   | https://github.com/{% raw %}{{ site.github_user }}{% endraw %}/{% raw %}{{ site.github_user }}{% endraw %}.github.io | Source code repository
  2   | https://{% raw %}{{ site.github_user }}{% endraw %}.github.io/                      | `Domain 1`, hosted by GitHub Pages
  3   | <https://travis-ci.org/>                             | CI/CD for {% raw %}{{ site.github_user }}{% endraw %}.github.io
- 4   | https://{% raw %}{{ site.github_user }}{% endraw %}.netlify.com/                    | `Domain 2`, hosted by Netlify
- 5   | <https://www.netlify.com/>                           | CI/CD for {% raw %}{{ site.github_user }}{% endraw %}.netlify.com
+ 4   | https://{% raw %}{{ site.github_user }}{% endraw %}.netlify.app/                    | `Domain 2`, hosted by Netlify
+ 5   | <https://www.netlify.com/>                           | CI/CD for {% raw %}{{ site.github_user }}{% endraw %}.netlify.app
  6   | https://{% raw %}{{ site.github_user }}{% endraw %}.github.io/                             | `Domain 3`, hosted by Cloudflare
  7   | <https://www.cloudflare.com/>                        | CDN for {% raw %}{{ site.github_user }}{% endraw %}.github.io
  8   | <https://www.godaddy.com/>                           | Domain service for {% raw %}{{ site.github_user }}{% endraw %}.github.io
  9   | <https://sharethis.com/>                             | Share buttons
  10  | <https://disqus.com/>                                | Comments service
  11  | <https://analytics.google.com>                       | Track website traffic
- 12  | <https://jekyllrb.com/>                              | Comments service
+ 12  | <https://jekyllrb.com/>                              | Static site generator
  13  | <https://highlightjs.org/>                           | Syntax highlighting
  14  | <https://www.mathjax.org/>                           | JS engine for mathematics
  15  | <https://mermaidjs.github.io/>                       | Charts generated from text via JavaScript

--- a/pages/_quests/0001/self-operating-website-01-the-summoning.md
+++ b/pages/_quests/0001/self-operating-website-01-the-summoning.md
@@ -121,6 +121,7 @@ remote_theme: bamr87/zer0-mistakes
 plugins:
   - jekyll-remote-theme
   - jekyll-seo-tag
+  - jekyll-include-cache
 ```
 
 Declare the build dependencies so the same site renders identically on your machine and in CI:
@@ -132,8 +133,11 @@ gem "jekyll", "~> 4.3"
 group :jekyll_plugins do
   gem "jekyll-remote-theme"
   gem "jekyll-seo-tag"
+  gem "jekyll-include-cache"
 end
 ```
+
+The `jekyll-include-cache` gem is required: the `bamr87/zer0-mistakes` root layout uses the `include_cached` tag, and the build fails with a `Liquid::SyntaxError` (`Unknown tag 'include_cached'`) without it.
 
 Every construct needs a face. The remote theme supplies the layouts, but your repo still needs an entry page that picks one. A minimal `index.md` is all it takes — front matter that names a layout the theme provides, plus a heading:
 

--- a/pages/_quests/0001/seo-optimization.md
+++ b/pages/_quests/0001/seo-optimization.md
@@ -149,6 +149,9 @@ This **🟢 Easy** quest expects:
 # In an existing Jekyll site, add the SEO and sitemap plugins
 cd ~/my-site
 bundle add jekyll-seo-tag jekyll-sitemap
+# `bundle add` only edits the Gemfile — Jekyll won't load the plugins until you
+# also add them to the `plugins:` list in _config.yml (see Chapter 2). Without
+# that step, /sitemap.xml is never generated.
 bundle exec jekyll serve
 
 # View the generated metadata
@@ -170,6 +173,9 @@ open http://127.0.0.1:4000/
 # In an existing Jekyll site, add the SEO and sitemap plugins
 cd $HOME\my-site
 bundle add jekyll-seo-tag jekyll-sitemap
+# `bundle add` only edits the Gemfile — Jekyll won't load the plugins until you
+# also add them to the `plugins:` list in _config.yml (see Chapter 2). Without
+# that step, /sitemap.xml is never generated.
 bundle exec jekyll serve
 
 Start-Process http://127.0.0.1:4000/
@@ -190,6 +196,9 @@ Start-Process http://127.0.0.1:4000/
 # In an existing Jekyll site, add the SEO and sitemap plugins
 cd ~/my-site
 bundle add jekyll-seo-tag jekyll-sitemap
+# `bundle add` only edits the Gemfile — Jekyll won't load the plugins until you
+# also add them to the `plugins:` list in _config.yml (see Chapter 2). Without
+# that step, /sitemap.xml is never generated.
 bundle exec jekyll serve
 xdg-open http://127.0.0.1:4000/
 ```


### PR DESCRIPTION
## 🔧 Quest fix — `developer/0001`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: developer/0001

Evidence: execute-mode, non-truncated (`truncated=null`), `errored=0`, all 5 results `executed=true` — M7 honest-run gate satisfied, so fixes applied. Verdicts: 3 `fail` + 2 `warn`. All kept edits gated on tier-1 `quest_validator.py` (held-or-rises) + `brand_lint` (clean); the agentic `overall` was **not** used to keep anything. No frontmatter touched → no `_data/quests` regen.

**Kept edits**

- **pages/_quests/0001/self-operating-website-01-the-summoning.md** — fixed verified failed command `bundle exec jekyll build` (`Liquid::SyntaxError: Unknown tag 'include_cached'`) + high recommendation (area: Chapter 1 Gemfile/_config.yml): added `gem "jekyll-include-cache"` to the Gemfile `:jekyll_plugins` group and the `_config.yml` `plugins:` list, plus a one-line prose note. tier-1 score 70/74 (94.6%) → 70/74 (94.6%) held, brand clean. ✅ kept.
- **pages/_quests/0001/github-pages-portal.md** — three surgical fixes: (1) high rec + failed command `index.md content` — corrected filename to `index.markdown` (what `jekyll new` actually generates); (2) high rec + failed command `gem install jekyll bundler` (`Gem::FilePermissionError`) — switched to `gem install --user-install …` with an rbenv/rvm/bundle-path note; (3) medium rec — removed the fabricated `highlander: true` key from the `_config.yml` example. tier-1 74/74 (100.0%) → 74/74 (100.0%) held, brand clean. ✅ kept.
- **pages/_quests/0001/it-journey-stack-analysis.md** — five fixes for verified failed commands: relabeled three mislabeled fences (```python`→```text` for the requirements.txt block and the pip dependency list; ```ruby`→```text` for the Gemfile.lock-style list; ```bash`→```yaml` for `.pre-commit-config.yaml`) and hardened the Quick Start block (high rec) — prepended `git clone https://github.com/bamr87/it-journey && cd it-journey` and switched `docker-compose up` → `docker compose up` (v1 EOL). tier-1 63/74 (85.1%) → 63/74 (85.1%) held, brand clean. ✅ kept.
- **pages/_quests/0001/seo-optimization.md** — high + medium rec (sitemap gotcha): after each `bundle add jekyll-seo-tag jekyll-sitemap` (macOS/Windows/Linux path blocks), added a note that `bundle add` alone does not register the plugins and they must be added to the `_config.yml` `plugins:` list (Chapter 2) or `/sitemap.xml` is never generated. tier-1 74/74 (100.0%) → 74/74 (100.0%) held, brand clean. ✅ kept.
- **pages/_quests/0001/personal-site.md** — two high content_accuracy fixes: relabeled the `jekyllrb.com` row from "Comments service" to "Static site generator" (was a duplicate mislabel of the Disqus row), and updated the outdated `<user>.netlify.com` user subdomain to `<user>.netlify.app` (rows 4–5). tier-1 53/69 (76.8%) → 53/69 (76.8%) held, brand clean. ✅ kept.

**Left (out of scope for smallest content-only edit / handful cap):**

- github-pages-portal: high rec "add real custom-domain steps or drop the claim", medium rec "add multi-page/nav section", medium rec "note github-pages gem Jekyll version pin", medium rec Chapter 1→3 index.html-vs-index.markdown conflict warning, low rec "separate validation-checklist/kaizen metadata" — each needs substantive new authoring rather than a surgical fix; left for a human authoring pass.
- it-journey-stack-analysis: high recs "replace auto-seeded objectives" and "add real hands-on steps or reclassify", medium rec "add github_token to peaceiris step", low recs (SRI hash how-to, prerequisites/XP block), and the illustrative `LinkHealthGuardian` pseudocode failure — larger rewrites, out of scope.
- personal-site: high rec "replace the whole link-table page with real step-by-step GitHub Pages instructions", the contradictory duplicate GitHub Pages/Cloudflare URL rows, unprocessed `{% raw %}` rendering, medium auto-seeded-objectives placeholder, low Travis→GitHub Actions swap — this quest (overall 16) needs a substantive rewrite beyond a smallest-edit pass.
- seo-optimization: low recs (adjust Chapter 1 example description length, explain `:jekyll_plugins` auto-require mechanics) and medium reordering — deferred; the high-priority sitemap defect is fixed.
- self-operating-website-01-the-summoning: medium rec (pass `base_path` into the Actions build) and two low recs (concrete first-PR git sequence, Knowledge Check answers) — deferred; the build-breaking defect is fixed.

_No vendored quests encountered (none carry `source_repo:`/`source_url:`). No edits were reverted by the M1 gate._

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/30003953368)._
