### PR TITLE
🔧 Quest fix: digital-artist/0001

### DIFF
--- a/pages/_quests/0001/stack-attack.md
+++ b/pages/_quests/0001/stack-attack.md
@@ -815,7 +815,9 @@ pip install \
   psycopg[binary]==3.2.* \
   django-storages[s3]==1.14.* \
   sentry-sdk[django]==2.* \
-  django-health-check==3.18.*
+  django-health-check==3.18.* \
+  python-decouple==3.8.* \
+  django-celery-beat==2.7.*
 
 # Freeze dependencies
 pip freeze > requirements.txt
@@ -897,6 +899,7 @@ THIRD_PARTY_APPS = [
     "health_check.db",
     "health_check.cache",
     "health_check.contrib.celery_ping",
+    "django_celery_beat",
 ]
 
 LOCAL_APPS = [
@@ -931,7 +934,11 @@ REST_FRAMEWORK = {
         "rest_framework.filters.SearchFilter",
         "rest_framework.filters.OrderingFilter",
     ],
-    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.CursorPagination",
+    # PageNumberPagination — matches the numeric `page`/`page_size` params and
+    # the `count`-based pageCount math the SalesOrdersPage.tsx example below
+    # uses. (CursorPagination uses opaque tokens instead and does not support
+    # jumping to an arbitrary page, so it would break that frontend code.)
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 50,
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }
@@ -1133,10 +1140,19 @@ npm install -D \
 # Initialize Tailwind CSS
 npx tailwindcss init -p
 
+# shadcn/ui needs a "@/*" path alias before it will initialize — add it to
+# tsconfig.json ("compilerOptions.paths": { "@/*": ["./src/*"] }, plus
+# "baseUrl": ".") and to vite.config.ts (resolve.alias["@"] = path.resolve(
+# __dirname, "./src")). Skipping this step is why `shadcn init` fails with
+# "Could not find valid path aliases".
+
 # Initialize shadcn/ui
-# The CLI may prompt "Select a component library" (Base UI / React Aria /
-# Radix UI) before it reaches the --yes-covered prompts — this quest's
-# generated components assume Radix UI, so answer that prompt with Radix UI.
+# The current CLI first prompts for a "preset" (Nova/Vega/Maia/Lyra/Mira/
+# Luma/Sera/Rhea) that this quest does not otherwise use — pick any preset
+# (e.g. `--preset nova` for a non-interactive run), then it may also prompt
+# "Select a component library" (Base UI / React Aria / Radix UI) before it
+# reaches the --yes-covered prompts — this quest's generated components
+# assume Radix UI, so answer that prompt with Radix UI.
 npx shadcn@latest init
 
 # Add core shadcn/ui components used in ERP
@@ -1146,7 +1162,12 @@ npx shadcn@latest add dropdown-menu navigation-menu sidebar
 npx shadcn@latest add data-table skeleton toast
 
 # Install API client generator
-npm install -D openapi-typescript orval
+# The Vite react-ts template now ships TypeScript 6.x, but openapi-typescript
+# currently peer-requires TypeScript ^5.x — plain `npm install` fails with an
+# ERESOLVE conflict. Install with --legacy-peer-deps and expect npm to report
+# a handful of vulnerabilities in the resulting tree (review `npm audit`
+# before shipping this to production).
+npm install -D openapi-typescript orval --legacy-peer-deps
 ```
 
 ### 🏗️ Auto-Generating the API Client
@@ -1423,6 +1444,8 @@ Requirements:
 ```
 
 **Sample Agent Output — `docker-compose.yml`:**
