### PR TITLE
fix(ci): unbreak the quest-perfection report job on single-slice sweeps

### DIFF
--- a/.github/workflows/quest-perfection.yml
+++ b/.github/workflows/quest-perfection.yml
@@ -692,13 +692,54 @@ jobs:
         run: pip install pyyaml
 
       # Each slice job uploaded quest-perfection-<branch_slug> with the sealed
-      # plan + evidence and the session report. merge-multiple stays off, so each
-      # artifact lands in its own slices/<artifact-name>/ directory.
+      # plan + evidence and the session report. merge-multiple stays off, so a
+      # multi-slice sweep lands each artifact in its own slices/<artifact-name>/
+      # directory — but see the normalization step below for the one-slice case.
       - name: Download every slice artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: quest-perfection-*
           path: slices
+
+      # LAYOUT NORMALIZATION — download-artifact only nests under
+      # slices/<artifact-name>/ when the pattern matches 2+ artifacts. Its rule is
+      #   isSingleArtifactDownload || mergeMultiple || artifacts.length === 1
+      #     ? resolvedPath : path.join(resolvedPath, artifact.name)
+      # so a pattern matching EXACTLY ONE artifact extracts FLAT into `path`.
+      # Every consumer below addresses slices/<artifact-name>/walk-plan.json, so a
+      # one-slice sweep — the normal case once the OODA/budget filter trims the
+      # matrix to a single character path — read as "0/1 slices delivered" and
+      # hard-failed a run whose slice had actually succeeded end to end. That red
+      # run on main then withheld the deploy: sync-gh-pages requires main's HEAD
+      # to be fully green, so the site silently stopped publishing.
+      # Re-nest the flat layout here so both shapes are identical downstream.
+      - name: Normalize the slice artifact layout
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, shutil
+          from pathlib import Path
+
+          root = Path("slices")
+          flat = root / "walk-plan.json"
+          if not flat.is_file():
+              # Already nested (2+ artifacts), or nothing was delivered at all —
+              # the delivery check below is what judges the latter.
+              print("nested layout or no delivery — nothing to normalize.")
+              raise SystemExit(0)
+
+          plan = json.loads(flat.read_text(encoding="utf-8"))
+          # Rebuild the artifact name the slice job used: branch_slug is the matrix
+          # slug "<character.key>/<level.code>" with '/' replaced by '-'.
+          branch_slug = f"{plan['character']['key']}-{plan['level']['code']}"
+          dest = root / f"quest-perfection-{branch_slug}"
+          dest.mkdir(parents=True, exist_ok=True)
+          for item in sorted(root.iterdir()):
+              if item == dest:
+                  continue
+              shutil.move(str(item), str(dest / item.name))
+          print(f"re-nested flat single-artifact download into {dest}/")
+          PY
 
       # FAILED-SLICE VISIBILITY — the slice legs run continue-on-error so one
       # flaky leg can't fail the whole sweep, which means the run conclusion no


### PR DESCRIPTION
Review of every failing workflow run in recent history. One real code defect was found; the rest are already fixed, transient, or benign. Details below.

## The defect

`quest-perfection.yml`'s `report` job downloads slice artifacts with `pattern: quest-perfection-*` and then addresses each at `slices/<artifact-name>/walk-plan.json`. That layout only holds for **2+ matched artifacts**. The action's own rule ([`download-artifact.ts`](https://github.com/actions/download-artifact/blob/3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c/src/download-artifact.ts)) is:

```ts
isSingleArtifactDownload || inputs.mergeMultiple || artifacts.length === 1
  ? resolvedPath
  : path.join(resolvedPath, artifact.name)
```

so a pattern matching **exactly one** artifact extracts **flat** into `path`.

Once the OODA/budget filter trims the matrix to a single character path — now the normal case — the delivery check finds no `slices/quest-perfection-<branch_slug>/walk-plan.json`, reports `0/1 slices delivered`, and hard-fails the run as a sweep-wide wipeout. The workflow's inline comment ("each artifact lands in its own `slices/<artifact-name>/` directory") was simply wrong for this case.

The slice job had actually succeeded end to end. In [run 31310120768](https://github.com/bamr87/it-journey/actions/runs/31310120768) all 25 steps of `slice (developer/0001, …)` were green, the engine was not rate-limited (`AUTH_SKIPPED` empty), and the artifact it uploaded scores **4 quests**.

## Blast radius

Every scheduled run has failed this way since **2026-07-19** — so for three weeks there has been no ledger update, no `.quests/DASHBOARD.md` render, and no report PR.

It also closed the deploy gate. `sync-gh-pages` merges to `gh-pages` only when main's HEAD is fully green, and this failing check run sits on main's HEAD. The most recent sync run logged `COUNT: 21`, `STATE: failed` and skipped the merge — **gh-pages is 21 commits behind main, and the last Pages build was 2026-08-02.**

## The fix

Re-nest the flat layout immediately after the download, deriving the artifact name from the plan's own `character.key`/`level.code` — exactly how the slice job builds `branch_slug`. All three downstream consumers (delivery check, ledger replay, PR-body composer) then see one identical shape. No-ops on the already-nested and zero-artifact paths.

Deriving from `walk-plan.json` rather than `PLAN_MATRIX` is deliberate: when several slices are planned but only one delivers, the matrix cannot say which one arrived — the plan file can.

## Verification

Ran against the **real artifact** from the last failed run (ID `9037440296`), plus that run's real `PLAN_MATRIX`:

| | before | after |
|---|---|---|
| downloaded tree | `slices/walk-plan.json` (flat — as predicted) | `slices/quest-perfection-developer-0001/walk-plan.json` |
| delivery check | `0/1` → `::error::` → exit 1 | `1/1` → proceeds |
| wipeout guard | (unreached) | `attempted=1 productive=1` → passes |
| PR body row | (unreached) | ``` `developer/0001` window 2/6 (5q) ``` |

Also exercised the three no-op paths: already-nested (2 artifacts), `slices/` absent, and a re-run over its own output (idempotent). `actionlint -shellcheck=` clean on the edited file.

## The other failing runs — no action needed

| Workflow | Status |
|---|---|
| 🔗 Link Health Guardian | Already fixed on main by #586 (2026-08-06), after the last failure on 08-03. Cause was `'output' is set in args as well as in the action configuration`. Next scheduled run confirms. |
| pages build and deployment (gh-pages) | Failed 07-22 → 07-28, green since 07-29. It has not run since 08-02 only because the deploy gate above is shut; this PR reopens it. |
| CodeQL · Dependabot | Both 2026-08-06, both `Failed to resolve action download info. Error: Service Unavailable` / `Bad Gateway` — a GitHub incident, not repo config. CodeQL has since run green. |
| 🔄 Automated PR Freshness | One run whose `sweep` job was cancelled while queued (never got a runner) — the `pr-freshness` concurrency group superseding an older pending run. 4 green runs since. |
| markdown-oneline · 🤝 Content Auto-Merge | 2026-07-21, on `automated/quest-fix-system-engineer-0101`; that PR is no longer open. Stale. |

## Worth a follow-up (not changed here)

The deploy gate treats *any* failed check on main's HEAD as blocking, including the scheduled agent loops. `quest-perfection.yml` is **designed** to hard-fail on a genuine token wipeout — and whenever it legitimately does, site publishing stops until someone notices. Decoupling the two (e.g. gating `sync-gh-pages` on build/content checks rather than every check suite) is a policy call, so I left it alone; flagging it because this incident is exactly that coupling firing on a false positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dhof7m3cCWfKQGmCFu6wHS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dhof7m3cCWfKQGmCFu6wHS)_