### PR TITLE
🔧 Quest fix: security-specialist/1011

### DIFF
--- a/pages/_quests/1011/agentic-behavior-tuning.md
+++ b/pages/_quests/1011/agentic-behavior-tuning.md
@@ -125,8 +125,11 @@ RECORDED=0
 for TASK_NUM in 1 2 3; do
     echo "Measuring task $TASK_NUM..."
     
-    # Get the latest agent run for this task (degrade gracefully if none exists yet)
-    RUN_ID=$(gh run list --workflow=agent-task.yml --limit=1 --json databaseId -q '.[0].databaseId' 2>/dev/null || true)
+    # Get the latest agent run for THIS task by matching its branch
+    # (copilot/issue-{N}-{slug}); a bare --limit=1 would return the same
+    # newest run for every task. Degrade gracefully if none exists yet.
+    RUN_ID=$(gh run list --workflow=agent-task.yml --limit=50 --json databaseId,headBranch \
+        -q "[.[] | select(.headBranch | startswith(\"copilot/issue-$TASK_NUM-\"))][0].databaseId" 2>/dev/null || true)
     if [ -z "$RUN_ID" ]; then
         echo "⚠️  No agent-task.yml run found for task $TASK_NUM — run the agent workflow at least once, then re-run this script."
         continue

--- a/pages/_quests/1011/agentic-multi-agent-observability.md
+++ b/pages/_quests/1011/agentic-multi-agent-observability.md
@@ -95,6 +95,7 @@ graph LR
 
 Every multi-agent operation needs a single identifier that travels through every agent:
 
+{% raw %}
 ```yaml
 # .github/workflows/orchestrator-with-tracing.yml
 name: Multi-Agent with Observability
@@ -107,13 +108,13 @@ jobs:
   orchestrate:
     runs-on: ubuntu-latest
     outputs:
-      correlation_id: ${% raw %}{{ steps.init_trace.outputs.correlation_id }}{% endraw %}
+      correlation_id: ${{ steps.init_trace.outputs.correlation_id }}
     steps:
       - name: Initialise correlation ID
         id: init_trace
         run: |
           # Create a unique correlation ID for this entire multi-agent operation
-          CORRELATION_ID="task-${% raw %}{{ github.event.issue.number }}{% endraw %}-${% raw %}{{ github.run_id }}{% endraw %}"
+          CORRELATION_ID="task-${{ github.event.issue.number }}-${{ github.run_id }}"
           echo "correlation_id=$CORRELATION_ID" >> "$GITHUB_OUTPUT"
           echo "🔗 Correlation ID: $CORRELATION_ID"
 
@@ -121,7 +122,7 @@ jobs:
     needs: orchestrate
     runs-on: ubuntu-latest
     env:
-      CORRELATION_ID: ${% raw %}{{ needs.orchestrate.outputs.correlation_id }}{% endraw %}
+      CORRELATION_ID: ${{ needs.orchestrate.outputs.correlation_id }}
     steps:
       - name: Execute with tracing
         run: |
@@ -134,9 +135,10 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: trace-${% raw %}{{ env.CORRELATION_ID }}{% endraw %}-analysis
-          path: "trace-analysis-${% raw %}{{ env.CORRELATION_ID }}{% endraw %}.jsonl"
+          name: trace-${{ env.CORRELATION_ID }}-analysis
+          path: "trace-analysis-${{ env.CORRELATION_ID }}.jsonl"
 ```
+{% endraw %}
 
 > **`traced_subtask.py` is a thin wrapper you author around `trace_writer.py`.**
 > The workflow above calls `work/gh-600/scripts/traced_subtask.py`, which is not a

--- a/pages/_quests/1011/security-fundamentals.md
+++ b/pages/_quests/1011/security-fundamentals.md
@@ -233,8 +233,10 @@ Here is the integrity pillar made concrete. A checksum lets you detect if a file
 # Compute a SHA-256 hash of a downloaded artifact
 sha256sum app-release.tar.gz
 
