### PR TITLE
🔧 Quest fix: game-developer/0001

### DIFF
--- a/pages/_quests/0001/liquid-templating.md
+++ b/pages/_quests/0001/liquid-templating.md
@@ -149,7 +149,7 @@ This **🟡 Medium** quest expects:
 
 ## 🌍 Choose Your Adventure Platform
 
-*Liquid lives inside your Jekyll site, so the only setup is a running site. Use `--livereload` so each edit shows instantly.*
+*Liquid lives inside your Jekyll site, so the only setup is a running site. Use `--livereload` so each edit shows instantly. The `my-castle` folder below is the site you scaffolded in [Jekyll Fundamentals](/quests/0001/jekyll-fundamentals/) - `cd` into that same directory, not a fresh one.*
 
 ### 🍎 macOS Kingdom Path
 
@@ -267,13 +267,15 @@ A list of the five most recent posts, each with an optional "New" badge:
 
 ```liquid
 
+{% raw %}{% assign week_ago = site.time | date: "%s" | minus: 604800 %}{% endraw %}
 <ul class="post-list">
 {% raw %}{% for post in site.posts limit:5 %}{% endraw %}
+  {% raw %}{% assign post_ts = post.date | date: "%s" %}{% endraw %}
   <li>
     <a href="{% raw %}{{ post.url | relative_url }}{% endraw %}">{% raw %}{{ post.title }}{% endraw %}</a>
     {% raw %}{% if post.featured %}{% endraw %}
       <span class="badge">⭐ Featured</span>
-    {% raw %}{% elsif post.date > site.time | date: "%s" | minus: 604800 %}{% endraw %}
+    {% raw %}{% elsif post_ts > week_ago %}{% endraw %}
       <span class="badge">New</span>
     {% raw %}{% endif %}{% endraw %}
   </li>
@@ -281,6 +283,8 @@ A list of the five most recent posts, each with an optional "New" badge:
 </ul>
 
 ```
+
+Liquid can't chain filters after a comparison operator inside an `elsif` condition - precompute both sides with `assign` first, as shown, then compare the plain values.
 
 Useful loop helpers:
 
@@ -297,7 +301,25 @@ Useful loop helpers:
 
 ```
 
-`if` understands `and`, `or`, `==`, `!=`, `>`, `<`, `contains`. Use `unless` for the negative case and `case`/`when` for many branches.
+`if` understands `and`, `or`, `==`, `!=`, `>`, `<`, `contains`. Use `unless` for the negative case and `case`/`when` for many branches:
+
+```liquid
+
+{% raw %}{% assign tags = "liquid,jekyll,templating" | split: "," %}{% endraw %}
+{% raw %}{% if tags contains "jekyll" %}{% endraw %}
+  Tagged with Jekyll!
+{% raw %}{% endif %}{% endraw %}
+
+{% raw %}{% case page.difficulty %}{% endraw %}
+  {% raw %}{% when "Easy" %}{% endraw %}
+    <span class="badge">🟢 Easy</span>
+  {% raw %}{% when "Medium" %}{% endraw %}
+    <span class="badge">🟡 Medium</span>
+  {% raw %}{% else %}{% endraw %}
+    <span class="badge">🔴 Advanced</span>
+{% raw %}{% endcase %}{% endraw %}
+
+```
 
 ### 🔍 Knowledge Check: Logic
 - [ ] How do you limit a `for` loop to the first five items?
@@ -404,12 +426,14 @@ Pair this with **loop-edge helpers** to render clean separators. `forloop.first`
 
 ```liquid
 
-{% raw %}{% for tag in page.tags %}{% endraw %}
-  {% raw %}{% unless forloop.first %}{% endraw %}, {% raw %}{% endunless %}{% endraw %}{% raw %}{{ tag }}{% endraw %}
-{% raw %}{% endfor %}{% endraw %}
+{% raw %}{%- for tag in page.tags -%}{% endraw %}
+  {% raw %}{%- unless forloop.first -%}{% endraw %}, {% raw %}{%- endunless -%}{% endraw %}{% raw %}{{ tag }}{% endraw %}
+{% raw %}{%- endfor -%}{% endraw %}
 <!-- Output: liquid, jekyll, templating  (no leading comma) -->
 
 ```
+
+The dashes on every `for`/`unless`/`endfor` tag matter here - without them, each tag leaves behind whitespace and newlines, breaking the clean single-line output this chapter is teaching.
 
 ### 🔍 Knowledge Check: Restraint
 - [ ] How do you leave a note in a template that never reaches the output?


### PR DESCRIPTION
## 🔧 Quest fix — `game-developer/0001`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: game-developer/0001

Evidence: execute-mode, fully-scored run (`total=scored=5`, `errored=0`, no truncation). 4 of 5 quests in the slice `pass`ed and were left untouched (out of scope — only `warn`/`fail` quests carry verified issues). One quest, `liquid-templating.md`, came back `warn` (overall 71) and was execution-grounded (`executed: true`, no error, not budget-exhausted) — eligible. Not vendored (no `source_repo`/`source_url`).

- **pages/_quests/0001/liquid-templating.md** — fixed failed command: Chapter 2 "New badge" `elsif` condition (verified: `commands[].status=failed`, `Liquid syntax error ... Expected end_of_string but found pipe`). Filters can't be chained after a comparison operator inside `elsif`; replaced with `assign`-precomputed `week_ago`/`post_ts` values compared directly, per the high-priority recommendation (area: "Chapter 2 — 'New' badge elsif example"). tier-1 score_pct 100.0 → 100.0 (held), brand clean. ✅ kept.
- **pages/_quests/0001/liquid-templating.md** — fixed failed command: Chapter 4 forloop/whitespace example (verified: `commands[].status=failed`, actual rendered output had stray newlines/leading spaces instead of the claimed single-line `liquid, jekyll, templating`). Added whitespace-control dashes to the `for`/`unless`/`endfor` tags so the snippet actually produces the output it claims, per the high-priority recommendation (area: "Chapter 4 — forloop/whitespace example"). tier-1 score_pct 100.0 → 100.0 (held), brand clean. ✅ kept.
- **pages/_quests/0001/liquid-templating.md** — addressed low-priority recommendation (area: "Platform setup section"): added a one-line note that `my-castle` is the site scaffolded in the Jekyll Fundamentals prerequisite, not a fresh folder. tier-1 score_pct 100.0 → 100.0 (held), brand clean. ✅ kept.
- **pages/_quests/0001/liquid-templating.md** — addressed low-priority recommendation (area: "Chapter 2 — case/when and contains"): added a short runnable `case`/`when` + `contains` example alongside the existing prose-only mention. tier-1 score_pct 100.0 → 100.0 (held), brand clean. ✅ kept.

No frontmatter was touched, so `_data/quests/**` regeneration is not required.

_Left:_ nothing reverted — all 4 queued issues passed the deterministic gate and were kept. The other 4 quests in the slice (`github-pages-basics.md`, `jekyll-fundamentals.md`, `yaml-configuration.md`, `git-workflow-mastery.md`) all verdict `pass` — out of scope per M7 (no verified issues to act on), left untouched.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/33103735375)._
