### PR TITLE
🔧 Quest fix: security-specialist/1011

### DIFF
--- a/pages/_quests/1011/agentic-behavior-tuning.md
+++ b/pages/_quests/1011/agentic-behavior-tuning.md
@@ -110,8 +110,24 @@ set -euo pipefail
 
 RESULTS_FILE="work/gh-600/baseline-results.jsonl"
 RUN_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+mkdir -p "$(dirname "$RESULTS_FILE")"
 
 echo "=== Agent Behaviour Baseline Measurement ==="
+
+# No agent-task.yml history yet? Pass --seed to write three synthetic sample
+# records so you can complete the iteration cycle and pass Quest Validation now,
+# then re-run WITHOUT --seed once real agent runs exist to capture live data.
+if [ "${1:-}" = "--seed" ]; then
+    : > "$RESULTS_FILE"
+    for TASK_NUM in 1 2 3; do
+        cat >> "$RESULTS_FILE" << EOF
+{"date":"$RUN_DATE","task":$TASK_NUM,"run_id":"seed","pr_opened":false,"tests_passed":false,"seed":true}
+EOF
+    done
+    echo "✅ Seed baseline written to $RESULTS_FILE (3 synthetic records)."
+    echo "   Re-run without --seed once real agent-task.yml runs exist."
+    exit 0
+fi
 
 RECORDED=0
 
@@ -153,6 +169,8 @@ fi
 echo "✅ Baseline recorded ($RECORDED task(s)) in $RESULTS_FILE"
 ```
 
+> **No agent history yet?** If you haven't yet run an `agent-task.yml` workflow (or you completed [Q12](/quests/1010/agentic-failure-root-cause-analysis/) on a different repo), run `bash work/gh-600/scripts/measure_agent_baseline.sh --seed` to write three synthetic sample records. This lets you finish the iteration cycle and pass Quest Validation now; re-run without `--seed` once real agent runs exist to replace the seed data with live measurements.
+
 ---
 
 ### Chapter 2 — Instruction Change Patterns
@@ -166,6 +184,26 @@ Based on common agent failure patterns, here are the most impactful instruction 
 | Agent creates vague commit messages | Specify commit message format exactly | Improves traceability |
 | Agent opens PR too early | Define PR readiness criteria | Reduces draft PR churn |
 | Agent re-reads files it's already read | Add "mark as read" memory convention | Reduces redundant actions |
+
+> **Exercise 13.1b:** Actually apply an instruction change. Pick one row from the table above and edit the real files — this is the hands-on core of Objective 3, not just a log entry. Example, enforcing the mandatory planning step and traceable branches:
+
+**`copilot-instructions.md`** — add the planning rule:
+
+```markdown
+## Workflow
+- **PLAN FIRST:** post a short plan (files to touch, ordered steps) before editing any file.
+- Implement the fix only after the plan is posted.
+```
+
+**`AGENTS.md`** — add the branch-naming rule:
+
+```markdown
+## Branch naming
+Branch name MUST follow: `copilot/issue-{N}-{3-5-word-slug}`
+Example: `copilot/issue-42-add-input-validation`
+```
+
+Commit both edits before you continue — Chapter 3 measures their impact and Quest Validation confirms the files changed.
 
 ---
 
@@ -245,7 +283,11 @@ ls docs/agent-instructions/*.md >/dev/null 2>&1 \
   && echo "✅ Iteration log: iteration records in docs/agent-instructions/"
 test -f docs/agent-instructions/CHANGELOG.md \
   && echo "✅ Instruction changelog: CHANGELOG.md present"
-# 🏆 Quest Q13 complete when all three checks print ✅
+grep -q "copilot/issue-" AGENTS.md 2>/dev/null \
+  && echo "✅ Instruction change: AGENTS.md carries the new branch-naming rule"
+grep -qi "plan first" copilot-instructions.md 2>/dev/null \
+  && echo "✅ Instruction change: copilot-instructions.md carries the new planning rule"
+# 🏆 Quest Q13 complete when all checks print ✅
 ```
 
 ## 🏆 Quest Rewards