-# Compare it to the publisher's published hash. If they differ,
-# the file's integrity is compromised - do not trust it.
+# Compare it to the publisher's published hash. Replace EXPECTED_HASH with the
+# actual 64-character hex hash the publisher provides before running this - a
+# placeholder errors with "no properly formatted checksum lines found".
+# If the hashes differ, the file's integrity is compromised - do not trust it.
 echo "EXPECTED_HASH  app-release.tar.gz" | sha256sum --check
 ```
 
@@ -310,9 +312,12 @@ If an attacker defeats the firewall, identity and encryption still stand. No sin
 
 ```sql
 -- ❌ Over-privileged: the app login can read AND drop tables
+-- MySQL 8.0+ no longer auto-creates the account via GRANT, so create it first.
+CREATE USER 'app_user'@'%' IDENTIFIED BY 'a-strong-password';
 GRANT ALL PRIVILEGES ON shop.* TO 'app_user'@'%';
 
 -- ✅ Least privilege: the app can only read and write the rows it serves
+CREATE USER 'app_user'@'10.0.%' IDENTIFIED BY 'a-strong-password';
 GRANT SELECT, INSERT, UPDATE, DELETE ON shop.orders TO 'app_user'@'10.0.%';
 GRANT SELECT ON shop.products TO 'app_user'@'10.0.%';
 ```


### PR DESCRIPTION
## 🔧 Quest fix — `security-specialist/1011`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: security-specialist/1011

Evidence honest & verified: execute-mode, non-truncated, all 5 results `executed==true`, 0 errored. Acted on the 3 `warn` quests only; the 2 `pass` quests were left untouched. No vendored quests in this slice.

- **pages/_quests/1011/security-fundamentals.md** — fixed failed command `GRANT ... TO 'app_user'@'%'` (verified: `commands[].status=failed` — MySQL 8.0+ rejects implicit user creation via GRANT) + high-priority recommendation (area: *Chapter 3 SQL example (least privilege)*). Added `CREATE USER 'app_user'@'%'` / `@'10.0.%'` before the GRANTs with a note. tier-1 score_pct 100.0 → 100.0 (held), brand clean. ✅ kept.
- **pages/_quests/1011/security-fundamentals.md** — fixed failed command `echo "EXPECTED_HASH ..." | sha256sum --check` (verified: `commands[].status=failed` — literal placeholder errors with "no properly formatted checksum lines found") + medium recommendation (area: *Chapter 1 sha256sum --check example*). Added a comment instructing the learner to substitute the real 64-hex hash before running. tier-1 score_pct 100.0 → 100.0 (held), brand clean. ✅ kept.
- **pages/_quests/1011/agentic-multi-agent-observability.md** — fixed failed command (verified: `commands[].status=failed` — Chapter 1 YAML workflow with leaked `${% raw %}{{ X }}{% endraw %}` tags, 5 occurrences) + high recommendation (area: *Chapter 1 YAML workflow*). Wrapped the whole fenced block in a single `{% raw %}`/`{% endraw %}` pair (matching the sibling orchestration-patterns quest's convention) and restored plain `${{ X }}` expressions — now valid, copy-pasteable GitHub Actions syntax. tier-1 score_pct 78.4 → 78.4 (held), brand clean, 0 raw leaks remain. ✅ kept.
- **pages/_quests/1011/agentic-behavior-tuning.md** — addressed high recommendation (area: *Exercise 13.1 script logic*). Replaced the per-task `gh run list --limit=1` (which returned the same newest run for tasks 1/2/3) with a `headBranch startswith("copilot/issue-$TASK_NUM-")` filter matching the quest's own branch-naming convention. tier-1 score_pct 78.4 → 78.4 (held), brand clean. ✅ kept.

_Left (out of minimal scope / larger authoring, not defects with a failed-command signal):_
- security-fundamentals.md — 3 recs: add a likelihood×impact risk-matrix section (medium), repeat the "never expose vulnerable apps publicly" safety warning across OS setup sections (medium), date-caveat the OWASP "current edition" phrasing (low).
- agentic-behavior-tuning.md — high rec to add a runnable AGENTS.md-editing step + a matching Quest Validation check (substantive new content), plus medium/low recs (iteration-log destination path, PR-search convention, re-run baseline step).
- agentic-multi-agent-observability.md — medium/low recs (artifact download-artifact hand-off between chapters, `traced_subtask.py` starter stub, link/describe `validate_quest.py`).

_Reverts:_ none. _Vendored skips:_ none. _Frontmatter touched:_ none (no `make quest-data` needed).

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/30090038199)._
