### PR TITLE
🔧 Quest fix: security-specialist/1011

### DIFF
--- a/pages/_quests/1011/agentic-multi-agent-failure-recovery.md
+++ b/pages/_quests/1011/agentic-multi-agent-failure-recovery.md
@@ -136,7 +136,7 @@ jobs:
           if [ $EXIT_CODE -eq 0 ]; then
             echo "status=success" >> "$GITHUB_OUTPUT"
           else
-            echo "status=failed" >> "$GITHUB_OUTPUT"
+            echo "status=failure" >> "$GITHUB_OUTPUT"
             # Save partial results before exiting
             python3 work/gh-600/scripts/save_checkpoint.py --task analysis
             exit $EXIT_CODE
@@ -160,7 +160,7 @@ jobs:
         run: |
           UPSTREAM_STATUS="${% raw %}{{ needs.sub-agent-1.outputs.status }}{% endraw %}"
           
-          if [ "$UPSTREAM_STATUS" = "failed" ]; then
+          if [ "$UPSTREAM_STATUS" = "failure" ]; then
             echo "⚠️ Sub-agent 1 failed — running in degraded mode"
             python3 work/gh-600/scripts/subtask.py \
               --task synthesis \
@@ -189,7 +189,7 @@ jobs:
           python3 work/gh-600/scripts/recovery_coordinator.py \
             --results-dir ./results/ \
             --task-id "${% raw %}{{ github.event.inputs.task_id }}{% endraw %}" \
-            --agent1-status "${% raw %}{{ needs.sub-agent-1.result }}{% endraw %}" \
+            --agent1-status "${% raw %}{{ needs.sub-agent-1.outputs.status }}{% endraw %}" \
             --agent2-status "${% raw %}{{ needs.sub-agent-2.result }}{% endraw %}" \
             --output recovery-plan.json
 
@@ -199,6 +199,10 @@ jobs:
           python3 work/gh-600/scripts/redelegate_tasks.py \
             --failed-tasks "${% raw %}{{ steps.assess.outputs.failed_tasks }}{% endraw %}"
 ```
+
+> **⚠️ `continue-on-error` gotcha:** when a job sets `continue-on-error: true`, GitHub Actions reports `needs.<job>.result` as `success` to dependents even when the job actually failed — so failure detection that reads `needs.sub-agent-1.result` silently breaks. Pass the job's own captured `outputs.status` (from `steps.run.outputs.status`) downstream instead, as the coordinator step does above. Apply the same captured-status pattern to every `continue-on-error` job — including `sub-agent-2` — before wiring its status into the recovery coordinator.
+
+> **📦 Helper scripts:** `subtask.py`, `save_checkpoint.py`, and `redelegate_tasks.py` are assumed to exist in `work/gh-600/scripts/` from your prior GH-600 quests (or as your own stubs) — this chapter focuses on the orchestration and recovery wiring, not on re-implementing those task runners. Only `recovery_coordinator.py` is authored in full below.
 
 ---
 
@@ -321,12 +325,12 @@ if __name__ == "__main__":
 Validate your work with these standalone checks — run each from your quest workspace (no extra tooling required):
 
 ```bash
-# ✅ Recovery workflow present
-test -f orchestrator-with-recovery.yml && echo "orchestrator-with-recovery.yml present"
-# ✅ Recovery coordinator present
-test -f recovery_coordinator.py && echo "recovery_coordinator.py present"
+# ✅ Recovery workflow present (path matches the code block's header comment)
+test -f .github/workflows/orchestrator-with-recovery.yml && echo "orchestrator-with-recovery.yml present"
+# ✅ Recovery coordinator present (path matches the code block's header comment)
+test -f work/gh-600/scripts/recovery_coordinator.py && echo "recovery_coordinator.py present"
 # ✅ All five compensation strategy types documented (expect a count of 5)
