### PR TITLE
fix(ci): skip the brand gate on the gh-pages deploy PR

### DIFF
--- a/.github/workflows/content-quality.yml
+++ b/.github/workflows/content-quality.yml
@@ -14,12 +14,21 @@
 # the fast objective gate.
 #
 # Runs on `pull_request` (safe, read-only) so it also covers fork PRs.
+#
+# NOT on the `gh-pages` deploy PR: `sync-gh-pages.yml` opens a main -> gh-pages
+# PR twice daily, and `gh-pages` has diverged from `main` (68 commits), so the
+# merge ref GitHub builds for that PR never resolves — every `pull_request`
+# workflow in the repo dies at startup, before a single job is created. That is
+# a property of the deploy PR, not of this gate (feature-branch runs are green),
+# so filter the base branch rather than papering over the red.
 # =============================================================================
 name: ✒️ Content Quality (brand gate)
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    branches-ignore:
+      - gh-pages
     paths:
       - 'pages/**/*.md'
       - 'pages/**/*.markdown'


### PR DESCRIPTION
<!-- fleet-doctor key="bamr87/it-journey:.github/workflows/content-quality.yml" -->

## Problem

- **Repo:** bamr87/it-journey
- **Workflow:** `.github/workflows/content-quality.yml` — ✒️ Content Quality (brand gate)
- **Signals:** `failing`, `flaky` (80% success / 15 runs / 14d)

The "flaky" reading is an artifact. The workflow is not intermittently broken — it fails **deterministically on one specific kind of PR** and passes on every other.

Correlating each run in the 14d window against its head branch:

| conclusion | head branch |
|---|---|
| **failure** | `main` (2026-08-28 18:28) |
| **failure** | `main` (2026-08-28 05:01) |
| success | `automated/quest-perfection-2026-08-28` |
| success | `automated/quest-fix-game-developer-0001` |
| success | `style/markdown-oneline` |
| success | `content/second-shift-quest` |
| … | (all other feature branches green) |

Every failure is on `head_branch: main`. The only PRs with head `main` are the deploy PRs that `sync-gh-pages.yml` opens twice daily (cron `20 2,14 * * *`): [`#661 🚀 Deploy: sync gh-pages with main@71f84118`](https://github.com/bamr87/it-journey/pull/661), base `gh-pages`.

## Root cause

The failing run creates **no jobs at all**:

```
$ gh run view -R bamr87/it-journey 33199465695
X main ✒️ Content Quality (brand gate) bamr87/it-journey#661 · 33199465695
X This run likely failed because of a workflow file issue.

$ gh run view -R bamr87/it-journey 33199465695 --log-failed
failed to get run log: log not found
```

That is a startup failure — GitHub never got as far as running a step, so there is nothing wrong with `brand_lint.py` or any step in this file. It is not specific to this workflow either: **all seven** `pull_request` workflows on that same head SHA failed identically.

```
$ gh api "repos/bamr87/it-journey/actions/runs?head_sha=71f8411..." --jq '...'
failure  pull_request  CI
failure  pull_request  Frontmatter Validation
failure  pull_request  markdown-oneline
failure  pull_request  ✒️ Content Quality (brand gate)
failure  pull_request  🎯 Quest Content Validation
failure  pull_request  📝 Content Review
failure  pull_request  🔗 Link Health Guardian
```

For a `pull_request` event GitHub resolves workflows from the **merge ref** (head merged into base). The base here is `gh-pages`, and `gh-pages` is not the mirror the sync workflow's header comment assumes it is:

```
$ gh api repos/bamr87/it-journey/compare/gh-pages...main --jq '{ahead_by,behind_by,status}'
{"ahead_by":1,"behind_by":68,"status":"diverged"}
```

`gh-pages` carries 68 commits `main` does not, so the merge ref for the deploy PR never resolves and every `pull_request` workflow dies at startup. `sync-gh-pages.yml` even documents the opposite expectation — *"Only the Pages build runs on the gh-pages update"* — but that reasoning covers the **push** to `gh-pages`, not the **PR** that precedes it.

## Fix

Add a base-branch filter so the brand gate never subscribes to the deploy PR:

```yaml
on:
  pull_request:
    types: [opened, synchronize, reopened]
    branches-ignore:
      - gh-pages
    paths:
      - 'pages/**/*.md'
      - 'pages/**/*.markdown'
```

`branches-ignore` filters on the PR's **base**, so this drops exactly the `main → gh-pages` deploy PR and nothing else. Real content PRs (base `main`) are unaffected — they are the runs that are already green.

Deliberately *not* done: no `continue-on-error`, no retry, no change to the gate's logic. The gate works; it was being asked a question about a PR it has no business inspecting. A deploy PR contains no reviewable content change — it is `main`'s already-merged, already-linted content being republished.

## Expected impact

- Removes 2 spurious red checks/day from this workflow (~14/mo), and with it the false `failing` + `flaky` signal that put it on the fleet-doctor queue.
- Minutes recovered are ~0 — startup failures never bill. The cost here is **signal**, not compute: a permanently-red required check on the deploy PR trains reviewers to ignore red, and it is why this workflow reads as 80%-success/flaky rather than 100%-on-content-PRs.

## Scope note

The same one-line filter fixes the five sibling workflows (`CI`, `Frontmatter Validation`, `markdown-oneline`, `🎯 Quest Content Validation`, `🔗 Link Health Guardian`) — they are red on every deploy PR for the identical reason. This PR is kept to the one workflow the fleet-doctor queue named. The durable fix is arguably in `sync-gh-pages.yml`: push `main → gh-pages` directly (the branch is meant to be a mirror) instead of routing through a PR that no one reviews, which would remove all seven red checks and the divergence at once. Worth deciding separately.

## Links

- Failing run: https://github.com/bamr87/it-journey/actions/runs/33199465695
- Prior failing run (same cause): https://github.com/bamr87/it-journey/actions/runs/33143508865
- Deploy PR that triggered it: https://github.com/bamr87/it-journey/pull/661
- Dash Actions analytics: https://bamr87.github.io/bamr87/actions/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
