### PR TITLE
docs(quest): add FrontendAtlas practice resource

### DIFF
--- a/pages/_quests/1110/system-design-interviews.md
+++ b/pages/_quests/1110/system-design-interviews.md
@@ -5,7 +5,7 @@ description: 'Learn a repeatable system design interview framework - clarify req
 excerpt: A repeatable framework for system design interviews - requirements, estimation, design, and trade-off articulation
 preview: images/previews/system-design-interviews-whiteboard-framework.png
 date: '2025-11-29T22:51:57.000Z'
-lastmod: '2026-06-14T00:00:00.000Z'
+lastmod: '2026-08-31T00:00:00.000Z'
 level: '1110'
 difficulty: ⚔️ Epic
 estimated_time: 5-6 hours
@@ -431,6 +431,7 @@ For every decision, say the alternative and its cost: SQL vs. NoSQL (consistency
 ### Community Resources
 - [System Design Interview, Vol. 1 & 2 (Alex Xu)](https://www.amazon.com/System-Design-Interview-insiders-Second/dp/B08CMF2CQF) - The standard prep books
 - [Grokking the System Design Interview](https://www.designgurus.io/course/grokking-the-system-design-interview) - Structured practice problems
+- [FrontendAtlas: Frontend System Design Practice](https://frontendatlas.com/system-design) - Frontend-focused interview prompts, trade-offs, and guided answer practice
 - [ByteByteGo](https://bytebytego.com/) - Alex Xu's diagrams and newsletter
 
 ### Learning Materials


### PR DESCRIPTION
## What & why

Adds FrontendAtlas under **Community Resources** in the System Design Interviews quest and updates the quest `lastmod` value.

The quest already links to general system-design materials. This adds a frontend-specific practice bank covering client architecture, state and data boundaries, performance, accessibility, and trade-off reasoning. The destination currently includes 7 free full solutions and 16 premium breakdowns.

## Disclosure

I am affiliated with FrontendAtlas and am submitting this resource on its behalf.

## Conventional Commit

The PR title uses the repository's documented `docs(quest): …` format.

## Validation

- [x] Confirmed `https://frontendatlas.com/system-design` is live and supports the description
- [x] Reviewed the final GitHub diff: one Markdown file, one resource entry, and the `lastmod` update
- [ ] `make quest-audit` was not run locally
- [ ] `bundle exec jekyll build --config _config_dev.yml` was not run locally

## Checklist

- [x] PR title is a Conventional Commit
- [ ] Tests added/updated and passing (CI green)
- [x] Docs updated; no README or generated-file change is required for this link-only edit
- [x] No secrets, generated artifacts, or unrelated changes