-grep -oiE "retry|fallback|escalat|compensat|checkpoint" recovery_coordinator.py | tr '[:upper:]' '[:lower:]' | sort -u | wc -l
+grep -oiE "retry|fallback|escalat|compensat|checkpoint" work/gh-600/scripts/recovery_coordinator.py | tr '[:upper:]' '[:lower:]' | sort -u | wc -l
 ```
 
 Manual completion checklist:

--- a/pages/_quests/1011/ai-feature-pipeline-architect.md
+++ b/pages/_quests/1011/ai-feature-pipeline-architect.md
@@ -127,7 +127,8 @@ You'll know you've truly mastered this quest when you can:
 brew install node python3 docker docker-compose git
 
 # Install AI development tools
-brew install copilot-cli
+# (no `copilot-cli` Homebrew formula exists — use the npm package or gh extension)
+npm install -g @githubnext/github-copilot-cli   # or: gh extension install github/gh-copilot
 pip3 install langchain anthropic openai
 
 # Set up MCP development environment
@@ -196,7 +197,8 @@ echo '{
 const aiPipeline = {
   stages: ['intake', 'implementation', 'documentation', 'testing', 'deployment'],
   orchestrate: async (userRequest) => {
-    // Cross-platform AI orchestration logic
+    // Illustrative only — `processFeatureRequest` is a placeholder you supply;
+    // running this snippet as-is throws a ReferenceError until you define it.
     return await processFeatureRequest(userRequest);
   }
 };
@@ -322,6 +324,8 @@ echo "I want users to be able to reset their passwords via email" | python intak
 
 ### 🏗️ Building Your Implementation Pipeline
 
+> **🧭 Architecture sketch — pseudocode, not runnable as-is.** The sub-agents this orchestrator wires together (`CodeGenerationAgent`, `SecurityAgent`, `OptimizationAgent`) are illustrative and are **not** defined in this quest; instantiating `ImplementationOrchestrator()` as written raises `NameError`. Treat this block as a design blueprint and supply the agents yourself — Chapter 1's intake stage is the fully runnable, copy-paste example.
+
 ```python
 class ImplementationOrchestrator:
     def __init__(self):
@@ -357,6 +361,8 @@ class ImplementationOrchestrator:
 - Living documentation that updates with code changes
 - Multi-format output optimization (Markdown, JSON, HTML)
 
+> **🧭 Architecture sketch — pseudocode, not runnable as-is.** The helper methods called below (`generate_openapi_spec`, `generate_user_guide`, `generate_mermaid_diagram`, `generate_changelog`) are illustrative and are **not** implemented here; calling `generate_docs(...)` as written raises `AttributeError`. Treat this block as a design blueprint you flesh out yourself.
+
 ```python
 class DocumentationAgent:
     async def generate_docs(self, code_artifacts: dict, requirements: dict):
@@ -378,6 +384,8 @@ class DocumentationAgent:
 - Performance testing and load simulation
 - Test coverage analysis and improvement suggestions
 - Continuous quality monitoring with AI insights
+
+> **🧭 Architecture sketch — pseudocode, not runnable as-is.** The sub-agents referenced below (`unit_test_agent`, `integration_agent`, `performance_agent`) are illustrative and are **not** defined here; calling `run_testing_pipeline(...)` as written raises `AttributeError`. Treat this block as a design blueprint you flesh out yourself.
 
 ```python
 class TestingOrchestrator:
@@ -406,6 +414,8 @@ class TestingOrchestrator:
 - Multi-environment deployment orchestration
 - Monitoring and alerting setup with AI insights
 - Automated rollback and disaster recovery procedures