+
+> ⚠️ **Before you run `docker compose up -d`:** the `django`, `celery-worker`, and `celery-beat` services below build from `erp-backend/Dockerfile.dev`, and the `prometheus`/`grafana` services bind-mount `docker/prometheus/prometheus.yml` and `docker/grafana/provisioning/`. None of these three files are provided by this quest — they are left as an exercise. Ask your `/stackattack` agent to generate a minimal `Dockerfile.dev` (Python 3.12 base image, `pip install -r requirements.txt`, `CMD` matching the service's command) and a starter `prometheus.yml` (`scrape_configs` targeting `django:8000` and `redis-exporter`) before Challenge 4, or Compose will fail with a "mount a directory onto a file" / build-context error.
 
 ```yaml
 # docker-compose.yml


### PR DESCRIPTION
## 🔧 Quest fix — `digital-artist/0001`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: digital-artist/0001

Slice: 1 quest walked (`Stack Attack: AI-Built Django + React Enterprise ERP`, execute-mode, non-truncated, `verdict: fail`, `executed: true`, no error, not budget_exhausted → eligible). All edits below target `pages/_quests/0001/stack-attack.md` (not vendored — no `source_repo`/`source_url`).

- **Chapter 4 pip install list** — fixed failed command (`config/settings/base.py sample output` → `ModuleNotFoundError: No module named 'decouple'`) and the matching high-priority recommendation (area: "Chapter 4 — settings.py excerpt"). Added `python-decouple==3.8.*` to the pip install list so the documented settings excerpt's `from decouple import Csv, config` actually resolves. tier-1 score_pct 91.9 → 91.9 (held), brand clean. ✅ kept.
- **Chapter 4 pip install list + `THIRD_PARTY_APPS`** — addressed the high-priority recommendation (area: "Chapter 6 — docker-compose.yml") re: celery-beat's `--scheduler django_celery_beat.schedulers:DatabaseScheduler` depending on an uninstalled package. Added `django-celery-beat==2.7.*` to the install list and `"django_celery_beat"` to `THIRD_PARTY_APPS`. tier-1 score_pct 91.9 → 91.9 (held), brand clean. ✅ kept.
- **Chapter 6 docker-compose.yml section** — addressed the failed command (`docker-compose.yml sample output` — bind-mounting a nonexistent host file fails with "mount a directory onto a file") and the same high-priority recommendation's "or clearly mark as left as an exercise" option. Added an explicit warning callout before the compose file naming the three never-provided files (`erp-backend/Dockerfile.dev`, `docker/prometheus/prometheus.yml`, `docker/grafana/provisioning/`) and what to do before Challenge 4. tier-1 score_pct 91.9 → 91.9 (held), brand clean. ✅ kept.
- **Chapter 5 `shadcn@latest init` step** — fixed failed command (undocumented "preset" prompt + "Could not find valid path aliases") and the matching high-priority recommendation (area: "Chapter 5 — shadcn/ui init"). Added the missing tsconfig.json/vite.config.ts `@/*` path-alias step and a note on the current CLI's preset prompt. tier-1 score_pct 91.9 → 91.9 (held), brand clean. ✅ kept.
- **Chapter 5 `openapi-typescript`/`orval` install** — fixed failed command (ERESOLVE peer conflict: template ships TypeScript 6.x, openapi-typescript peer-requires ^5.x) and the matching high-priority recommendation. Added `--legacy-peer-deps` to the install command plus a note to review `npm audit` before shipping. tier-1 score_pct 91.9 → 91.9 (held), brand clean. ✅ kept.
- **`config/settings/base.py` — `DEFAULT_PAGINATION_CLASS`** — addressed the medium-priority recommendation (pagination mismatch between `REST_FRAMEWORK` settings and the `SalesOrdersPage.tsx` example). Switched `CursorPagination` → `PageNumberPagination` to match the frontend's `page`/`page_size`/`count`-based code, with an inline comment explaining why. tier-1 score_pct 91.9 → 91.9 (held), brand clean. ✅ kept.

_Left:_ the low-priority recommendation (area: "Code fence labeling" — distinguishing `/stackattack` chat-prompt fences from real runnable code) was left unfixed — lowest priority and the per-slice edit cap was reached with the six higher-priority fixes above. No edits were reverted; no quests were vendored-skipped or ineligible in this slice (the single walked quest was execution-grounded and fully in scope). No frontmatter was touched, so `_data/quests/**` regeneration is not required for this fix.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/33405970801)._