--- a/pages/_quests/1011/agentic-multi-agent-observability.md
+++ b/pages/_quests/1011/agentic-multi-agent-observability.md
@@ -140,12 +140,13 @@ jobs:
 ```
 {% endraw %}
 
-> **`traced_subtask.py` is a thin wrapper you author around `trace_writer.py`.**
+> **`traced_subtask.py` is a thin CLI wrapper around `trace_writer.py`.**
 > The workflow above calls `work/gh-600/scripts/traced_subtask.py`, which is not a
 > separate tool — it runs your sub-task and emits trace entries using the
-> `trace_writer.py` module defined in Chapter 2. If you'd rather keep the example
-> fully self-contained, call `trace_writer.py` directly instead. Either way the
-> script must exist under `work/gh-600/scripts/` before the workflow runs.
+> `trace_writer.py` module defined in Chapter 2. Its full code is given at the end of
+> Chapter 2 so the workflow's `run:` step produces the exact `--output` file that the
+> `upload-artifact` step then uploads. Both scripts must exist under
+> `work/gh-600/scripts/` before the workflow runs.
 
 ---
 
@@ -203,6 +204,38 @@ if __name__ == "__main__":
     write_trace(cid, "analysis-agent", "write-report", "completed",
                 {"report_path": "analysis-report.json"},
                 f"trace-{cid}.jsonl")
+```
+
+The workflow in Chapter 1 invokes the wrapper below, which accepts the exact `--correlation-id`, `--subtask`, and `--output` flags the `run:` step passes and writes to that `--output` path:
+
+```python
+# work/gh-600/scripts/traced_subtask.py
+"""Thin CLI wrapper: runs a sub-task and emits trace entries via trace_writer."""
+
+import argparse
+
+from trace_writer import write_trace
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--correlation-id", required=True)
+    parser.add_argument("--subtask", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    agent_id = f"{args.subtask}-agent"
+    write_trace(args.correlation_id, agent_id, args.subtask, "started",
+                output_file=args.output)
+
+    # ... your real sub-task work happens here ...
+
+    write_trace(args.correlation_id, agent_id, args.subtask, "completed",
+                {"subtask": args.subtask}, args.output)
+
+
+if __name__ == "__main__":
+    main()
 ```
 
 ---


### PR DESCRIPTION
## 🔧 Quest fix — `security-specialist/1011`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: security-specialist/1011

Evidence honest-run gate passed: `mode=execute`, all 5 results `executed=true`, not truncated, 0 errored. Acted only on the 3 `warn` quests' verified issues (failed commands + recommendations). The 2 `pass` quests were left untouched.

**pages/_quests/1011/agentic-behavior-tuning.md** (warn) — tier-1 `score_pct 78.4 → 78.4` (held), brand clean. ✅ kept.
- Fixed the two failed commands (`measure_agent_baseline.sh` + Quest Validation self-check) and the **high** rec _(Exercise 13.1 / Quest Validation dependency)_: the baseline script exited 1 and never wrote `baseline-results.jsonl` without pre-existing GH Actions history, so validation could never pass. Added the rec's suggested bootstrap — a `--seed` mode that writes three synthetic sample records (plus a `mkdir -p` for the output dir) and a prose note pointing learners without history to it. Verified: `bash …/measure_agent_baseline.sh --seed` now exits 0 and creates the file the validation `test -f` check requires.
- Addressed the **high** rec _(Objective 3 — Implement instruction changes)_: added hands-on **Exercise 13.1b** where the learner actually edits `copilot-instructions.md` and `AGENTS.md` (concrete before/after rule text), so the stated objective has a real exercise, not just a narrative log entry.
- Addressed the **medium** rec _(Quest Validation checklist)_: added two `grep` checks confirming the instruction files were actually modified, so the checklist matches the objectives.

**pages/_quests/1011/agentic-multi-agent-observability.md** (warn) — tier-1 `score_pct 78.4 → 78.4` (held), brand clean. ✅ kept.
- Addressed the **high** rec _(Chapter 1 callout / traced_subtask.py)_: the workflow called an undefined `traced_subtask.py`, and the documented "call `trace_writer.py` directly" fallback was confirmed broken (ignored the CLI flags, wrong filename). Provided the actual `traced_subtask.py` wrapper — real `argparse` for `--correlation-id/--subtask/--output` that writes to the exact `--output` path the `upload-artifact` step references — and corrected the callout to point at it (dropping the broken fallback advice). Verified: the extracted wrapper runs against `trace_writer.py` and produces the referenced artifact file.

_Left (out of scope for this pass / kept PR small):_
- **pages/_quests/1011/agentic-multi-agent-orchestration-patterns.md** (warn) — only medium/low pedagogical recommendations, no failed commands (dead `task_description` input, missing event-driven exercise, existence-only validation, no reference `partition_task.py`). Left for a future daily pass to keep this PR small and reviewable.
- The **low** recs on the two edited quests (prerequisite deep-links; relabeling worked examples; label-filtered workflow trigger) — deferred; none blocks the learner's success chain.

_No frontmatter changed, so no `_data/quests/**` regeneration needed. No vendored quests present (none carry `source_repo`/`source_url`)._

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/30264458312)._
