### PR TITLE
fix(links): repair sister-site link rot — BASH domain, lifehacker deep links, blog redirects

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -159,7 +159,7 @@ default_icon: "bi" ## Bootstrap Icons https://icons.getbootstrap.com/
 
 links:
   - label: "BASH Consulting"
-    url: "https://bashconsultants.com"
+    url: "https://bash-365.com"
     icon: "bi-link"
   - label: "Twitter"
     icon: "bi-twitter"

--- a/_data/home/bookmarks.yml
+++ b/_data/home/bookmarks.yml
@@ -4,7 +4,7 @@ groups:
     items:
       - { title: GitHub, url: 'https://github.com/bamr87', icon: github }
       - { title: it-journey.dev, url: 'https://it-journey.dev', icon: rocket-takeoff }
-      - { title: BASH Consulting, url: 'https://bashconsultants.com', icon: terminal }
+      - { title: BASH Consulting, url: 'https://bash-365.com', icon: terminal }
       - { title: lifehacker.dev, url: 'https://lifehacker.dev', icon: newspaper }
   - name: AI
     items:

--- a/pages/_quests/1010/automate-traffic-report.md
+++ b/pages/_quests/1010/automate-traffic-report.md
@@ -241,4 +241,4 @@ It's tempting to run this as a hosted cron, but the script needs the **local ser
 
 ## 🎓 Path Complete
 
-You've connected Google Analytics to your agent, learned to query it, and automated the reporting. Loop back to **[the series hub](/quests/1010/)** for more Monitoring & Observability quests — or read the full story in the post [Auditing Site Analytics & SEO with an AI Agent and MCP](https://lifehacker.dev).
+You've connected Google Analytics to your agent, learned to query it, and automated the reporting. Loop back to **[the series hub](/quests/1010/)** for more Monitoring & Observability quests — or read the full story in the post [The first thing analytics told me was that the analytics were wrong](https://lifehacker.dev/posts/2026/06/14/ai-assisted-analytics-seo-audit/).

--- a/pages/_quests/1110/404-hunting.md
+++ b/pages/_quests/1110/404-hunting.md
@@ -381,7 +381,7 @@ Objective: Use guardian logs to create a minimal viable resource (MVR) or redire
 
 ## 📚 Quest Resource Codex
 
