### PR TITLE
🔧 Quest fix: game-developer/0001

### DIFF
--- a/pages/_quests/0001/stack-attack.md
+++ b/pages/_quests/0001/stack-attack.md
@@ -327,7 +327,7 @@ erp_stack:
     ci_cd: "GitHub Actions"
     monitoring: "Prometheus + Grafana"
     log_aggregation: "Loki + Promtail"
-```markdown
+```
 
 ### Phase 4 — Architecture Diagrams
 Generate Mermaid diagrams showing:
@@ -865,6 +865,7 @@ Include configuration for:
 
 ```python
 # config/settings/base.py
+from datetime import timedelta
 from decouple import Csv, config
 from pathlib import Path
 
@@ -1121,8 +1122,10 @@ npm install \
   tailwind-merge
 
 # Install shadcn/ui prerequisites
+# Pinned to the Tailwind v3 CLI workflow below — the current npm `latest`
+# tag (Tailwind v4) removed the `init` subcommand this quest relies on.
 npm install -D \
-  tailwindcss \
+  tailwindcss@^3 \
   postcss \
   autoprefixer \
   @types/node
@@ -1131,6 +1134,9 @@ npm install -D \
 npx tailwindcss init -p
 
 # Initialize shadcn/ui
+# The CLI may prompt "Select a component library" (Base UI / React Aria /
+# Radix UI) before it reaches the --yes-covered prompts — this quest's
+# generated components assume Radix UI, so answer that prompt with Radix UI.
 npx shadcn@latest init
 
 # Add core shadcn/ui components used in ERP
@@ -1292,11 +1298,14 @@ const columns: ColumnDef<SalesOrder>[] = [
   {
     accessorKey: "customer.name",
     header: "Customer",
-    cell: ({ row }) => (
-      <Link to="/contacts/$id" params={% raw %}{{ id: row.original.customer.id }}{% endraw %}>
-        {row.original.customer.name}
-      </Link>
-    ),
+    cell: ({ row }) => {
+      const customerParams = { id: row.original.customer.id };
+      return (
+        <Link to="/contacts/$id" params={customerParams}>
+          {row.original.customer.name}
+        </Link>
+      );
+    },
   },
   {
     accessorKey: "order_date",


### PR DESCRIPTION
## 🔧 Quest fix — `game-developer/0001`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: game-developer/0001

Evidence: execute-mode, non-truncated (`mode=execute`, no top-level `truncated`), 1 result
(`pages/_quests/0001/stack-attack.md`, verdict `fail`, `executed=true`, no `error`, not
`budget_exhausted`) — execution-grounded and eligible. Not vendored (no `source_repo`/`source_url`).
Tier-1 baseline: `quest_validator.py` 68/74 (91.9%), brand_lint clean.

- **pages/_quests/0001/stack-attack.md** — fixed failed command `config/settings/base.py sample`
  (verified: `commands[].status=failed`, AST `NameError` on `timedelta`; matches high-priority
  recommendation "settings/base.py sample"). Added `from datetime import timedelta`.
  tier-1 score_pct 91.9 → 91.9 (held), brand clean. ✅ kept.
- **pages/_quests/0001/stack-attack.md** — fixed failed command `src/pages/sales/orders/index.tsx sample`
  (verified: `commands[].status=failed`, 6 `tsc` syntax errors from a leaked
  `{% raw %}{{ id: row.original.customer.id }}{% endraw %}` Jekyll tag inside the JSX prop; matches
  high-priority recommendation "SalesOrdersPage.tsx sample"). Rewrote the prop as a plain local
  `customerParams` object so the code needs no Liquid escaping and compiles as authored — re-ran
  `tsc --noEmit` on the extracted sample and the syntax errors (TS1109/TS1005/TS1160) are gone,
  only the expected "Cannot find module" resolution errors remain (same class already treated as
  passing for this quest's other illustrative snippets). tier-1 score_pct 91.9 → 91.9 (held),
  brand clean. ✅ kept.
- **pages/_quests/0001/stack-attack.md** — fixed failed command `npm install -D tailwindcss ... && npx tailwindcss init -p`
  (verified: `commands[].status=failed`, "could not determine executable to run" — npm `latest`
  resolves Tailwind v4, which dropped the `init` CLI; matches high-priority recommendation
  "Tailwind CSS setup"). Pinned `tailwindcss@^3` (the smaller of the recommendation's two options,
  since no downstream `tailwind.config.js`/v4 CSS-config content exists elsewhere in the quest to
  migrate) with a one-line comment explaining why. tier-1 score_pct 91.9 → 91.9 (held), brand
  clean. ✅ kept.
- **pages/_quests/0001/stack-attack.md** — addressed failed command `npx shadcn@latest init` +
  medium-priority recommendation (area: "shadcn/ui init") together: added a comment documenting
  the new "Select a component library" prompt the CLI now shows and the answer (Radix UI, matching
  the components this quest scaffolds afterward) so it no longer stalls the learner. tier-1
  score_pct 91.9 → 91.9 (held), brand clean. ✅ kept.
- **pages/_quests/0001/stack-attack.md** — addressed low-priority recommendation (area: "Chapter 1 /
  stackattack.prompt.md nested code fence"). The inner ` ```yaml ` block was closed with
  ` ```markdown ` instead of a bare ` ``` `, an invalid CommonMark closing fence; fixed to a bare
  fence. tier-1 score_pct 91.9 → 91.9 (held), brand clean. ✅ kept.

All five edits applied together; combined tier-1 rerun after all edits: 68/74 (91.9%, held vs.
91.9% baseline), `brand_lint.py` clean, no new warnings. No frontmatter touched, so `make
quest-data` was not needed.

_Left (per-slice cap reached; these stay for a future pass):_
- Medium recommendation (area: "missing urls.py and Dockerfile.dev") — the `/health/`,
  `/api/schema/`, `/api/token/` wiring and a `Dockerfile.dev` sample are structural additions, not
  a smallest-faithful edit; left for a dedicated authoring pass rather than bolted on to hit the cap.
- Medium recommendation (area: "pagination mismatch") — reconciling `CursorPagination` in the
  backend sample vs. page-number pagination in the frontend sample needs a design decision (which
  side is correct), not mechanical; left for a human/author call.
- Low recommendation (area: "fence language labels") — relabeling several `/stackattack` chat-prompt
  fences (sql/text/bash/jsx → a consistent "prompt" convention) touches many locations across the
  file; deferred to keep this PR small and reviewable.
- Low recommendation (area: "docker-compose default credentials warning") — not evidence of a
  failure the walker hit (no failed command), lower priority than the cap allowed; deferred.

No quests skipped as vendored or ineligible — the slice's single result was the one eligible quest,
and it was fixed.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/32864510993)._