+
+> **🧭 Architecture sketch — pseudocode, not runnable as-is.** The sub-agents referenced below (`risk_agent`, `config_agent`, `deploy_agent`, `monitoring_agent`) are illustrative and are **not** defined here; calling `deploy_feature(...)` as written raises `AttributeError`. Treat this block as a design blueprint you flesh out yourself.
 
 ```python
 class DeploymentOrchestrator:


### PR DESCRIPTION
## 🔧 Quest fix — `security-specialist/1011`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: security-specialist/1011

Consumed one honest, execute-mode walk (all 5 results `executed`, none truncated, `errored=0`). Acted only on the two `fail` quests; the 3 `pass` quests were left untouched. Tier-1 numbers below are read straight from `quest_validator.py --summary`; each edit was kept only because tier-1 held-or-rose **and** `brand_lint` stayed clean (never the agentic `overall`).

**pages/_quests/1011/agentic-multi-agent-failure-recovery.md** (verdict `fail`) — tier-1 `58/74 (78.4%) → 58/74 (78.4%)` held, brand clean ✅
- Fixed **high** rec (area: *Chapter 2/3 code-block paths vs Quest Validation*): the Quest Validation bash block now checks the same nested paths the code blocks' own header comments declare (`.github/workflows/orchestrator-with-recovery.yml`, `work/gh-600/scripts/recovery_coordinator.py`) instead of flat workspace-root filenames, so validation actually exercises the files the learner creates.
- Fixed **high** rec (area: *continue-on-error + needs.<job>.result*): the recovery coordinator step now reads `needs.sub-agent-1.outputs.status` (the job's own captured step output) instead of `needs.sub-agent-1.result`, which `continue-on-error: true` masks to `success`. Kept the emitted status value self-consistent with the coordinator's `== "failure"`/`== "success"` checks (`status=failed → status=failure`, and the downstream `if [ "$UPSTREAM_STATUS" = ... ]` guard) and added a short `continue-on-error` gotcha note that also flags `sub-agent-2` needs the same treatment.
- Addressed **medium** rec (area: *Missing referenced scripts*): added a scoping note that `subtask.py`, `save_checkpoint.py`, and `redelegate_tasks.py` are assumed-present helpers (prior GH-600 quests / learner stubs), so the two "apply retry / implement re-delegation" objectives read as wiring exercises rather than missing implementations.

**pages/_quests/1011/ai-feature-pipeline-architect.md** (verdict `fail`) — tier-1 `71/74 (95.9%) → 71/74 (95.9%)` held, brand clean ✅
- Addressed the 4 failed commands on the Chapter 2–5 orchestrators (`ImplementationOrchestrator`/`DocumentationAgent`/`TestingOrchestrator`/`DeploymentOrchestrator` raising `NameError`/`AttributeError`) and the matching **high** rec by relabeling each block as an "architecture sketch — pseudocode, not runnable as-is", naming the undefined sub-agents and pointing learners to Chapter 1 as the runnable example, so no one executes broken code expecting Chapter-1 behavior.
- Fixed the failed command on the Universal Web Path JS snippet (`aiPipeline.orchestrate('test')` → `ReferenceError: processFeatureRequest is not defined`) and its **low** rec by commenting the snippet as illustrative with a placeholder the learner supplies.
- Fixed **medium** rec (area: *brew install copilot-cli*): replaced the non-existent Homebrew formula with `npm install -g @githubnext/github-copilot-cli` (or `gh extension install github/gh-copilot`).

_Left (not fixed, honestly out of this pass):_
- **Deliberately left** the Chapter 1 `model="claude-3-5-sonnet-latest"` **medium** rec — Chapter 1 is the one sandbox-verified working example, and swapping the literal risks either fabricating a model id or breaking that verified run; a placeholder/env-var refactor is safer authored deliberately, not under the fix cap.
- **Out of minimal-fix scope:** quest 2's "scale down / build out stages 2–5" **high** completeness rec and the **medium** ADR-template rec both require substantial new authored content, not a small edit; the pseudocode relabel already removes the "runs broken" hazard.
- **Left as low-priority under the per-slice cap:** quest 1's raw-Jekyll-tag and deeper end-to-end-validation **low** recs; quest 2's `newgrp docker` subshell **low** note.
- No vendored quests in this slice (neither file carries `source_repo:`/`source_url:`). No frontmatter changed, so no `_data/quests` regeneration is required.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/30355858267)._
