### PR TITLE
fix(ci): stop the agentic quest review cancelling itself, skip the deploy PR

### DIFF
--- a/.github/workflows/agentic-quest-review.yml
+++ b/.github/workflows/agentic-quest-review.yml
@@ -38,14 +38,30 @@ on:
         default: '0'
   pull_request:
     types: [opened, synchronize, reopened, labeled]
+    # NOT the `gh-pages` deploy PR: sync-gh-pages.yml opens a main -> gh-pages PR
+    # twice daily, and gh-pages has diverged from main (68 commits), so the merge
+    # ref GitHub builds for it never resolves — every pull_request workflow in the
+    # repo dies at startup, before a single job is created.
+    branches-ignore:
+      - gh-pages
     paths:
       - 'pages/_quests/**/*.md'
 
 permissions:
   contents: read
 
+# A `labeled` event for any label other than `agentic-review` produces a run whose
+# only job is skipped by the `if:` below — but concurrency is evaluated BEFORE the
+# job `if:`, so in a shared group that no-op run CANCELS the real review already in
+# flight. Every automated PR gets three labels applied right after `opened`, which
+# is exactly how PR #648 and #657 turned one review into six runs, none of which
+# survived. Give the no-op label runs their own group so they can cancel nothing;
+# everything that actually reviews still shares one group and still supersedes.
 concurrency:
-  group: agentic-quest-review-${{ github.ref }}
+  group: >-
+    agentic-quest-review-${{ github.ref }}-${{
+    (github.event.action == 'labeled' && github.event.label.name != 'agentic-review')
+    && github.run_id || 'review' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
<!-- fleet-doctor key="bamr87/it-journey:.github/workflows/agentic-quest-review.yml" -->

## Problem

- **Repo:** bamr87/it-journey
- **Workflow:** `.github/workflows/agentic-quest-review.yml` — 🤖 Agentic Quest Review
- **Signals:** `cancel-heavy`, `failing`, `flaky` (75% success / 14 runs / 14d)

Two *independent* causes, which is why the signal reads as all three at once. In the last 14 days this workflow completed a review exactly **once**.

```
$ gh api ".../workflows/agentic-quest-review.yml/runs" --jq '...'
failure    2026-08-28T05:01:29Z  main
skipped    2026-08-27T18:35:21Z  automated/quest-fix-game-developer-0001
skipped    2026-08-27T18:35:17Z  automated/quest-fix-game-developer-0001
cancelled  2026-08-27T18:35:17Z  automated/quest-fix-game-developer-0001
cancelled  2026-08-27T18:35:17Z  automated/quest-fix-game-developer-0001
skipped    2026-08-25T15:35:03Z  automated/quest-fix-game-developer-0001
cancelled  2026-08-25T15:35:02Z  automated/quest-fix-game-developer-0001
skipped    2026-08-25T15:35:02Z  automated/quest-fix-game-developer-0001
skipped    2026-08-25T15:35:01Z  automated/quest-fix-game-developer-0001
cancelled  2026-08-25T15:35:01Z  automated/quest-fix-game-developer-0001
cancelled  2026-08-25T15:35:01Z  automated/quest-fix-game-developer-0001
success    2026-08-20T04:04:08Z  claude/quest-walkthrough-video-framework-u1j7fg
```

## Root cause 1 — the workflow cancels itself (`cancel-heavy`)

Six runs on 2026-08-25 within **two seconds**, four more on 2026-08-27 within four. Not a retry storm — a label burst:

```
$ gh pr list -R bamr87/it-journey --head automated/quest-fix-game-developer-0001 --json number,labels,createdAt
#657  createdAt 2026-08-27T18:35:13Z  labels: automated, auto:content, auto:quest-fix
#648  createdAt 2026-08-25T15:34:57Z  labels: automated, auto:content, auto:quest-fix
```

`quest-fix.yml` opens the PR and then applies **three** labels. With `types: [..., labeled]` that is 1 `opened` + 3 `labeled` events, so four runs — and they all landed in one concurrency group with `cancel-in-progress: true`.

The `if:` guard was written to make this cheap:

```yaml
# on `labeled` ONLY when the label is `agentic-review` — so a
# random label never triggers a paid run.
```

It does prevent the *spend*, but not the *cancel*: **concurrency is evaluated before the job-level `if:`**. Each no-op label run first evicts the in-flight review, and only then discovers it has nothing to do and reports `skipped`. That is the exact `cancelled`/`skipped` pairing at identical timestamps above — the `opened` run that would have done the real review was killed by a label event ~4 seconds later, on every automated quest PR.

The queue's guidance — *"check whether `cancel-in-progress: true` is ALREADY set; if so the fix is to start fewer runs, not to add more cancelling"* — applies, with the wrinkle that `on:` cannot filter by label name, so the run cannot be prevented. The equivalent is to stop the un-preventable no-op run from *contending*.

## Root cause 2 — the `gh-pages` deploy PR (`failing`)

The one `failure`, on `head_branch: main`, is [PR #661](https://github.com/bamr87/it-journey/pull/661) — the `main → gh-pages` deploy PR that `sync-gh-pages.yml` opens twice daily. It produced **no jobs**:

```
$ gh run view -R bamr87/it-journey 33143508865
X This run likely failed because of a workflow file issue.
$ gh run view -R bamr87/it-journey 33143508865 --log-failed
failed to get run log: log not found
```

All **seven** `pull_request` workflows on that SHA failed identically, because `gh-pages` has diverged from `main` and the PR's merge ref never resolves:

```
$ gh api repos/bamr87/it-journey/compare/gh-pages...main --jq '{ahead_by,behind_by,status}'
{"ahead_by":1,"behind_by":68,"status":"diverged"}
```

Nothing to do with this workflow's logic. Same cause as #662.

## Fix

**1. Isolate the no-op label runs** so they cancel nothing, while every run that actually reviews keeps sharing one group and still supersedes its predecessor:

```yaml
concurrency:
  group: >-
    agentic-quest-review-${{ github.ref }}-${{
    (github.event.action == 'labeled' && github.event.label.name != 'agentic-review')
    && github.run_id || 'review' }}
  cancel-in-progress: true
```

- `labeled` with a label that is *not* `agentic-review` → group keyed by `github.run_id`, unique per run: it cancels nothing and nothing cancels it (it is skipped by the `if:` regardless).
- everything else — `opened` / `synchronize` / `reopened`, `workflow_dispatch`, and `labeled` with `agentic-review` → group `…-review`, i.e. today's behaviour, so a new push still supersedes a running review.

**2. Skip the deploy PR** — `branches-ignore: [gh-pages]` on the `pull_request` trigger, filtering on base branch.

No `continue-on-error`, no retries, no change to the convergence guard or the spend caps — the cost controls in this workflow are sound and untouched.

## Expected impact

- **~0.2m/14d of `cancelled` runner time recovered** — small, because a cancelled run dies in seconds. The real recovery is *the review itself*: on the last two automated quest PRs the advisory review never ran, so `quest-fix` PRs merged with no agentic feedback at all. This restores the ~0.4m/run review on those PRs rather than saving minutes.
- Removes 2 spurious startup failures/day and the false `failing` + `flaky` classification.
- Run count on a label burst drops from 4 billed-and-discarded to 1 useful + 3 immediately-skipped.

## Verification

`lint-workflows.yml` runs `actionlint` on changed workflow files, so the new `concurrency.group` expression is statically validated by this PR's own CI. Contexts used (`github.ref`, `github.event.action`, `github.event.label.name`, `github.run_id`) are all available at workflow level; `github.event.label` is `null` on non-label events, which the `&&`/`||` chain handles by falling through to `'review'`.

## Links

- Failing run: https://github.com/bamr87/it-journey/actions/runs/33143508865
- Self-cancelled review: https://github.com/bamr87/it-journey/actions/runs/33104218345
- Label-burst PRs: [#657](https://github.com/bamr87/it-journey/pull/657), [#648](https://github.com/bamr87/it-journey/pull/648)
- Companion PR (same deploy-PR cause): #662
- Dash Actions analytics: https://bamr87.github.io/bamr87/actions/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
