### PR TITLE
🔧 Quest fix: digital-artist/0001

### DIFF
--- a/pages/_quests/0001/side-quest-avatar-forge.md
+++ b/pages/_quests/0001/side-quest-avatar-forge.md
@@ -97,7 +97,7 @@ Options for sourcing an avatar:
 
 ### Step 2: Update Your Data File
 
-Edit `_data/contributors/YOUR_USERNAME.yml`:
+Edit `_data/contributors/YOUR_USERNAME.yml` — add or update only the `avatar:` key inside the existing `profile:` block, so you don't overwrite any other profile fields already there:
 
 ```yaml
 profile:
@@ -117,7 +117,8 @@ If adding the image to the repo:
 
 ```bash
 mkdir -p assets/images/contributors
-cp /path/to/your/avatar.png assets/images/contributors/YOUR_USERNAME.png
+cp <PATH_TO_YOUR_AVATAR> assets/images/contributors/YOUR_USERNAME.png
+# Replace <PATH_TO_YOUR_AVATAR> with the real path to your image file, e.g. ~/Downloads/avatar.png
 ```
 
 ### Step 4: Verify

--- a/pages/_quests/0001/side-quest-badge-collector.md
+++ b/pages/_quests/0001/side-quest-badge-collector.md
@@ -121,11 +121,23 @@ Badges include an `earned_on` date that's preserved across regeneration — your
 
 ### Step 1: Check Your Current Badges
 
-Run the stats generator (or check your data file after it's been auto-updated):
+`_data/contributors/YOUR_USERNAME.yml` is created by the **[Forge Your Character](/quests/0001/forge-your-character/)** prerequisite quest and kept up to date by the stats generator — you don't create it here; run the generator (or check your data file after it's been auto-updated):
 
 ```bash
 make contributor-stats USERNAME=YOUR_USERNAME
 cat _data/contributors/YOUR_USERNAME.yml
+```
+
+(`YOUR_USERNAME` is your GitHub handle, e.g. `octocat`.)
+
+Your file should already contain an `achievements` array like this — that's your ground truth for what you've earned so far:
+
+```yaml
+achievements:
+  - id: first_blood
+    earned_on: '2026-01-05'
+  - id: quest_forger
+    earned_on: '2026-02-14'
 ```
 
 Look at the `achievements` section to see what badges you've earned.

--- a/pages/_quests/0001/stating-the-stats.md
+++ b/pages/_quests/0001/stating-the-stats.md
@@ -255,13 +255,14 @@ Create a Ruby script to analyze your Jekyll site and generate statistics:
 
 require 'yaml'
 require 'date'
+require 'time'
 
 # This script generates comprehensive site statistics
 # Run during Jekyll build or manually: ruby scripts/generation/generate_statistics.rb
 
 class StatisticsGenerator
   def initialize
-    @site_root = File.expand_path('../..', __FILE__)
+    @site_root = File.expand_path('../../..', __FILE__)
     @posts_dir = File.join(@site_root, 'pages/_posts')
     @output_file = File.join(@site_root, '_data/content_statistics.yml')
   end
@@ -326,7 +327,7 @@ class StatisticsGenerator
     # Simple frontmatter parser
     if content =~ /^---\s*\n(.*?)\n---\s*\n(.*)$/m
       begin
-        frontmatter = YAML.safe_load($1)
+        frontmatter = YAML.safe_load($1, permitted_classes: [Date, Time])
         body = $2
         [frontmatter, body]
       rescue => e
@@ -536,7 +537,7 @@ permalink: /stats/
         <div class="card-body text-center">
           <i class="bi bi-fonts display-4 text-success"></i>
           <h2 class="card-title mt-3 mb-0">
-            {% raw %}{{ site.data.content_statistics.total_words | number_with_delimiter }}{% endraw %}
+            {% raw %}{{ site.data.content_statistics.total_words }}{% endraw %}
           </h2>
           <p class="card-text text-muted">Total Words</p>
         </div>
@@ -1034,6 +1035,7 @@ Shows 0 posts but I have posts
 - Verify posts are in `pages/_posts/` directory
 - Check frontmatter is valid YAML
 - Ensure posts have proper date format
+- If every post is skipped, confirm `parse_post` calls `YAML.safe_load($1, permitted_classes: [Date, Time])` — without `permitted_classes` it raises `Psych::DisallowedClass` on the standard unquoted `date:` field and silently skips every post
 - Run script with debugging: `ruby -d scripts/generation/generate_statistics.rb`
 
 **Issue: Page styling broken**

--- a/pages/_quests/0001/terminal-mastery.md
+++ b/pages/_quests/0001/terminal-mastery.md
@@ -333,10 +333,12 @@ cd ../Documents            # Go up one level, then into Documents
 ```bash
 # Create directories for organized learning
 mkdir terminal-practice
