### PR TITLE
🔧 Quest fix: developer/0001

### DIFF
--- a/pages/_quests/0001/barodybroject-stack-analysis.md
+++ b/pages/_quests/0001/barodybroject-stack-analysis.md
@@ -668,9 +668,13 @@ python3 -m venv .venv
 source .venv/bin/activate
 pip install -r src/requirements.txt
 cd src
-# The project defaults to PostgreSQL (DB_CHOICE=postgres). For a quick local run
-# with no database server, use SQLite instead so `migrate` works out of the box:
-export DB_CHOICE=sqlite
+# NOTE: This project now requires PostgreSQL. The old SQLite quick-run fallback
+# (DB_CHOICE=sqlite) has been removed, so `migrate` raises ImproperlyConfigured
+# without a database. Keep the Docker Compose stack from Option 1 running (it
+# provides PostgreSQL), then export the connection variables it uses — copy the
+# DB_HOST / DB_NAME / DB_USERNAME / DB_PASSWORD values from
+# .devcontainer/docker-compose_dev.yml before migrating, for example:
+export DB_HOST=localhost DB_NAME=barodybroject DB_USERNAME=postgres DB_PASSWORD=postgres
 python manage.py migrate
 python manage.py runserver
 

--- a/pages/_quests/0001/building-testing-git-init-script.md
+++ b/pages/_quests/0001/building-testing-git-init-script.md
@@ -162,7 +162,7 @@ shellcheck scripts/git_init.sh
 - `bats tests/bats/test_headless.bats` returns pass for headless creation
 - `--gitignore` creates a `.gitignore` file when requested
 - `--scaffold python` creates `src` and `tests`
- - `--dry-run` prints operations and does not create files or push
+- `--dry-run` prints operations and does not create files or push
 
 ## Next Steps (Optional)
 


### PR DESCRIPTION
## 🔧 Quest fix — `developer/0001`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: developer/0001

Honest-run gate passed: all 5 results `mode==execute`, non-truncated, `executed==true`, `errored==0`. Acted on the 2 `fail` quests only (`advanced-markdown`, `css-styling-basics`, `bootstrap-framework` all passed — untouched). Neither edited quest is vendored.

- **pages/_quests/0001/barodybroject-stack-analysis.md** — fixed the HIGH failed command (verified: `commands[].status==failed` on the Quick Setup block + high-priority recommendation, area "Quick Setup bash block"). The live repo removed the `DB_CHOICE=sqlite` fallback and `migrate` now raises `ImproperlyConfigured`; replaced the broken SQLite lines with the supported PostgreSQL path (Docker Compose from Option 1 provides the DB) and the `DB_HOST/DB_NAME/DB_USERNAME/DB_PASSWORD` variables the error names, sourced from `.devcontainer/docker-compose_dev.yml`. tier-1 score_pct 71.6 → 71.6 (held), brand clean. ✅ kept.
- **pages/_quests/0001/building-testing-git-init-script.md** — fixed the LOW recommendation (area "Acceptance Criteria formatting"): removed the stray leading space on the `--dry-run` bullet so it renders as a sibling list item, not nested. tier-1 score_pct 78.4 → 78.4 (held), brand clean. ✅ kept.

_Left (not fixed):_
- **git-init — HIGH "Missing core asset scripts/git_init.sh" + HIGH "Acceptance criteria verifiability"** — the core defect is that `scripts/git_init.sh` does not exist in the repo, so every runnable command 127s. Fixing it requires shipping a file under `scripts/**`, which is **outside the content-only writable surface** (`pages/_quests/**`). Left for a human / non-content change. The quest already carries a prominent "Get the script first" warning block, so no content edit can make it functional today.
- **git-init — MEDIUM "'Try it locally' fetch-step guard"** — left; a `test -f` guard would only paper over the missing-script defect above, and does not move the deterministic tier-1 signal.
- **barodybroject — 3 MEDIUM + 1 LOW recommendations** (operationalize the "assess drift" objective into an exercise, add sample pip-audit output/triage, split read/do sections + add a final validation step, label settings.py excerpts) — left as out of the small per-slice cap; each is an authoring expansion rather than a witnessed broken command, and can be picked up on a later pass.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/30264458312)._