-- Companion Article: <https://lifehacker.dev>
+- Companion Article: [Kill dead links in Jekyll: stable permalinks, redirect_from, and a CI link checker](https://lifehacker.dev/hacks/kill-dead-links-jekyll-permalinks/)
 - Jekyll Permalinks: <https://jekyllrb.com/docs/permalinks/>
 - Jekyll-redirect-from: <https://github.com/jekyll/jekyll-redirect-from>
 - Jekyll-sitemap: <https://github.com/jekyll/jekyll-sitemap>

--- a/pages/_quests/codex/world_map.md
+++ b/pages/_quests/codex/world_map.md
@@ -116,9 +116,9 @@ Battle-tested wisdom and real-world experiences from fellow code warriors who've
 
 #### 📅 Recent Chronicles (2024-2025)
 
-- [AI-Powered Development Workflows](https://lifehacker.dev) - Advanced automation techniques
-- [GitHub Actions Mastery](https://lifehacker.dev) - CI/CD optimization
-- [Docker for IT-Journey](https://lifehacker.dev) - Containerization strategies
+- [Letting Copilot Untangle 25 Scripts Across Four Repos](https://lifehacker.dev/posts/2025/07/07/ai-assisted-script-consolidation-development-workflows/) - AI-powered automation techniques
+- [Consolidating GitHub Actions into a Modular Architecture](https://lifehacker.dev/posts/2025/01/27/consolidating-github-actions-modular-architecture/) - CI/CD optimization
+- [Dockering Your IT-Journey](https://lifehacker.dev/hacks/dockering-your-it-journey/) - Containerization strategies
 - Jekyll Theming & Bootstrap (planned) - Site customization
 
 ### ⚔️ Quests Territory (`/quests/`)
@@ -315,7 +315,7 @@ Site navigation is managed through YAML files in `_data/navigation/`:
 
 - [🏛️ Main Portal](/) - Primary entrance to IT-Journey
 - [🏰 Quest Central](/quests/) - Complete quest index and navigation
-- [📜 Chronicle Archive](https://lifehacker.dev) - All chronicles and blog posts
+- [📜 Chronicle Archive](https://lifehacker.dev/news/) - All chronicles and blog posts, at the sister site lifehacker.dev
 - [📚 Library Index](/docs/) - Documentation and guides
 - [📔 Personal Notebook](/notes/) - Your learning space
 
@@ -357,8 +357,8 @@ Site navigation is managed through YAML files in `_data/navigation/`:
 ### 🔧 For System Administrators
 
 1. **Platform Setup:** [The Self-Operating Website epic](/quests/codex/self-operating-website/)
-2. **Docker Environment:** [Container Setup](https://lifehacker.dev)
-3. **CI/CD Integration:** [GitHub Actions](https://lifehacker.dev)
+2. **Docker Environment:** [Docker from Zero: Essential Commands](https://lifehacker.dev/hacks/docker-from-zero-essential-commands/)
+3. **CI/CD Integration:** [GitHub Actions hacks on lifehacker.dev](https://lifehacker.dev/news/hacks/)
 4. **Monitoring:** [Site Analytics](/about/features/)
 
 ## 🌟 Hidden Treasures & Advanced Features

--- a/redirects/README.md
+++ b/redirects/README.md
@@ -1,0 +1,11 @@
+# redirects/
+
+Redirect stubs for content that moved off it-journey.dev. Each stub pins the page's **old** it-journey URL via `permalink:` and forwards to its new home via `redirect_to:` (rendered by the `jekyll-redirect-from` plugin, already enabled in `_config.yml`). All stubs set `sitemap: false` so search engines follow the redirect instead of indexing the shim.
+
+## posts/
+
+The blog was removed in the 2026-06 quest-refocus overhaul (PR #366); articles were rewritten into **lifehacker.dev**. These 42 stubs map every old `/posts/:year/:month/:day/:slug/` URL that has a confirmed lifehacker.dev destination, derived from lifehacker.dev's import ledger (`docs/content-import/triage.plan.json`, PR bamr87/lifehacker.dev#55: 42 `rewrite` verdicts out of 110 triaged posts). Destination URLs were verified live (HTTP 200) when generated on 2026-08-01.
+
+Old posts with a `skip` verdict (opinion essays, superseded content) and posts relocated inside this repo (e.g. the GH-600 track, now under `pages/_docs/`) intentionally have **no** stub here — a deliberate 404 or their in-repo home is correct.
+
+This directory sits outside `pages/` on purpose: the frontmatter-validation CI gate covers `pages/**/*.md`, and these shims carry only the minimal keys a redirect needs.

--- a/redirects/posts/2019-08-22-auto-hide-navbar.md
+++ b/redirects/posts/2019-08-22-auto-hide-navbar.md
@@ -1,0 +1,6 @@
+---
+title: "Auto Hide Navbar: Dynamic Scroll Detection"
+permalink: /posts/2019/08/22/auto-hide-navbar/
+redirect_to: https://lifehacker.dev/hacks/auto-hide-navbar/
+sitemap: false
+---

--- a/redirects/posts/2019-08-22-dockering-your-it-journey.md
+++ b/redirects/posts/2019-08-22-dockering-your-it-journey.md
@@ -1,0 +1,6 @@
+---
+title: "Dockerizing Your IT Journey: Jekyll with Docker"
+permalink: /posts/2019/08/22/dockering-your-it-journey/
+redirect_to: https://lifehacker.dev/hacks/dockering-your-it-journey/
+sitemap: false
+---

--- a/redirects/posts/2022-05-21-windows-sub-linux-setup.md
+++ b/redirects/posts/2022-05-21-windows-sub-linux-setup.md
@@ -1,0 +1,6 @@
+---
+title: "Windows Subsystem for Linux (WSL) Setup Guide"
+permalink: /posts/2022/05/21/windows-sub-linux-setup/
+redirect_to: https://lifehacker.dev/hacks/windows-sub-linux-setup/
+sitemap: false
+---

--- a/redirects/posts/2023-11-04-latex-cv-professional-resume.md
+++ b/redirects/posts/2023-11-04-latex-cv-professional-resume.md
@@ -1,0 +1,6 @@
+---
+title: "LaTex your CV"
+permalink: /posts/2023/11/04/latex-cv-professional-resume/
+redirect_to: https://lifehacker.dev/hacks/latex-cv-professional-resume/
+sitemap: false
+---

--- a/redirects/posts/2023-12-04-robots-txt-jekyll.md
+++ b/redirects/posts/2023-12-04-robots-txt-jekyll.md
@@ -1,0 +1,6 @@
+---
+title: "robots dot txt"
+permalink: /posts/2023/12/04/robots-txt-jekyll/
+redirect_to: https://lifehacker.dev/hacks/robots-txt-jekyll/
+sitemap: false
+---

--- a/redirects/posts/2024-02-14-building-code-extension.md
+++ b/redirects/posts/2024-02-14-building-code-extension.md
@@ -1,0 +1,6 @@
+---
+title: "Building a VS Code Extension for Copilot"
+permalink: /posts/2024/02/14/building-code-extension/
+redirect_to: https://lifehacker.dev/hacks/building-code-extension/
+sitemap: false
+---

--- a/redirects/posts/2024-04-25-placeholders.md
+++ b/redirects/posts/2024-04-25-placeholders.md
@@ -1,0 +1,6 @@
+---
+title: "Content Placeholders: Templates That Survive Contact With Authors"
+permalink: /posts/2024/04/25/placeholders/
+redirect_to: https://lifehacker.dev/hacks/placeholders/
+sitemap: false
+---

--- a/redirects/posts/2024-05-01-doc-scraper.md
+++ b/redirects/posts/2024-05-01-doc-scraper.md
@@ -1,0 +1,6 @@
+---
+title: "Document Scraping: Extract Structured Data From the Web"
+permalink: /posts/2024/05/01/doc-scraper/
+redirect_to: https://lifehacker.dev/hacks/doc-scraper/
+sitemap: false
+---

--- a/redirects/posts/2024-05-14-jekyll-sidebar.md
+++ b/redirects/posts/2024-05-14-jekyll-sidebar.md
@@ -1,0 +1,6 @@
+---
+title: "Jekyll Sidebar: Display Files and Folders"
+permalink: /posts/2024/05/14/jekyll-sidebar/
+redirect_to: https://lifehacker.dev/hacks/jekyll-sidebar/
+sitemap: false
+---

--- a/redirects/posts/2024-05-16-dynamic-sidebar-tree.md
+++ b/redirects/posts/2024-05-16-dynamic-sidebar-tree.md
@@ -1,0 +1,6 @@
+---
+title: "Dynamic Sidebar Tree: Jekyll Navigation Guide"
+permalink: /posts/2024/05/16/dynamic-sidebar-tree/
+redirect_to: https://lifehacker.dev/posts/2024/05/16/dynamic-sidebar-tree/
+sitemap: false
+---

--- a/redirects/posts/2024-05-24-searchbar-and-sitemaping.md
+++ b/redirects/posts/2024-05-24-searchbar-and-sitemaping.md
@@ -1,0 +1,6 @@
+---
+title: "Searchbar and Sitemapping in Jekyll: A Complete Guide"
+permalink: /posts/2024/05/24/searchbar-and-sitemaping/
+redirect_to: https://lifehacker.dev/hacks/searchbar-and-sitemaping/
+sitemap: false
+---

--- a/redirects/posts/2024-05-28-auto-increment-frontmatter-version.md
+++ b/redirects/posts/2024-05-28-auto-increment-frontmatter-version.md
@@ -1,0 +1,6 @@
+---
+title: "Auto Increment Frontmatter Version"
+permalink: /posts/2024/05/28/auto-increment-frontmatter-version/
+redirect_to: https://lifehacker.dev/posts/2024/05/28/auto-increment-frontmatter-version/
+sitemap: false
+---

--- a/redirects/posts/2024-06-02-markdown-code-to-scripts.md
+++ b/redirects/posts/2024-06-02-markdown-code-to-scripts.md
@@ -1,0 +1,6 @@
+---
+title: "Converting Markdown Code Blocks to Shell Scripts"
+permalink: /posts/2024/06/02/markdown-code-to-scripts/
+redirect_to: https://lifehacker.dev/hacks/markdown-code-to-scripts/
+sitemap: false
+---

--- a/redirects/posts/2024-06-27-gpt-prompt-engineering.md
+++ b/redirects/posts/2024-06-27-gpt-prompt-engineering.md
@@ -1,0 +1,6 @@
+---
+title: "GPT Prompt Engineering"
+permalink: /posts/2024/06/27/gpt-prompt-engineering/
+redirect_to: https://lifehacker.dev/hacks/gpt-prompt-engineering/
+sitemap: false
+---

--- a/redirects/posts/2025-01-27-consolidating-github-actions-modular-architecture.md
+++ b/redirects/posts/2025-01-27-consolidating-github-actions-modular-architecture.md
@@ -1,0 +1,6 @@
+---
+title: "Consolidating GitHub Actions: From Embedded Scripts to Modular Architecture"
+permalink: /posts/2025/01/27/consolidating-github-actions-modular-architecture/
+redirect_to: https://lifehacker.dev/posts/2025/01/27/consolidating-github-actions-modular-architecture/
+sitemap: false
+---

--- a/redirects/posts/2025-01-27-fixing-github-actions-link-checker-keyerror.md
+++ b/redirects/posts/2025-01-27-fixing-github-actions-link-checker-keyerror.md
@@ -1,0 +1,6 @@
+---
+title: "Fixing GitHub Actions Link Checker: KeyError 'details' Resolution"
+permalink: /posts/2025/01/27/fixing-github-actions-link-checker-keyerror/
+redirect_to: https://lifehacker.dev/hacks/fixing-github-actions-link-checker-keyerror/
+sitemap: false
+---

--- a/redirects/posts/2025-03-08-setting-up-django-and-git.md
+++ b/redirects/posts/2025-03-08-setting-up-django-and-git.md
@@ -1,0 +1,6 @@
+---
+title: "Setting Up Django and Git: A Magical Beginner's Guide"
+permalink: /posts/2025/03/08/setting-up-django-and-git/
+redirect_to: https://lifehacker.dev/hacks/django-new-project-to-github-push/
+sitemap: false
+---

--- a/redirects/posts/2025-07-05-advanced-version-management-ai-implementation.md
+++ b/redirects/posts/2025-07-05-advanced-version-management-ai-implementation.md
@@ -1,0 +1,6 @@
+---
+title: "Advanced Version Management System: Complete Implementation with AI-Assisted Development"
+permalink: /posts/2025/07/05/advanced-version-management-ai-implementation/
+redirect_to: https://lifehacker.dev/hacks/jq-default-operator-eats-false/
+sitemap: false
+---

--- a/redirects/posts/2025-07-05-ai-powered-modular-shell-script-refactoring.md
+++ b/redirects/posts/2025-07-05-ai-powered-modular-shell-script-refactoring.md
@@ -1,0 +1,6 @@
+---
+title: "AI-Powered Modular Shell Script Refactoring: Evolution Engine Architecture"
+permalink: /posts/2025/07/05/ai-powered-modular-shell-script-refactoring/
+redirect_to: https://lifehacker.dev/hacks/sourced-bash-logging-lib-reload-guard/
+sitemap: false
+---

--- a/redirects/posts/2025-07-05-debugging-github-actions-workflows-ai-assisted.md
+++ b/redirects/posts/2025-07-05-debugging-github-actions-workflows-ai-assisted.md
@@ -1,0 +1,6 @@
+---
+title: "Debugging GitHub Actions Workflows: AI-Assisted Troubleshooting Session"
+permalink: /posts/2025/07/05/debugging-github-actions-workflows-ai-assisted/
+redirect_to: https://lifehacker.dev/hacks/ci-script-hangs-wrap-version-in-timeout/
+sitemap: false
+---

--- a/redirects/posts/2025-07-09-fixing-github-actions-bash-compatibility-ai-evolution-engine.md
+++ b/redirects/posts/2025-07-09-fixing-github-actions-bash-compatibility-ai-evolution-engine.md
@@ -1,0 +1,6 @@
+---
+title: "Fixing GitHub Actions: Bash 3.2 Compatibility for AI Evolution Engine"
+permalink: /posts/2025/07/09/fixing-github-actions-bash-compatibility-ai-evolution-engine/
+redirect_to: https://lifehacker.dev/hacks/ci-bash-3-2-compatibility/
+sitemap: false
+---

--- a/redirects/posts/2025-07-10-github-actions-authentication-fix-2025-07-10.md
+++ b/redirects/posts/2025-07-10-github-actions-authentication-fix-2025-07-10.md
@@ -1,0 +1,6 @@
+---
+title: "GitHub Actions Authentication Fix: Resolving CI/CD Workflow Failures"
+permalink: /posts/2025/07/10/github-actions-authentication-fix-2025-07-10/
+redirect_to: https://lifehacker.dev/hacks/gh-cli-github-token-in-actions/
+sitemap: false
+---

--- a/redirects/posts/2025-07-22-vscode-for-neuroscience.md
+++ b/redirects/posts/2025-07-22-vscode-for-neuroscience.md
@@ -1,0 +1,6 @@
+---
+title: "VS Code for Neuroscience: Complete Setup Guide for macOS"
+permalink: /posts/2025/07/22/vscode-for-neuroscience/
+redirect_to: https://lifehacker.dev/tools/vscode-for-neuroscience/
+sitemap: false
+---

--- a/redirects/posts/2025-08-01-enhancing-bashcrawl-cellar-scroll-educational-content.md
+++ b/redirects/posts/2025-08-01-enhancing-bashcrawl-cellar-scroll-educational-content.md
@@ -1,0 +1,6 @@
+---
+title: "Enhancing Bashcrawl: Creating Terminal Education Content"
+permalink: /posts/2025/08/01/enhancing-bashcrawl-cellar-scroll-educational-content/
+redirect_to: https://lifehacker.dev/posts/2025/08/01/enhancing-bashcrawl-cellar-scroll-educational-content/
+sitemap: false
+---

--- a/redirects/posts/2025-08-27-vscode-front-matter-fork-development-setup.md
+++ b/redirects/posts/2025-08-27-vscode-front-matter-fork-development-setup.md
@@ -1,0 +1,6 @@
+---
+title: "VSCode Front Matter: Complete Fork & Development Guide"
+permalink: /posts/2025/08/27/vscode-front-matter-fork-development-setup/
+redirect_to: https://lifehacker.dev/hacks/vscode-front-matter-fork-development-setup/
+sitemap: false
+---

--- a/redirects/posts/2025-08-31-404-hunting-quest.md
+++ b/redirects/posts/2025-08-31-404-hunting-quest.md
@@ -1,0 +1,6 @@
+---
+title: "404 Hunting: The Quest for Resources"
+permalink: /posts/2025/08/31/404-hunting-quest/
+redirect_to: https://lifehacker.dev/hacks/kill-dead-links-jekyll-permalinks/
+sitemap: false
+---

--- a/redirects/posts/2025-11-15-github-pages-hidden-gem.md
+++ b/redirects/posts/2025-11-15-github-pages-hidden-gem.md
@@ -1,0 +1,6 @@
+---
+title: "GitHub Pages: The Hidden Gem Revolutionizing Web Publishing"
+permalink: /posts/2025/11/15/github-pages-hidden-gem/
+redirect_to: https://lifehacker.dev/hacks/github-pages-hidden-gem/
+sitemap: false
+---

--- a/redirects/posts/2025-11-16-jekyll-and-travis.md
+++ b/redirects/posts/2025-11-16-jekyll-and-travis.md
@@ -1,0 +1,6 @@
+---
+title: "Jekyll and Travis"
+permalink: /posts/2025/11/16/jekyll-and-travis/
+redirect_to: https://lifehacker.dev/hacks/jekyll-and-travis/
+sitemap: false
+---

--- a/redirects/posts/2025-11-16-work-directory-ci-cd.md
+++ b/redirects/posts/2025-11-16-work-directory-ci-cd.md
@@ -1,0 +1,6 @@
+---
+title: "The work/ Directory: CI/CD Integration Best Practices"
+permalink: /posts/2025/11/16/work-directory-ci-cd/
+redirect_to: https://lifehacker.dev/hacks/work-directory-ci-cd/
+sitemap: false
+---

--- a/redirects/posts/2025-11-16-working-directories-in-software-development.md
+++ b/redirects/posts/2025-11-16-working-directories-in-software-development.md
@@ -1,0 +1,6 @@
+---
+title: "Working Directories: Backbone of Software Builds"
+permalink: /posts/2025/11/16/working-directories-in-software-development/
+redirect_to: https://lifehacker.dev/hacks/working-directories-in-software-development/
+sitemap: false
+---

--- a/redirects/posts/2025-11-19-terminal-frontend-architecture.md
+++ b/redirects/posts/2025-11-19-terminal-frontend-architecture.md
@@ -1,0 +1,6 @@
+---
+title: "Architecting the Glass Interface: Building Frontends for Terminal Scripts"
+permalink: /posts/2025/11/19/terminal-frontend-architecture/
+redirect_to: https://lifehacker.dev/hacks/terminal-frontend-architecture/
+sitemap: false
+---

--- a/redirects/posts/2025-11-24-mastering-react-beginners-guide.md
+++ b/redirects/posts/2025-11-24-mastering-react-beginners-guide.md
@@ -1,0 +1,6 @@
+---
+title: "Mastering React: A Beginner's Guide"
+permalink: /posts/2025/11/24/mastering-react-beginners-guide/
+redirect_to: https://lifehacker.dev/hacks/mastering-react-beginners-guide/
+sitemap: false
+---

--- a/redirects/posts/2025-11-26-mastering-prompt-engineering-vscode-copilot.md
+++ b/redirects/posts/2025-11-26-mastering-prompt-engineering-vscode-copilot.md
@@ -1,0 +1,6 @@
+---
+title: "Mastering Prompt Engineering: A Practical Guide to VS Code Copilot"
+permalink: /posts/2025/11/26/mastering-prompt-engineering-vscode-copilot/
+redirect_to: https://lifehacker.dev/hacks/mastering-prompt-engineering-vscode-copilot/
+sitemap: false
+---

--- a/redirects/posts/2025-11-28-prd-machine-self-writing-documentation.md
+++ b/redirects/posts/2025-11-28-prd-machine-self-writing-documentation.md
@@ -1,0 +1,6 @@
+---
+title: "PRD Machine: Building a Self-Writing Product Requirements Distillery"
+permalink: /posts/2025/11/28/prd-machine-self-writing-documentation/
+redirect_to: https://lifehacker.dev/posts/2025/11/28/prd-machine-self-writing-documentation/
+sitemap: false
+---

--- a/redirects/posts/2025-12-20-docker-beginners-tutorial.md
+++ b/redirects/posts/2025-12-20-docker-beginners-tutorial.md
@@ -1,0 +1,6 @@
+---
+title: "Docker for Beginners: Complete Tutorial to Get Started with Containers"
+permalink: /posts/2025/12/20/docker-beginners-tutorial/
+redirect_to: https://lifehacker.dev/hacks/docker-from-zero-essential-commands/
+sitemap: false
+---

--- a/redirects/posts/2025-12-20-essential-vscode-extensions-developers.md
+++ b/redirects/posts/2025-12-20-essential-vscode-extensions-developers.md
@@ -1,0 +1,6 @@
+---
+title: "Essential VS Code Extensions for Developers: The Ultimate 2025 Guide"
+permalink: /posts/2025/12/20/essential-vscode-extensions-developers/
+redirect_to: https://lifehacker.dev/tools/essential-vscode-extensions-developers/
+sitemap: false
+---

--- a/redirects/posts/2026-02-23-terminal-bash-finance-accounting.md
+++ b/redirects/posts/2026-02-23-terminal-bash-finance-accounting.md
@@ -1,0 +1,6 @@
+---
+title: "A Finance Professional's Guide to the Terminal"
+permalink: /posts/2026/02/23/terminal-bash-finance-accounting/
+redirect_to: https://lifehacker.dev/hacks/excel-to-grep-awk-month-end-close/
+sitemap: false
+---

--- a/redirects/posts/2026-03-07-foundational-ci-cd-pipelines-github-vscode-extensions.md
+++ b/redirects/posts/2026-03-07-foundational-ci-cd-pipelines-github-vscode-extensions.md
@@ -1,0 +1,6 @@
+---
+title: "Foundational CI/CD Pipelines with GitHub Actions for VS Code Extensions"
+permalink: /posts/2026/03/07/foundational-ci-cd-pipelines-github-vscode-extensions/
+redirect_to: https://lifehacker.dev/hacks/github-actions-vscode-extension-pipeline/
+sitemap: false
+---

--- a/redirects/posts/2026-04-19-ai-assisted-nanobar-footer-refactoring.md
+++ b/redirects/posts/2026-04-19-ai-assisted-nanobar-footer-refactoring.md
@@ -1,0 +1,6 @@
+---
+title: "AI-Assisted UI/UX Refactoring: Nanobar Modularization and Footer Fix"
+permalink: /posts/2026/04/19/ai-assisted-nanobar-footer-refactoring/
+redirect_to: https://lifehacker.dev/posts/2026/04/19/ai-assisted-nanobar-footer-refactoring/
+sitemap: false
+---

--- a/redirects/posts/2026-06-14-ai-assisted-analytics-seo-audit.md
+++ b/redirects/posts/2026-06-14-ai-assisted-analytics-seo-audit.md
@@ -1,0 +1,6 @@
+---
+title: "Auditing Site Analytics & SEO with an AI Agent and MCP"
+permalink: /posts/2026/06/14/ai-assisted-analytics-seo-audit/
+redirect_to: https://lifehacker.dev/posts/2026/06/14/ai-assisted-analytics-seo-audit/
+sitemap: false
+---

--- a/redirects/posts/2026-06-22-fix-local-jekyll-docker-yanked-ffi.md
+++ b/redirects/posts/2026-06-22-fix-local-jekyll-docker-yanked-ffi.md
@@ -1,0 +1,6 @@
+---
+title: "Fix a Local Jekyll Docker Build Broken by a Yanked FFI Gem"
+permalink: /posts/2026/06/22/fix-local-jekyll-docker-yanked-ffi/
+redirect_to: https://lifehacker.dev/hacks/fix-local-jekyll-docker-yanked-ffi/
+sitemap: false
+---

--- a/redirects/posts/2026-06-23-embedding-giscus-comments-zer0-mistakes.md
+++ b/redirects/posts/2026-06-23-embedding-giscus-comments-zer0-mistakes.md
@@ -1,0 +1,6 @@
+---
+title: "Embedding Giscus Comments in the zer0-mistakes Theme"
+permalink: /posts/2026/06/23/embedding-giscus-comments-zer0-mistakes/
+redirect_to: https://lifehacker.dev/posts/2026/06/23/embedding-giscus-comments-zer0-mistakes/
+sitemap: false
+---


### PR DESCRIPTION
Part 3 of a 3-repo network-alignment pass (it-journey = the game, lifehacker.dev = the chronicle, bash-365.com = the distribution arm). Companions: bamr87/bashconsultants#30 (domain sweep) and bamr87/lifehacker.dev#403 (feed cap + CLAUDE.md).

## What changed

### BASH Consulting domain (2 files)
`_config.yml` `links:` and `_data/home/bookmarks.yml` pointed at the retired `bashconsultants.com` mirror; the canonical domain is `bash-365.com` (per that repo's CNAME).

### Mislabeled lifehacker.dev deep links (3 quest files, 8 links)
Eight links presented as deep links to specific articles but pointed at the bare `https://lifehacker.dev` domain — quest walkthrough reports have repeatedly flagged them as unverified (e.g. `pages/_quest-reports/2026-07-14-system-engineer-1010.md`). Each now points at its real article, with the label corrected to the article's actual title:

- `pages/_quests/codex/world_map.md` — 3 "Recent Chronicles" entries, the Chronicle Archive hub link (→ `/news/`), and 2 sysadmin quick-links
- `pages/_quests/1010/automate-traffic-report.md` — the companion analytics/SEO post
- `pages/_quests/1110/404-hunting.md` — fittingly, the 404-hunting quest's companion article was itself a soft 404; now → *Kill dead links in Jekyll*

**Every target verified HTTP 200 against the live site.**

### Old-blog redirects (`redirects/posts/`, 42 stubs + README)
The 2026-06 overhaul (#366) removed the blog with **zero** redirects — every old `/posts/:year/:month/:day/:slug/` URL has been a 404 since, despite `jekyll-redirect-from` being enabled. These 42 stubs forward each old URL to its rewritten lifehacker.dev home, generated from lifehacker.dev's import ledger (`docs/content-import/triage.plan.json`: 42 `rewrite` verdicts of 110 triaged posts; 10 reframed slugs matched manually). All 42 destinations verified HTTP 200. Skipped posts and content relocated in-repo intentionally get no stub — see `redirects/README.md`.

The directory sits outside `pages/` deliberately: the frontmatter-validation gate covers `pages/**/*.md`, and these shims carry only the keys a redirect needs.

## Validation

- `make content-audit` → PASS (pre-existing bashcrawl forward-reference warnings only)
- `make docker-build-ci` → PASS; spot-checked `_site/posts/2019/08/22/auto-hide-navbar/index.html` renders the meta-refresh to lifehacker.dev
- `tools/unwrap-prose.py --check` on all changed markdown → clean
- No quest frontmatter changed → no `make quest-data` regen needed

## Follow-up (out of scope here)
`world_map.md`'s "Chronicle Categories" table still links internal `/posts/tags/*` paths that died with the blog — that's a section rewrite, left for the quest-fix lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)