-mkdir -p projects/web-dev/my-first-site    # -p creates parent directories too
 
 # Navigate into your new workspace
 cd terminal-practice
+
+# Create your projects tree inside the workspace (later chapters copy/search this)
+mkdir -p projects/web-dev/my-first-site    # -p creates parent directories too
 
 # Create multiple directories at once
 mkdir docs scripts tests
@@ -395,6 +397,9 @@ EOF
 **Step 2: Copying and Moving with Precision**
 
 ```bash
+# Set up the targets these examples copy/move into
+mkdir -p backups styles backup && touch important-file.txt
+
 # Copy files (cp command)
 cp quest-log.md quest-backup.md          # Copy single file
 cp *.js scripts/                         # Copy all JavaScript files to scripts folder
@@ -412,6 +417,9 @@ cp -i important-file.txt backup/         # -i prompts before overwriting
 **Step 3: Strategic File Removal**
 
 ```bash
+# Set up sample files these examples remove/move
+mkdir -p ~/.trash && touch temp-file.txt session.tmp unwanted-file.txt
+
 # Remove files (DANGER ZONE - be careful!)
 rm temp-file.txt                         # Remove single file
 rm -i *.tmp                              # Remove with confirmation (-i)
@@ -419,7 +427,7 @@ rm -rf old-project/                      # Remove directory and contents (-rf)
 
 # Safer alternatives
 mv unwanted-file.txt ~/.trash/           # Move to trash instead of deleting
-ls *.log | head -5 | xargs rm           # Remove only first 5 log files
+ls *.log 2>/dev/null | head -5 | xargs -r rm   # Remove only first 5 log files (-r skips if none exist)
 
 # Create a safety alias (add to ~/.zshrc or ~/.bashrc)
 alias rm='rm -i'                        # Always prompt before deleting
