### PR TITLE
fix(notes): resolve wiki links against the index's actual field name

### DIFF
--- a/assets/js/notes-workbench.js
+++ b/assets/js/notes-workbench.js
@@ -154,11 +154,11 @@
       var title = String(e.title || '').toLowerCase().trim();
       var base = String(e.basename || '').toLowerCase().trim();
       if (title === key || base === key || base === slug) {
-        return { url: e.permalink, title: e.title };
+        return { url: e.url, title: e.title };
       }
       if (!partial && title.indexOf(key + ':') === 0) partial = e;
     }
-    return partial ? { url: partial.permalink, title: partial.title } : null;
+    return partial ? { url: partial.url, title: partial.title } : null;
   }
   md.setWikiResolver(resolveWiki);
 


### PR DESCRIPTION
## What this fixes

`[[Wiki Links]]` in local workbench notes never resolved. A link to a page that exists still rendered as the muted "create this note" button.

`resolveWiki()` in `assets/js/notes-workbench.js` read `e.permalink`, but the theme's generated index emits `url`:

```json
{ "title": "Bash Cheatsheet: Essential Commands & Scripts",
  "basename": "bash-cheatsheet",
  "url": "/notes/cheatsheets/bash-cheatsheet/",
  "collection": "notes", "tags": [], "categories": [],
  "aliases": [], "outgoing": [], "excerpt": "…" }
```

So the lookup handed back `{ url: undefined }`, `linkHref()` correctly rejected it, and every match fell through to the unresolved branch. Two-line fix.

## Why the tests missed it

The renderer suite covered wiki links, but it called `MD.setWikiResolver()` with a **stub** — so it exercised `notes-markdown.js` and never `resolveWiki()` against the real index. The seam between the two was the one thing untested, and that's exactly where the bug was.

The browser suite now closes that gap: it fetches the real `/assets/data/wiki-index.json`, writes a note linking to a page from it, and asserts a real anchor with the expected `href`.

I verified the test actually catches the bug by reverting the fix — it fails as it should:

```
FAIL [[link]] renders as a real anchor, not a create button
       href=null expected=/notes/cheatsheets/bash-cheatsheet/
FAIL no stray create-button for a page that exists
```

## Verification

- Browser suite **52 passed, 0 failed** (49 before, +3 new wiki-link assertions).
- Jekyll CI-parity build clean.
- No behavior change beyond wiki-link resolution; the unresolved-link path still offers to create a local note when the target genuinely doesn't exist.

## Related

Found while researching [bamr87/zer0-mistakes#412](https://github.com/bamr87/zer0-mistakes/issues/412), a feature request for better notes/knowledge-base extension points in the theme — one of its asks is adding `lastmod` and `description` to this same index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014t3vW3Ezy83joAzdMSdLpk

---
_Generated by [Claude Code](https://claude.ai/code/session_014t3vW3Ezy83joAzdMSdLpk)_