### PR TITLE
🔧 Quest fix: system-engineer/0101

### DIFF
--- a/pages/_quests/0101/deployment-pipelines.md
+++ b/pages/_quests/0101/deployment-pipelines.md
@@ -191,11 +191,24 @@ gh api repos/:owner/:repo/environments
 <details>
 <summary>Click to expand Cloud/Container instructions</summary>
 
+This snippet assumes a `Dockerfile` already exists in the repo root. If you are starting from an empty repo, create a minimal one first so the `docker build` below has something to build:
+
+```dockerfile
+# Dockerfile — a minimal, buildable example
+FROM alpine:3.20
+CMD ["echo", "hello from myapp"]
+```
+
 ```bash
 # Containers make promotion trivial: the SAME image tag moves between envs.
-docker build -t myapp:$(git rev-parse --short HEAD) .
-# Push once; deploy the identical digest to staging, then production.
-docker tag myapp:$(git rev-parse --short HEAD) registry.example.com/myapp:staging
+SHA=$(git rev-parse --short HEAD)
+docker build -t myapp:$SHA .
+# Push the image once, then promote that identical digest — never rebuild between envs.
+docker tag myapp:$SHA registry.example.com/myapp:staging
+docker push registry.example.com/myapp:staging
+# Promote the same artifact to production by re-tagging the staging image (no rebuild).
+docker tag registry.example.com/myapp:staging registry.example.com/myapp:production
+docker push registry.example.com/myapp:production
 ```
 
 > The golden rule of promotion: build once, deploy the same artifact everywhere. Never rebuild between staging and production, or you have not tested what you ship.

--- a/pages/_quests/0101/self-operating-website-08-the-cartographer.md
+++ b/pages/_quests/0101/self-operating-website-08-the-cartographer.md
@@ -95,6 +95,7 @@ Before you draw your first fault line, make sure your pack is stocked:
 
 - **Prior chapter:** Complete [Chapter VII — The Named Familiars](/quests/1101/self-operating-website-07-the-named-familiars/). This quest assumes you already have a working autonomous repo with named agents.
 - **Tools:** Git, a text editor or IDE, and a local Ruby/Jekyll toolchain (`bundle exec jekyll build` must run) so you can reproduce builds. A terminal with Bash for the triage script.
