### PR TITLE
fix(ci): scope 📝 Content Review to PRs into main (skip gh-pages deploy PRs)

### DIFF
--- a/.github/workflows/content-review.yml
+++ b/.github/workflows/content-review.yml
@@ -17,6 +17,12 @@ name: 📝 Content Review
 
 on:
   pull_request:
+    # Only PRs *into* main. The `🚀 Sync gh-pages from main` deploy PRs
+    # (main -> gh-pages) are opened and auto-merged within ~9s, which deletes the
+    # refs/pull/N/merge ref this run resolves its workflow from, so the run dies
+    # at load time with zero jobs ("workflow file issue"). They also carry nothing
+    # to review: gh-pages is a mirror of commits already reviewed into main.
+    branches: [main]
     types: [opened, reopened, ready_for_review]
     paths:
       - 'pages/**/*.md'


### PR DESCRIPTION
<!-- fleet-doctor key="bamr87/it-journey:.github/workflows/content-review.yml" -->

Opened by the bamr87 dash **fleet doctor** (daily `fleet-pulse` remediation pass). Draft — review before merging.

## Problem

- **Repo / workflow:** `bamr87/it-journey` — `.github/workflows/content-review.yml` (📝 Content Review)
- **Signals:** `failing`, `flaky` — 61.9% success over 22 runs in the last 14d, latest verdict `failure`.

The "flaky" signal is not flakiness. Split the 14-day run history by what triggered each run and it is perfectly deterministic:

| PR kind | Result |
| --- | --- |
| PRs into `main` (`automated/quest-*`, `style/*`, `docs/*`) | **success, every time** |
| `🚀 Deploy: sync gh-pages with main@…` (main → `gh-pages`) | **failure, every time** (8/8) |

Every failure is a gh-pages deploy PR; no PR into `main` has ever failed.

## Root cause

The failing runs never start. `GET /actions/runs/33584843521/jobs` returns an **empty job list**, and the run summary is:

> ✗ This run likely failed because of a workflow file issue.

That is Actions failing to resolve the workflow from `refs/pull/N/merge` — not a YAML error. The file is byte-identical on both branches (blob `9ba340e` on `main` and on `gh-pages`), and the same file succeeds on every PR into `main`. The timeline of run [33584843521](https://github.com/bamr87/it-journey/actions/runs/33584843521) / PR #686 shows what actually happens:

```
02:52:19Z  PR #686 opened   (main -> gh-pages, by `🚀 Sync gh-pages from main`)
02:52:23Z  content-review run created
02:52:28Z  PR #686 MERGED   <- refs/pull/686/merge deleted
02:52:29Z  run concluded: failure, 0 jobs
```

`sync-gh-pages.yml` opens the deploy PR and merges it inside the same job — **nine seconds** end to end. The merge ref this `pull_request` run needs in order to even load the workflow is gone before Actions gets to it, so the run dies at load time, one second after the merge. (`gh pr view 686` still reports `mergeable: UNKNOWN`, consistent with the merge ref never settling.)

Because the deploy PR mirrors all of `main`, it always touches `pages/**/*.md` and therefore always matches this workflow's `paths:` filter — so this recurs on every deploy, twice a day (the `20 2,14 * * *` sync cron).

## Fix

One line: add `branches: [main]` to the `pull_request` trigger.

```yaml
on:
  pull_request:
    branches: [main]
    types: [opened, reopened, ready_for_review]
    paths:
      - 'pages/**/*.md'
      - 'pages/**/*.markdown'
```

This is the right scoping on the merits, independent of the race: an *editorial* pass on a `gh-pages` deploy PR is meaningless — `gh-pages` is a generated mirror, and its content was already reviewed by this same workflow on the way into `main`. Worse, had one of these runs ever survived long enough to start, the `review` job checks out `github.event.pull_request.head.ref` and pushes editorial commits to it — which for a deploy PR is **`main` itself**, contradicting the repo's "never commit to `main`" rule.

No `continue-on-error`, no retry, no change to the review logic.

## Expected impact

- Removes ~8 failed runs per 14 days (2/day, one per scheduled sync at 02:20 and 14:20 UTC), taking this workflow from 61.9% to an expected 100% success rate and clearing it from the fleet's red list.
- Minutes recovered are negligible — these runs die in ~6s, and the workflow's whole 14d spend is 2.5m. The value here is **signal**, not spend: a workflow that is red on every deploy trains everyone to ignore it, and it is currently the reason `it-journey` shows up as a red repo in the fleet triage.
- Also closes the latent "editor bot pushes to `main`" hazard described above.

## Links

- Failing run: https://github.com/bamr87/it-journey/actions/runs/33584843521 (PR #686)
- Prior identical failures: [33519830616](https://github.com/bamr87/it-journey/actions/runs/33519830616) · [33463281042](https://github.com/bamr87/it-journey/actions/runs/33463281042) · [33403045031](https://github.com/bamr87/it-journey/actions/runs/33403045031) · [33288335830](https://github.com/bamr87/it-journey/actions/runs/33288335830) · [33257494995](https://github.com/bamr87/it-journey/actions/runs/33257494995) · [33199465690](https://github.com/bamr87/it-journey/actions/runs/33199465690) · [33143508878](https://github.com/bamr87/it-journey/actions/runs/33143508878)
- Dash Actions analytics: https://bamr87.github.io/bamr87/actions/
