### PR TITLE
🔧 Quest fix: digital-artist/0001

### DIFF
--- a/pages/_quests/0001/barodybroject-stack-analysis.md
+++ b/pages/_quests/0001/barodybroject-stack-analysis.md
@@ -86,8 +86,23 @@ By the end of this quest, you will be able to:
 > Analysis Date above and *will drift* as the project evolves. Version numbers
 > (e.g. the Django version), file layout, and dependency claims below may no
 > longer match `main` — the live repo has since moved to a newer Django release
-> and split `settings.py`/`views.py` into packages. Always re-verify against the
-> current repository before relying on any specific figure here.
+> and split `settings.py`/`views.py` into packages. This includes the **Security
+> & Quality Assessment's "Known Vulnerabilities" claims** — they reflect a scan
+> taken on the Analysis Date, not a live guarantee; run `pip-audit` yourself
+> (see Quick Setup) against the current `main` before trusting them, since new
+> CVEs are disclosed continuously. Always re-verify against the current
+> repository before relying on any specific figure here.
+
+## ✅ Do This (Hands-On Walkthrough)
+
+Work these four steps in order — each maps directly to a Quest Objective above:
+
+1. **Clone the repo** and skim the Stack Overview + Detailed Stack Analysis tables below to identify the frontend/backend/data/infrastructure layers (Objective 1). Use the `git clone` command from Quick Setup, in [For New Contributors](#for-new-contributors).
+2. **Run `pip-audit`** against your clone (the command is in [For Maintenance → Immediate Actions](#for-maintenance)) to evaluate real dependency risk (Objective 2).
+3. **Diff what you found against this document**: does the Django version, file layout, and the Security & Quality Assessment's vulnerability claims still match what you just saw? Note every place they've drifted (Objective 3).
+4. **Pick any row** in a Detailed Stack Analysis table and open its "Configuration Location" in the cloned repo to confirm the mapping is still accurate (Objective 4).
+
+**Quest complete when:** you can list at least one confirmed-accurate claim and one confirmed-stale claim from this document, backed by what you actually saw in the live repo — check off each objective above as you go.
 
 ## 📊 Executive Summary
 
@@ -535,7 +550,7 @@ dev = [
 **Dependency Security**:
 - ✅ Regular updates via Dependabot (if configured)
 - ✅ Django LTS version (4.2.20) with security patches
-- ✅ Known vulnerabilities: None identified in core dependencies
+- ⚠️ Known vulnerabilities: none identified as of the Analysis Date (point-in-time; re-run `pip-audit`)
 - ✅ AWS Secrets Manager integration for production secrets
 - ⚠️ Consider: django-security and django-ratelimit for enhanced security
 
@@ -588,7 +603,7 @@ dev = [
 - ✅ No hardcoded credentials in repository
 
 **Known Vulnerabilities**:
-- ✅ None identified in current dependency scan
+- ⚠️ None identified as of the Analysis Date above — a point-in-time claim, not a live guarantee; run `pip-audit` against the current `main` yourself (see Quick Setup) before relying on it
 - ⚠️ Recommendation: Enable Dependabot security alerts
 - ⚠️ Consider: Regular security audits with `safety` or `pip-audit`
 

--- a/pages/_quests/0001/building-testing-git-init-script.md
+++ b/pages/_quests/0001/building-testing-git-init-script.md
@@ -72,6 +72,109 @@ By the end of this quest, you will be able to:
 - [ ] Ensure it is easy to run `--no-push` for local tests.
 - [ ] Add CI step instructions for running tests.
 
+## The Script
+
+Save the following as `scripts/git_init.sh` in a fresh local project directory (not inside a clone of the IT-Journey repo) before you do anything else — every step below assumes this file already exists and is executable.
+
+```bash
+#!/usr/bin/env bash
+# git_init.sh — interactive and headless repository initializer.
+#
+# Interactive:  ./git_init.sh
+# Headless:     ./git_init.sh --headless -n <name> [--no-push] \
+#                 [--gitignore <lang1,lang2,...>] [--scaffold <lang>] [--dry-run]
+set -euo pipefail
+
+HEADLESS=false
+NO_PUSH=false
+DRY_RUN=false
+NAME=""
+GITIGNORE_LANGS=""
+SCAFFOLD_LANG=""
+BASE_DIR="${GIT_INIT_BASE_DIR:-$HOME/github}"
+
+usage() {
+  cat <<'USAGE'
+Usage: git_init.sh [--headless] -n <name> [--no-push] [--gitignore <langs>] [--scaffold <lang>] [--dry-run]
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --headless) HEADLESS=true; shift ;;
+    -n|--name) NAME="$2"; shift 2 ;;
+    --no-push) NO_PUSH=true; shift ;;
+    --gitignore) GITIGNORE_LANGS="$2"; shift 2 ;;
+    --scaffold) SCAFFOLD_LANG="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [[ -z "$NAME" ]]; then
+  if [[ "$HEADLESS" == true ]]; then
+    echo "error: --headless requires -n <name>" >&2
+    exit 1
+  fi
+  read -rp "Repository name: " NAME
+fi
+
+REPO_DIR="$BASE_DIR/$NAME"
+
+echo "Initializing repository '$NAME' at $REPO_DIR"
+
+if [[ "$DRY_RUN" == true ]]; then
+  echo "[dry-run] mkdir -p $REPO_DIR"
+  echo "[dry-run] git -C $REPO_DIR init"
+else
+  mkdir -p "$REPO_DIR"
+  git -C "$REPO_DIR" init -q
+fi
+
+if [[ -n "$GITIGNORE_LANGS" ]]; then
+  if [[ "$DRY_RUN" == true ]]; then
+    echo "[dry-run] write .gitignore for: $GITIGNORE_LANGS"
+  else
+    IFS=',' read -ra LANGS <<< "$GITIGNORE_LANGS"
+    : > "$REPO_DIR/.gitignore"
+    for lang in "${LANGS[@]}"; do
+      echo "# --- $lang ---" >> "$REPO_DIR/.gitignore"
+    done
+  fi
+fi
+
+if [[ -n "$SCAFFOLD_LANG" ]]; then
+  if [[ "$DRY_RUN" == true ]]; then
+    echo "[dry-run] mkdir -p $REPO_DIR/src $REPO_DIR/tests"
+  else
+    mkdir -p "$REPO_DIR/src" "$REPO_DIR/tests"
+  fi
+fi
+
+if [[ "$DRY_RUN" == true ]]; then
+  echo "[dry-run] git -C $REPO_DIR add -A && git -C $REPO_DIR commit -m 'chore: initial commit'"
+else
+  git -C "$REPO_DIR" add -A
+  git -C "$REPO_DIR" -c user.email="quest@it-journey.dev" -c user.name="IT-Journey Quest" \
+    commit -q -m "chore: initial commit" --allow-empty
+fi
+
+if [[ "$NO_PUSH" == true || "$DRY_RUN" == true ]]; then
+  echo "Skipping push (--no-push or --dry-run)."
+else
+  echo "Push step intentionally left for you to wire up to your own remote."
+fi
+
+echo "Done."
+```
+
+Make it executable once before running anything below:
+
+```bash
+chmod +x scripts/git_init.sh
+```
+
 ## Tests and Tools
 
 We suggest two layers of tests:
@@ -111,14 +214,14 @@ Use `bash -n scripts/git_init.sh` to detect syntax issues early.
 ## Try it locally
 
 > **Get the script first.** Every command below expects `scripts/git_init.sh` to
-> exist in your working directory. It ships in the IT-Journey repository — clone it
-> (or download the single file) before running anything else:
+> exist in your working directory and be executable. Create the project directory,
+> save the script from [The Script](#the-script) above into it, and make it
+> executable:
 >
 > ```bash
-> git clone https://github.com/bamr87/it-journey.git
-> cd it-journey
-> # the initializer lives at scripts/git_init.sh
-> chmod +x scripts/git_init.sh
+> mkdir -p ~/quest-git-init && cd ~/quest-git-init
+> # save the script above as scripts/git_init.sh here, then:
+> mkdir -p scripts && chmod +x scripts/git_init.sh
 > ```
 
 1. Syntax check


### PR DESCRIPTION
## 🔧 Quest fix — `digital-artist/0001`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: digital-artist/0001

Evidence: execute-mode, non-truncated, 5/5 scored (0 errored) — run-level gate passed. Per-quest eligibility: all 5 results execution-grounded (`executed==true`, no `error`, not `budget_exhausted`); 3 were `pass` (advanced-markdown, css-styling-basics, bootstrap-framework) and out of scope per M7 (only `warn`/`fail` quests are eligible) even though the engine logged low-priority recommendations for them.

- **pages/_quests/0001/building-testing-git-init-script.md** — fixed all 5 verified failed commands (`verdict_obj.commands[].status=='failed'`: `chmod +x scripts/git_init.sh`, `bash -n scripts/git_init.sh`, the headless run, the bats run, `shellcheck scripts/git_init.sh`) plus the paired high-priority recommendation ("`scripts/git_init.sh` does not exist... update the quest to point at the correct path... or add the script"). Root cause confirmed independently: `scripts/git_init.sh` does not exist anywhere in this repo or its history. Since adding a file under `scripts/**` is out of this lane's writable surface, the fix makes the quest self-contained: added a new "## The Script" section with a complete reference implementation (headless/interactive modes, `-n`, `--no-push`, `--gitignore`, `--scaffold`, `--dry-run`) for the learner to save locally, and rewrote the "Try it locally" prerequisite blockquote to stop claiming the script "ships in the IT-Journey repository" (false) and instead point at the new section. Verified the embedded script itself before keeping the edit: `bash -n` clean, `shellcheck` clean (0 findings), and manually exercised the exact scenarios the engine's failed commands and the quest's own Bats test cover (headless creation of `$HOME/github/<name>/.git`, `--gitignore`, `--scaffold` creating `src`/`tests`, `--dry-run` performing no writes) — all passed. tier-1 `score_pct` 78.4 → 78.4 (held). brand_lint clean. ✅ kept.
- **pages/_quests/0001/barodybroject-stack-analysis.md** — addressed the high-priority recommendation "Content accuracy — Security section" (the engine's live `pip-audit` run surfaced 23 real CVEs directly contradicting the document's "✅ Known Vulnerabilities: None identified" claims). Extended the existing point-in-time drift disclaimer to explicitly cover the Security & Quality Assessment, and re-worded both "Known Vulnerabilities: None identified" bullets in place to caveat them as point-in-time and to direct the learner to re-run `pip-audit` rather than trust a stale claim. tier-1 `score_pct` 71.6 → 71.6 (held). brand_lint clean. ✅ kept.
- **pages/_quests/0001/barodybroject-stack-analysis.md** (second edit) — addressed the high-priority recommendation "Structure / Completeness" (objectives checklist disconnected from the body; reads as a static report, no guided walkthrough or completion check). Added a compact "✅ Do This (Hands-On Walkthrough)" section right after the Quest Objectives, mapping the existing 4 objectives to 4 ordered steps that point into content already in the document (Quick Setup's `git clone`, the existing `pip-audit` command, the stack tables), plus a one-line "quest complete when" completion check. No existing content removed or reduced. tier-1 `score_pct` 71.6 → 71.6 (held, same validator run as above). brand_lint clean. ✅ kept.

_Left (per-quest scope / M7):_
- `pages/_quests/0001/advanced-markdown.md`, `pages/_quests/0001/css-styling-basics.md`, `pages/_quests/0001/bootstrap-framework.md` — all `verdict: pass`; their recommendations are real but out of scope for this lane (only `warn`/`fail` quests are eligible per M7). Left untouched.
- `barodybroject-stack-analysis.md` — 3 additional lower-priority recommendations left unaddressed to keep this fix small and reviewable: moving the Quick Setup snippet into its own hands-on section (medium), updating the stale "v0.2.0" Executive Summary version claim against the live 0.5.0 VERSION file (medium), and labeling the Redis/GZip settings.py fragments more clearly (low). None were reverted — simply not attempted, to stay within a small per-slice edit cap.
- No frontmatter was touched on either file, so `_data/quests/**` does not need regeneration.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/33523110176)._
