### PR TITLE
fix(ci): Link Health Guardian — drop conflicting lychee --output and the 12-min full-history fetch

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -124,10 +124,11 @@ jobs:
       success-rate: ${{ steps.results.outputs.success-rate }}
 
     steps:
+      # Shallow on purpose: the full scan never consults git history (the
+      # --changed-only diff path is PR-only), and a full-history fetch of this
+      # repo costs ~12 minutes of the job's ~12.5.
       - name: 📥 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
 
       - name: 🗄️ Restore lychee cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -151,10 +152,15 @@ jobs:
       - name: 📦 Install dependencies
         run: pip install requests
 
+      # `--output` must NOT appear in `args`: lychee-action also sets its own
+      # `output` input (default lychee/out.md) and its entrypoint hard-errors on
+      # the conflict. The JSON this job analyses is written by the analysis step
+      # below, which runs lychee itself (scripts/validation/link-checker.py ->
+      # run_lychee), so this step keeps the action's markdown job summary.
       - name: 🔗 Lychee link check
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
         with:
-          args: --no-progress --output ${{ env.OUTPUT_DIR }}/lychee_results.json .
+          args: --no-progress .
           fail: false
           jobSummary: true
 


### PR DESCRIPTION
<!-- fleet-doctor key="bamr87/it-journey:.github/workflows/link-checker.yml" -->

## Problem

`bamr87/it-journey` · `.github/workflows/link-checker.yml` (🔗 Link Health Guardian) — signals: **failing**, **high-cost-low-value**.

The weekly scheduled full scan is red. In the 14-day window the workflow ran 26 times for 24.3 minutes, of which **13.3 minutes ended in non-success** (45.2% effective). The failing job is `🔍 Full Link Health Assessment`; the step that dies is `🔗 Lychee link check`, 176 ms in.

## Root cause

Two independent things, both proven by the log of [run 30793139884](https://github.com/bamr87/it-journey/actions/runs/30793139884).

**1. The red — a `lychee-action` argument conflict.** The step passed `--output` inside `args` while the action's own `output` input still carried its default. The runner log shows both:

```
INPUT_ARGS:   --no-progress --output link-check-results/lychee_results.json .
INPUT_OUTPUT: lychee/out.md
...
Error: 'output' is set in args as well as in the action configuration. Please remove one of them.
##[error]Process completed with exit code 1.
```

`lychee-action`'s `entrypoint.sh` hard-errors on exactly that combination:

```bash
if [[ "$ARGS" =~ "--output " ]] && [ -n "${INPUT_OUTPUT:-}" ]; then
    echo "Error: 'output' is set in args as well as in the action configuration. ..."
    exit 1
fi
```

Nothing downstream actually needed that file: `scripts/validation/link-checker.py` runs lychee itself — `run_lychee()` builds `["lychee", "--output", <output_dir>/lychee_results.json]` and `run()` calls it unconditionally — so the JSON the analysis step parses is written by the analysis step, and would have been overwritten even if the action had produced it.

**2. The cost — a 12-minute full-history fetch.** The job took 12m24s; the `📥 Checkout` step alone accounts for 12m16s of it:

```
07:18:11  [command] git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules \
                      origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
07:30:27  ##[group] Checking out the ref
```

That is `fetch-depth: 0` pulling every branch and tag of this repo. The full-scan job never reads git history: the only `git diff` in `link-checker.py` is inside `_get_changed_files()`, reached solely via `--changed-only`, which this job does not pass (`determine_scope_files()` returns `["."]` for scope `website`).

## Fix

- `args: --no-progress .` — drop the conflicting `--output` fragment. The action keeps its documented defaults (`format: markdown` → `lychee/out.md` → `jobSummary: true`), so the human-readable summary is unchanged, and the machine-readable JSON keeps coming from the analysis step that already generates it.
- Remove `fetch-depth: 0` from the full-scan checkout. The **PR** job keeps `fetch-depth: 0` — it genuinely needs `origin/${BASE_REF}...HEAD` for its incremental diff.

No `continue-on-error`, no retries: the step is expected to go green on its own, and if lychee finds broken links the job still reports them through `fail: false` + the existing `📊 Workflow Summary` gate.

## Expected impact

- The Monday scheduled run stops failing at the lychee step, which restores the whole analysis → baseline-delta → artifact chain behind it (`📊 Run analysis` has been skipped every week since this broke).
- **~12 minutes recovered per full-scan run** (12m24s → well under a minute of checkout). Against the 14-day window's 13.3 wasted minutes, this removes both the failure and the bulk of the spend.

## Links

- Failing run: https://github.com/bamr87/it-journey/actions/runs/30793139884
- Failing job log: https://github.com/bamr87/it-journey/actions/runs/30793139884/job/91620754999
- Dash Actions analytics: https://bamr87.github.io/bamr87/actions/

---
🤖 Opened by the fleet-doctor loop in [bamr87/bamr87](https://github.com/bamr87/bamr87). Draft — please review before merging.
