### PR TITLE
ci(markdown-oneline): scope the pull_request trigger to main

### DIFF
--- a/.github/workflows/markdown-oneline.yml
+++ b/.github/workflows/markdown-oneline.yml
@@ -6,8 +6,16 @@
 # Fix locally:  python3 tools/unwrap-prose.py --write
 name: markdown-oneline
 
+# `branches: [main]` on the pull_request half matters as much as the paths
+# filter: gh-pages is the BUILT site, and the recurring "🚀 Deploy: sync
+# gh-pages with main@<sha>" pull requests target it. GitHub cannot resolve a
+# merge ref for those, so every one of them failed this workflow at STARTUP —
+# zero jobs, no logs, just a red X that had nothing to do with markdown. The
+# prose rule only applies to hand-authored source landing on main, which is
+# exactly what the push half already says.
 on:
   pull_request:
+    branches: [main]
     paths: ["**/*.md", "**/*.markdown"]
   push:
     branches: [main]


### PR DESCRIPTION
<!-- fleet-doctor key="bamr87/it-journey:.github/workflows/markdown-oneline.yml" -->

## Problem

`bamr87/it-journey` · `.github/workflows/markdown-oneline.yml` · signals `failing, flaky`
(32 runs / 14d, 64.5% success, latest verdict `failure`).

The failures are not markdown failures. The queued run
[33463281010](https://github.com/bamr87/it-journey/actions/runs/33463281010) has
**zero jobs** and `gh run view --log-failed` returns `failed to get run log: log not found` —
GitHub's own summary says *"This run likely failed because of a workflow file issue."*
That is a **startup failure**: the run was created and died before any job was scheduled.

Its trigger was `pull_request` on PR
[#680](https://github.com/bamr87/it-journey/pull/680) — `main` → **`gh-pages`**,
titled `🚀 Deploy: sync gh-pages with main@b500b16c`, reported `mergeable: UNKNOWN`.

The pattern holds across the whole window. Of the last 25 runs, every failure with
`headBranch: main` is one of these deploy-sync PRs, and each produced 0 jobs:

| run | jobs | PR base |
| --- | --- | --- |
| 33463281010 | 0 | `gh-pages` (#680) |
| 33403045006 | 0 | `gh-pages` |
| 33316787517 | 0 | `gh-pages` |
| 33288335823 | 0 | `gh-pages` |
| 33257495000 | 0 | `gh-pages` |
| 33199465689 | 0 | `gh-pages` |
| 33143508893 | 0 | `gh-pages` |

`gh pr list --base gh-pages` confirms these are a standing, recurring series
(#656, #658, #661, #666, #669, #673, #677, #680 …), so this is a permanent red,
not a flake.

## Root cause

The `pull_request` half of the trigger carries a `paths:` filter but **no `branches:` filter**:

```yaml
on:
  pull_request:
    paths: ["**/*.md", "**/*.markdown"]
  push:
    branches: [main]          # <- the push half is scoped; the PR half is not
    paths: ["**/*.md", "**/*.markdown"]
```

So the gate also fires on pull requests targeting `gh-pages`. `gh-pages` is the
**built** Jekyll site, not source; GitHub cannot resolve a merge ref for a
`main` → `gh-pages` deploy PR, so it cannot resolve the workflow file to run,
and the run fails at startup with no job and no log. Nothing in the markdown ever
gets checked — there is nothing here for `unwrap-prose.py` to pass or fail.

The remaining failures in the window (`automated/cms-mechanical`) are real
`pull_request` runs that produced jobs. Those are the gate working as intended and
are deliberately left alone.

## Fix

Add `branches: [main]` to the `pull_request` trigger, mirroring the `push` half that
was already scoped, plus a comment recording why:

```yaml
on:
  pull_request:
    branches: [main]
    paths: ["**/*.md", "**/*.markdown"]
```

One-paragraph-per-line is a rule about hand-authored source landing on `main`. A deploy
sync into the generated-site branch is out of scope by construction, so this narrows the
trigger to what the gate was seeded to cover and removes nothing it actually checks.

No `continue-on-error`, no retry, no weakened check: the gate still runs on every
markdown-touching PR into `main` and every push to `main`.

## Expected impact

Removes the recurring startup failure — roughly 7 of the last 25 runs, one per
`gh-pages` deploy sync. Success rate should go from 64.5% toward the ~90% floor set by
the genuine `cms-mechanical` prose failures, and `markdown-oneline` stops appearing in
the fleet's failing-workflow signal on days when only a deploy ran.

Minute savings are negligible (these runs die before billing) — the cost was a
permanently red required-looking check and a daily false signal into the fleet triage
snapshot.

## Note for the hub (not changed here)

The header says this file was *"Seeded by the bamr87 hub (`tools/fanout.sh --kit prose`)"*.
Any other seeded repo that also publishes from a `gh-pages`-style branch will have the
same unscoped `pull_request` trigger. Worth checking the hub's `prose` kit template
separately — deliberately out of scope for this PR.

## Links

- Failing run: https://github.com/bamr87/it-journey/actions/runs/33463281010
- Triggering PR: https://github.com/bamr87/it-journey/pull/680
- Dash Actions analytics: https://bamr87.github.io/bamr87/actions/
