### PR TITLE
fix(ci): only run PR gates on PRs targeting main (stops daily gh-pages startup failures)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,14 @@ name: CI
 # bamr87/bamr87/.github/workflows/standard-ci.yml. Don't edit the logic here.
 # (main is substituted with the repo's default branch on adoption.)
 
+# `pull_request.branches` filters on the PR's BASE branch. Without it this gate
+# also fires on the bot's `main` -> `gh-pages` deploy PR opened by
+# sync-gh-pages.yml, where GitHub cannot compute a merge ref against gh-pages'
+# unrelated history — every such run dies as a startup_failure (0 jobs) and
+# shows up as a red CI run that has nothing to do with the code.
 on:
   pull_request:
+    branches: [main]
   push:
     branches: [main]
 

--- a/.github/workflows/frontmatter-validation.yml
+++ b/.github/workflows/frontmatter-validation.yml
@@ -9,8 +9,14 @@ name: Frontmatter Validation
 # cms-daily-loop.yml (Lane A). Quest frontmatter is validated by
 # quest-validation.yml, so it is excluded here to avoid double coverage.
 
+# `branches:` filters on the PR's BASE branch. The `paths:` filter alone does not
+# exclude the bot's `main` -> `gh-pages` deploy PR (sync-gh-pages.yml): that PR's
+# diff spans the whole tree, so `pages/**/*.md` always matches, and the run then
+# dies as a startup_failure because GitHub cannot build a merge ref against
+# gh-pages' unrelated history.
 on:
   pull_request:
+    branches: [main]
     paths:
       - 'pages/**/*.md'
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
<!-- fleet-doctor key="bamr87/it-journey:.github/workflows/ci.yml" -->
<!-- fleet-doctor key="bamr87/it-journey:.github/workflows/frontmatter-validation.yml" -->

This PR resolves **two** fleet-doctor candidates (`CI` and `Frontmatter Validation`). They are one bug, in two files, so they get one PR rather than two conflicting ones — both markers are above so neither is re-filed.

## Problem

- **Repo:** bamr87/it-journey
- **Workflows:** `.github/workflows/ci.yml`, `.github/workflows/frontmatter-validation.yml`
- **Signals:** `failing`, `flaky` (both candidates)

Neither run has a log — `gh run view --log-failed` returns `failed to get run log: log not found`, and `gh run view` reports *"This run likely failed because of a workflow file issue."* The API confirms why:

```
$ gh api repos/bamr87/it-journey/actions/runs/33288336031/jobs --jq '.total_count'
0
```

Zero jobs, conclusion `failure` — a **startup_failure**. There is no log because nothing ever ran.

The failure is not isolated to these two workflows. Six workflows failed at the **same second** on the same PR:

```
33288336031 failure CI                        [pull_request/main] 2026-08-30T02:35:25Z
33288335830 failure 📝 Content Review          [pull_request/main] 2026-08-30T02:35:24Z
33288335827 failure 🔗 Link Health Guardian    [pull_request/main] 2026-08-30T02:35:24Z
33288335826 failure 🎯 Quest Content Validation [pull_request/main] 2026-08-30T02:35:24Z
33288335823 failure markdown-oneline           [pull_request/main] 2026-08-30T02:35:24Z
33288335820 failure Frontmatter Validation     [pull_request/main] 2026-08-30T02:35:24Z
```

Six red workflows, one cause.

## Root cause

The triggering PR is not a code PR:

```
$ gh pr view 669 -R bamr87/it-journey --json baseRefName,headRefName,mergeable,author
{"author":{"login":"app/github-actions","is_bot":true},
 "baseRefName":"gh-pages","headRefName":"main","mergeable":"UNKNOWN",...}
```

`sync-gh-pages.yml` opens a bot PR **`main` → `gh-pages`** on every deploy. `gh-pages` is a built-artifact branch with history unrelated to `main`, so GitHub cannot compute the PR's merge ref — `mergeable: UNKNOWN`. Every `pull_request`-scoped workflow in the repo fires on that PR and immediately dies at startup, before any job is created.

`frontmatter-validation.yml` already has a `paths:` filter (`pages/**/*.md`), which does *not* help: a whole-tree `main` → `gh-pages` diff matches that path every time. `paths:` filters the diff; it cannot filter the base branch.

This is also the `flaky` signal — these workflows are green on real PRs and on `push`, and red only on the daily deploy PR:

```
33264610164 success CI [push/main] 2026-08-29T17:03:18Z
```

## Fix

Add `branches: [main]` to the `pull_request` trigger in both files. `pull_request.branches` filters on the PR's **base** branch, so these gates now run on PRs into `main` and skip the `gh-pages` deploy PR entirely. Each file also gets a comment explaining why the filter is load-bearing, so it is not "tidied away" later.

```yaml
on:
  pull_request:
    branches: [main]
```

No gate coverage is lost: the `gh-pages` deploy PR is generated build output, not review surface, and the gates could never actually execute on it.

Only these two files change — the four other workflows hit by the same bug (`content-review`, `link-health`, `quest-validation`, `markdown-oneline`) are outside this work order's queue and need the same one-line filter in a follow-up.

## Expected impact

- 2 of the 6 daily startup failures stop (all 6 with the follow-up).
- Removes the standing red on `CI` and `Frontmatter Validation`, which currently sit at 81.0% and 76.5% success purely from this bot PR.
- Negligible minutes recovered — startup failures bill nothing. The cost here is signal, not spend: a permanently red CI badge that trains everyone to ignore it.

## Links

- https://github.com/bamr87/it-journey/actions/runs/33288336031 (CI)
- https://github.com/bamr87/it-journey/actions/runs/33288335820 (Frontmatter Validation)
- https://github.com/bamr87/it-journey/pull/669 (the triggering deploy PR)
- Dash: https://bamr87.github.io/bamr87/actions/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
