### PR TITLE
ci(pr-freshness): gate the sweep at the job level so a disabled lane starts no runner

### DIFF
--- a/.github/workflows/pr-freshness.yml
+++ b/.github/workflows/pr-freshness.yml
@@ -65,6 +65,11 @@ concurrency:
 
 jobs:
   sweep:
+    # The kill switch is a JOB-level condition, not a first step. A step-level
+    # gate still provisions a runner for every cron tick and every push to main
+    # only to echo "idle" — with PR_FRESHNESS_ENABLED unset that was 100% of
+    # runs. Evaluated here, a disabled lane starts no runner at all.
+    if: vars.PR_FRESHNESS_ENABLED == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -76,36 +81,20 @@ jobs:
       # whatever remote the workspace happens to be sitting on.
       GH_REPO: ${{ github.repository }}
       ONLY_PR: ${{ github.event.inputs.pr }}
-      ENABLED: ${{ vars.PR_FRESHNESS_ENABLED }}
     steps:
-      - name: Gate
-        id: gate
-        run: |
-          set -euo pipefail
-          if [ "$ENABLED" = "true" ]; then
-            echo "go=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "pr-freshness idle (PR_FRESHNESS_ENABLED=${ENABLED:-unset})."
-            echo "go=false" >> "$GITHUB_OUTPUT"
-          fi
-
       # The BASE branch's tooling. Never the PR's — the refresh below checks out
       # PR branches, and their scripts must never be the ones we execute.
-      - if: steps.gate.outputs.go == 'true'
-        uses: actions/checkout@v7
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - if: steps.gate.outputs.go == 'true'
-        uses: actions/setup-python@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 
-      - if: steps.gate.outputs.go == 'true'
-        run: pip install --quiet pyyaml    # ledger.py + build_reports_site.py
+      - run: pip install --quiet pyyaml    # ledger.py + build_reports_site.py
 
       - name: Refresh every stale automated PR
-        if: steps.gate.outputs.go == 'true'
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
<!-- fleet-doctor key="bamr87/it-journey:.github/workflows/pr-freshness.yml" -->

## Problem

`bamr87/it-journey` · `.github/workflows/pr-freshness.yml` · signals: `cron-heavy`, `high-cost-low-value`.

14d analytics: **65 runs · 25.4m total · 15.1m wasted · 40.8% effective · 98.5% success**. The success rate is the tell — this workflow is not red, it is *pointless*. Every run "succeeds" without doing anything.

Evidence:

- `gh api repos/bamr87/it-journey/actions/variables` returns 10 variables — `AGENT_DEMO_ENABLED`, `CMS_MECHANICAL_AUTOMERGE`, `CONTENT_AUTOMERGE_ENABLED`, `FLEET_CI_WORKFLOW`, `FLEET_HUB`, `ISSUE_AUTOCLOSE_ENABLED`, `ISSUE_AUTOMERGE_ENABLED`, `ISSUE_AUTOPILOT_ENABLED`, `ISSUE_RESOLVE_ENABLED`, `NODE_VERSION`. **`PR_FRESHNESS_ENABLED` is not among them.** It has never been set.
- Every recent run lasts 6–12s: `31868564218` (7s), `31855138692` (9s), `31830931569` (8s), `31802484912` (7s), `31778274150` (9s), `31759122422` (6s)… That is the runner boot plus one `echo`.

## Root cause

The kill switch is a **step**, not a job condition:

```yaml
jobs:
  sweep:
    runs-on: ubuntu-latest
    steps:
      - name: Gate
        id: gate
        run: |
          if [ "$ENABLED" = "true" ]; then ... else
            echo "pr-freshness idle (PR_FRESHNESS_ENABLED=${ENABLED:-unset})."
```

`vars.PR_FRESHNESS_ENABLED` is unset, so `steps.gate.outputs.go` is `false` and all four real steps are skipped — but GitHub has already scheduled the job and provisioned an `ubuntu-latest` VM by the time that step runs. The workflow fires on `schedule: '37 */6 * * *'` (4×/day) **plus every push to `main`**, which is what produces 65 runs in 14 days, 100% of them no-ops. Actions bills a minimum of one minute per job, so a 7-second no-op still costs a full billed minute.

## Fix

Hoist the gate from the first step to a job-level `if:`:

```yaml
jobs:
  sweep:
    if: vars.PR_FRESHNESS_ENABLED == 'true'
```

…and drop the now-tautological `Gate` step, the `ENABLED` env var, and the three `if: steps.gate.outputs.go == 'true'` step conditions. `vars` is available in `jobs.<id>.if`, so the decision moves ahead of runner provisioning: while the lane is off, the run resolves with zero jobs and zero runner minutes. The moment someone sets `PR_FRESHNESS_ENABLED=true`, behaviour is byte-for-byte what it was — the sweep logic, the token fallback chain, the `concurrency` queue-don't-cancel guard, and `timeout-minutes: 30` are all untouched.

This is a gate fix, not a mute: nothing is marked `continue-on-error`, and no failing check is being hidden. The workflow was already succeeding; it was just paying for a runner to say "idle".

## Expected impact

All 65 runs/14d become zero-job runs while the lane is disabled — **~25.4 minutes of Actions time per 14 days recovered (~55 min/month), and the 15.1m "wasted" attribution goes to zero.** Once the lane is switched on, cost returns to whatever the real sweep costs, which is the point.

Worth deciding separately: whether `PR_FRESHNESS_ENABLED` should be set to `true` at all. it-journey has `ISSUE_AUTOPILOT_ENABLED`, `ISSUE_AUTOMERGE_ENABLED` and `CONTENT_AUTOMERGE_ENABLED` on, and this workflow's own header documents the exact failure mode (PR #563 sitting conflicted for five days) it exists to prevent — so the merge lanes it backstops are live while their backstop is not. If it is meant to stay off permanently, deleting the workflow beats gating it.

## Links

- Sample no-op runs: [31868564218](https://github.com/bamr87/it-journey/actions/runs/31868564218) · [31855138692](https://github.com/bamr87/it-journey/actions/runs/31855138692) · [31830931569](https://github.com/bamr87/it-journey/actions/runs/31830931569)
- Dash Actions analytics: https://bamr87.github.io/bamr87/actions/

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