+- **Gemfile plugins:** The `bamr87/zer0-mistakes` theme relies on supporting plugins — at minimum `jekyll-remote-theme`, `jekyll-seo-tag`, and `jekyll-include-cache`. If you are reconstructing the environment from scratch rather than continuing an existing repo, a bare Gemfile will fail the build with unrelated `Unknown tag seo` / `Unknown tag include_cached` Liquid errors that have nothing to do with the bug you are triaging.
 - **Accounts:** A GitHub account and a repository you own. To file upstream you'll also need access to the upstream repo's issue tracker (for IT-Journey that's `bamr87/zer0-mistakes` — public, so you can open issues without special permissions).
 - **Optional:** A Claude Code OAuth token if you want the agent steps to draft repro notes for you.
 
@@ -117,31 +118,40 @@ set -euo pipefail
 echo "==> 1. Build with the full product (your repo as-is)"
 bundle exec jekyll build --trace 2>&1 | tee build-product.log || true
 
-echo "==> 2. Build a minimal page against the bare theme"
-# NOTE: do NOT put the repro in a hidden .triage/ dir — Jekyll skips dotdirs
-# by default, so the page would never build. Use a visible directory instead.
-mkdir -p triage && cat > triage/min.md <<'EOF'
+echo "==> 2. Build a minimal page against the bare theme, in an ISOLATED site"
+# Build from a throwaway source dir that shares ONLY the remote_theme — none of your
+# product's _config.yml, plugins, includes, or pages. Adding the repro into your own
+# repo and rebuilding just makes the two logs near-identical (the whole site plus one
+# page), so it never isolates anything. A separate --source/--config does.
+MINIMAL_DIR="$(mktemp -d)"
+cat > "$MINIMAL_DIR/_config.yml" <<'EOF'
+remote_theme: bamr87/zer0-mistakes
+plugins:
+  - jekyll-remote-theme
+EOF
+cat > "$MINIMAL_DIR/index.md" <<'EOF'
 ---
 layout: default
 title: Minimal Repro
-permalink: /triage/min/
 ---
 Just the theme. No custom includes, no custom CSS.
 EOF
-bundle exec jekyll build --trace 2>&1 | tee build-minimal.log || true
+bundle exec jekyll build --config "$MINIMAL_DIR/_config.yml" \
+  --source "$MINIMAL_DIR" --destination "$MINIMAL_DIR/_site" --trace 2>&1 \
+  | tee build-minimal.log || true
 
 echo "==> 3. Compare: if the bug appears in BOTH, it is a PLATFORM bug."
 echo "    If it only appears in build-product.log, it is a PRODUCT bug."
 grep -iE 'error|warning' build-product.log build-minimal.log || echo "No errors in either build."
 ```
 
-> If your build config (`_config.yml`) uses an `include:`/`exclude:` list that hides the `triage/` directory, add `triage` to `include:` so the minimal page is actually rendered. The point is the same: the minimal page must reach the build.
+> Because the minimal build uses its own `--source` and `--config`, none of your product's `_config.yml`, `include:`/`exclude:` lists, plugins, or pages apply — that is exactly what makes it a fair test of the bare theme. If the same failure still appears in `build-minimal.log`, your repo is no longer a suspect.
 
 If the minimal page reproduces the failure, you've drawn the fault line: it runs through the bedrock, not your construction. Document the exact commit of the theme you're on (`remote_theme: bamr87/zer0-mistakes@<sha>`), because "it broke" without a version is a map with no coordinates.
 
 **Finding the theme `<sha>`.** The remote theme is resolved to a specific commit at build time. To pin it precisely, you can:
 
-- Run `bundle exec gem contents jekyll-remote-theme` to locate the gem and inspect what it fetched, then check the theme's working copy under your cache.
+- Run `bundle exec jekyll build --verbose` and grep the output for `Downloading` — `jekyll-remote-theme` logs the exact `zip/<ref>` it fetches. (Note: `gem contents jekyll-remote-theme` only lists the plugin's own source files; the theme itself is fetched to a temp dir that is deleted after each build, so there is no persistent cache to inspect.)
 - Read your `Gemfile.lock` — it pins the gem versions involved in resolving the theme.
 - Check the upstream theme repo's commit history (`bamr87/zer0-mistakes`) and record the commit your build pulled (the latest on the branch your `remote_theme:` points at, at build time).
 

--- a/pages/_quests/0101/testing-integration.md
+++ b/pages/_quests/0101/testing-integration.md
@@ -270,7 +270,16 @@ test('total of an empty cart is zero', () => {
 
 ### 🏗️ Define the Three Test Scripts
 
-Before the pipeline can call them, create the three npm scripts every job below references. Each stage maps to the folder that holds its tests:
+Each script points at the folder that holds its tests, so first create those folders and move the unit test from Chapter 1 into `test/unit/`. Because `total.test.js` now sits two levels down, update its import to reach back up to `total.js`:
+
+```bash
+mkdir -p test/unit test/integration test/e2e
+mv total.test.js test/unit/total.test.js
+# total.js stays at the project root, so fix the import path in the moved test:
+sed -i "s#from './total.js'#from '../../total.js'#" test/unit/total.test.js
+```
+
+Now define the three npm scripts every job below references:
 
 ```bash
 npm pkg set scripts.test:unit="node --test test/unit"
@@ -278,7 +287,7 @@ npm pkg set scripts.test:integration="node --test test/integration"
 npm pkg set scripts.test:e2e="node --test test/e2e"
 ```
 
-Now `npm run test:unit` (and its `test:integration` and `test:e2e` siblings) run locally exactly as the CI jobs invoke them - without this step, `npm run test:unit` fails with `Missing script: "test:unit"`.
+Now `npm run test:unit` (and its `test:integration` and `test:e2e` siblings) run locally exactly as the CI jobs invoke them - without the folders, the move, and this step, `npm run test:unit` fails with either `Missing script: "test:unit"` or `Could not find '.../test/unit'`.
 
 ### 🏗️ A Gated, Tiered Pipeline
 
@@ -381,7 +390,10 @@ The operational playbook: **detect** by re-running failures, **quarantine** a kn
 ```yaml
 # Run the runner in a reporting mode that exposes flakiness rather than hiding it.
 # A test that passes only on retry should be logged and fixed, not trusted.
-      - run: npm run test:unit -- --test-reporter=tap
+# Call node --test directly so the flag lands BEFORE the test path; passing it via
+# `npm run test:unit -- --test-reporter=tap` appends the flag after `test/unit`, and
+# Node then treats it as another test path and errors with `Could not find '.../--test-reporter=tap'`.
+      - run: node --test --test-reporter=tap test/unit
 ```
 
 ### 🔍 Knowledge Check: Coverage and Flakiness


### PR DESCRIPTION
## 🔧 Quest fix — `system-engineer/0101`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: system-engineer/0101

Evidence honest & verified: `mode==execute`, non-truncated, 5/5 scored, 0 errored, every result `executed==true`. Acted on the 3 `warn` quests only (2 `pass` quests left untouched). No vendored quests in this slice.

**pages/_quests/0101/testing-integration.md** — tier-1 score_pct 100.0 → 100.0 (held), brand clean. ✅ kept.
- Fixed failed command `npm run test:unit` (verified: commands[].status=failed, `Could not find '.../test/unit'`) + HIGH rec (Chapter 2 "Define the Three Test Scripts"): added the `mkdir -p test/unit test/integration test/e2e`, `mv total.test.js test/unit/`, and import-path fixup step before the scripts run.
- Fixed failed command `npm run test:unit -- --test-reporter=tap` (verified: commands[].status=failed) + HIGH rec (Chapter 3 flaky-test reporter): replaced with `node --test --test-reporter=tap test/unit` so the flag lands before the path, with a note explaining why `-- <flag>` misplaces it.

**pages/_quests/0101/deployment-pipelines.md** — tier-1 score_pct 100.0 → 100.0 (held), brand clean. ✅ kept.
- Fixed failed command `docker build -t myapp:$(git rev-parse --short HEAD) .` (verified: commands[].status=failed, `failed to read dockerfile`) + HIGH rec (Cloud Realms Path — docker build): added a minimal inline sample `Dockerfile` before the build. Also completed the MEDIUM promotion-story rec (added `docker push` + a re-tagged `:production` push) so "build once, promote the same artifact" is actually shown.

**pages/_quests/0101/self-operating-website-08-the-cartographer.md** — tier-1 score_pct 94.6 → 94.6 (held), brand clean. ✅ kept.
- Fixed HIGH rec (Chapter 1 — triage.sh isolation design; verified: build-product.log/build-minimal.log 249/249 identical): rewrote step 2 to build the minimal page from a throwaway `--source`/`--config` temp dir sharing only `remote_theme`, so the comparison actually isolates the theme instead of rebuilding the whole product site plus one page. Updated the follow-on `include:/exclude:` callout to match.
- Fixed HIGH rec (Chapter 1 — pinning the theme SHA; verified: `gem contents` lists only plugin source, theme fetched to a deleted temp dir): replaced the `gem contents jekyll-remote-theme` bullet with `jekyll build --verbose` + grep `Downloading … zip/<ref>`, noting there is no persistent cache to inspect.
- Fixed MEDIUM rec (Chapter 1 — prerequisites; verified: `bundle install`/build failed with `Unknown tag seo` / `Unknown tag include_cached`): added a prerequisites bullet naming the supporting plugins (`jekyll-remote-theme`, `jekyll-seo-tag`, `jekyll-include-cache`) a from-scratch environment needs.

_Left (not fixed):_
- cartographer LOW rec (triage.sh copies itself/log files into `_site/`) — out of scope for the small fix; cosmetic, no learner-blocking defect.
- testing-integration MEDIUM (Postgres health-check options), LOW (`"type": "module"` warning), LOW (Test Sharding secondary objective) — deferred to keep the PR small and focused on the verified failed commands + HIGH recs; the loop can revisit tomorrow.
- deployment-pipelines MEDIUM (Mastery Challenge example stubs), LOW (Windows/Linux `|| echo` fallback), LOW (rollback caution note) — deferred, same rationale.

No frontmatter changed, so no `_data/quests/**` regeneration required.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/30355858267)._