@@ -468,8 +476,15 @@ wc -l *.txt                             # Just line counts for all text files
 **Step 2: Searching and Filtering Magic**
 
 ```bash
+# Set up sample files these search examples look through
+echo "function greet() { return 'hi'; }" > projects/app.js
+printf "info: start\nerror: disk failure\n" > logfile.txt
+echo "app.js" > file-list.txt
+printf "error: disk full\nwarning: low memory\n" > logs.txt
+printf "INFO start\nERROR disk failure\n" > app.log   # for the *.log pipeline example in Step 3
+
 # Find patterns in files using grep
-grep "terminal" learning-notes.txt       # Find lines containing "terminal"
+grep -i "terminal" learning-notes.txt    # Find lines containing "terminal" (case-insensitive, matches "Terminal")
 grep -i "COMMAND" *.txt                  # Case-insensitive search (-i)
 grep -r "function" projects/             # Recursive search in directory
 grep -n "error" logfile.txt              # Show line numbers (-n)


### PR DESCRIPTION
## 🔧 Quest fix — `digital-artist/0001`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: digital-artist/0001

Evidence: execute mode, non-truncated (5 quests walked, 1 engine-errored). Fixed verified issues on the 4 execution-grounded quests (`warn`/`fail`, no `error`, `executed==true`, not `budget_exhausted`).

- **pages/_quests/0001/stating-the-stats.md** — fixed the failed command `ruby scripts/generation/generate_statistics.rb` (verified: `commands[].status=failed`, 3 real bugs). Added `require 'time'` (`Time.now.iso8601` raised `NoMethodError`), corrected `File.expand_path('../..', __FILE__)` → `File.expand_path('../../..', __FILE__)` (was resolving to `<root>/scripts`, breaking `@posts_dir`/`@output_file`), and passed `permitted_classes: [Date, Time]` to `YAML.safe_load` (was rejecting every post's standard unquoted `date:` field, so `total_posts` stayed 0). Re-ran the patched script against a synthetic Jekyll post locally — it now completes and writes `_data/content_statistics.yml` correctly. Also addressed two medium recommendations: removed the non-existent `number_with_delimiter` Liquid filter (not a Jekyll/Liquid builtin) and added a troubleshooting entry for the `YAML.safe_load`/Date failure mode. tier-1 `average_score` 91.89 → 91.89 (held). brand_lint clean. ✅ kept.
- **pages/_quests/0001/terminal-mastery.md** — fixed 4 failed commands (verified: `commands[].status=failed` on Chapter 3 Step 2 cp/mv, Chapter 3 Step 3 rm, Chapter 4 Step 2 grep, Chapter 4 Step 3 pipelines — all failing because target files/dirs referenced later were never created earlier in the quest). Moved the `projects/` creation inside `terminal-practice` (was a sibling dir, so `cp -r projects/ backup-projects/` couldn't find it); added small setup lines creating `backups/`, `styles/`, `backup/`, `important-file.txt` before the cp/mv block; created `temp-file.txt`/`session.tmp`/`unwanted-file.txt`/`~/.trash` before the rm block and changed `xargs rm` → `xargs -r rm` (was erroring "missing operand" on an empty glob); added setup lines creating `logfile.txt`, `file-list.txt`, `logs.txt`, `app.log`, `projects/app.js` before the grep/pipeline blocks and fixed `grep "terminal"` → `grep -i "terminal"` (the quest's own generated file only contains capitalized "Terminal"). Replayed all 21 code blocks in a fresh sandbox end-to-end — all now exit 0. tier-1 `average_score` 95.95 → 95.95 (held). brand_lint clean. ✅ kept.
- **pages/_quests/0001/side-quest-avatar-forge.md** — addressed two medium recommendations: marked the placeholder `cp /path/to/your/avatar.png ...` as `<PATH_TO_YOUR_AVATAR>` with a substitution note (verified: `commands[].status=failed`, ran verbatim it errors "No such file or directory" and, unlike `YOUR_USERNAME`, was never flagged as a placeholder), and clarified Step 2 to update only the `avatar:` key inside the existing `profile:` block rather than implying a full-file replace. tier-1 `average_score` 85.14 → 85.14 (held). brand_lint clean. ✅ kept.
- **pages/_quests/0001/side-quest-badge-collector.md** — addressed the high-priority recommendation (area: "Step 1 / prerequisites") by stating in prose that `_data/contributors/YOUR_USERNAME.yml` comes from the prerequisite quest, adding a sample `achievements:` YAML block (verified valid via `YAML.safe_load`) as ground truth, and the low-priority recommendation clarifying `YOUR_USERNAME` = GitHub handle. tier-1 `average_score` 78.38 → 78.38 (held). brand_lint clean. ✅ kept.

_Left:_
- **pages/_quests/0001/forge-your-character.md** — skipped, not eligible: result carries an `error` ("claude exited 1 … Reached maximum number of turns (40)") and `verdict_obj` is `None` — an engine error, needs a re-walk, not grounded evidence to fix against.
- **terminal-mastery.md** — left the Chapter 2 Step 1/2 placeholder `cd` paths (`cd Documents`, `cd /Users/username/...`) and the hardcoded `# Expected output: bamr87` unfixed, plus the "Process Management Skills" objective gap (no `ps`/`top`/`kill`/`jobs` coverage) — all real, evidence-grounded issues, but adding a full process-management chapter or reworking every placeholder path is not the smallest edit; deferring to keep this PR small and reviewable (the loop runs daily).
- **side-quest-badge-collector.md** — left the "Step 4 only covers 4/12 catalog badges" and "add a screenshot of the rendered Featured/All Achievements section" medium recommendations unaddressed for the same reason (larger authoring effort than a single-pass smallest fix).
- No edit was reverted — every kept edit held-or-rose on the tier-1 validator and stayed brand-lint clean.
- No frontmatter was touched by any edit, so no `_data/quests/**` regeneration is needed for this fragment.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/33259079248)._
