### PR TITLE
fix(quest-perfection): keep genuinely-unexpected wipeouts loud, not silently green

### DIFF
--- a/.github/workflows/quest-perfection.yml
+++ b/.github/workflows/quest-perfection.yml
@@ -932,7 +932,19 @@ jobs:
             python3 scripts/quest/loop_health.py report --kind "$kind" --lane walk \
               --run-url "$run_url" --detail "$attempted slice(s) attempted, 0 quests scored; zero-score reasons:$reasons" || true
             echo "proceed=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            # auth/rate-limit are EXPECTED, self-healing states (a human rotating a
+            # secret, or a window refilling) — stay green so a scheduled run never
+            # withholds the gh-pages deploy over them (the whole point of this
+            # guard). Anything else (engine anomaly, a future new cause) is
+            # genuinely unexpected and must stay loud: fail the job so it's visible
+            # beyond the health issue. This can't become a new daily-red trap — the
+            # ledger's circuit breaker (M6) excludes a slice from selection after
+            # max_fix_rounds consecutive imperfect walks, so the same content
+            # anomaly can redden at most a few runs.
+            case "$kind" in
+              auth|rate-limit) exit 0 ;;
+              *) exit 1 ;;
+            esac
           fi
           # Progress was made — if a health issue is open from a previous bad spell,
           # close it: the loop heals its own alarm.


### PR DESCRIPTION
Follow-up to #641, which merged and got its OAuth credential rotated today. This is a fresh branch (per the merged-PR convention — #641's branch is fully squashed into `main`; this restarts from `origin/main` with one new commit).

# What happened

I manually dispatched `quest-perfection.yml` ([run 87](https://github.com/bamr87/it-journey/actions/runs/32799906663)) to confirm the rotated token, live, ahead of tomorrow's schedule. The gate's new preflight probe passed cleanly (`✅ preflight: ok — authenticated end-to-end`) — the credential fix works. But letting the loop actually *run* for the first time in 9 days immediately surfaced a bug in #641's own redesign.

The one planned quest ("Stack Attack: AI-Built Django + React Enterprise ERP") hit the execute engine's `--max-turns 40` cap mid-walk and scored 0 — a genuine engine anomaly, not auth and not a rate limit. `walk-evidence.json` correctly carries no `truncation_reason` for either of those, so the report job's wipeout guard correctly classified it as `kind=engine` and opened an accurate health issue (#642: *"produced no scored quests, and not because of auth or rate limits... smells like an engine or workflow bug"*).

But then the run **still exited 0** — every zero-productive cause (auth, rate-limit, *and* engine) fell through to the same unconditional `exit 0`. That directly contradicts #641's own stated contract ("red is reserved for the genuinely unexpected: engine exit codes outside the 0/2/4 contract...") and quietly recreates a milder version of the exact bug #641 fixed: real non-progress with no visible signal beyond a GitHub issue a human has to happen to notice. If the same slice keeps getting picked, this could go green-but-broken indefinitely.

# The fix

One place, `.github/workflows/quest-perfection.yml`'s report job (the wipeout guard at the end of "Replay ledger updates…"): route the exit code by `$kind` instead of always `exit 0`.

- `auth` / `rate-limit` → stay green (unchanged). These are the expected, self-healing states #641 was built to protect — a scheduled run must never withhold the `gh-pages` deploy over a credential a human hasn't rotated yet, or a window that refills on its own.
- Anything else (`engine`, or any future cause) → `exit 1`. Genuinely unexpected failures stay loud, as documented.

This can't reopen a daily-red trap: the ledger's circuit breaker (M6, `scripts/quest/ledger.py`) already excludes a slice from selection after `max_fix_rounds` (default 3) consecutive imperfect walks, so the same content anomaly can redden at most a handful of runs before the loop stops picking it. Verified directly — `ledger.py selftest` already pins this exact behavior ("Repeated imperfect (verdict-bearing) walks must trip stuck at max_fix_rounds").

The health-issue messaging itself (`scripts/quest/loop_health.py`) needed no change — its `engine` template is already accurate and doesn't misattribute the failure to credentials.

# Validation

- `python3 scripts/quest/ledger.py selftest` — passes (27 slices in universe; circuit-breaker test unaffected).
- YAML parses clean (`yaml.safe_load`); `lint-workflows.yml`'s `actionlint` will gate this PR the same way it gated #641.
- Live-reproduced against real evidence: this is the exact `walk-evidence.json` / report-job state from run 87, traced through the new branch by hand.

# Not in scope here

*Why* "Stack Attack" needs more than 40 turns (heavy quest, bootstraps a Django+React stack) is a content/tuning question, not a workflow-correctness one. It's already correctly surfaced via #642, which the loop's own circuit breaker and self-resolving health-issue mechanism will handle without further action — this PR only makes sure that surfacing is actually loud instead of silently green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfXMR5fF5ta9DvVCuRMiBG)_