### PR TITLE
fix(ci): only run workflow lint on PRs targeting main

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -18,8 +18,15 @@
 # =============================================================================
 name: 🧹 Lint workflows
 
+# `branches:` filters on the PR's BASE branch. The `paths:` filter alone does not
+# exclude the bot's `main` -> `gh-pages` deploy PR (sync-gh-pages.yml): that PR's
+# diff spans the whole tree, so `.github/workflows/**` always matches, and the run
+# then dies as a startup_failure because GitHub cannot build a merge ref against
+# gh-pages' unrelated history. Same fix already applied to ci.yml,
+# frontmatter-validation.yml (#670) and content-review.yml (#687).
 on:
   pull_request:
+    branches: [main]
     paths:
       - '.github/workflows/**'
 


### PR DESCRIPTION
<!-- fleet-doctor key="bamr87/it-journey:.github/workflows/lint-workflows.yml" -->

## Problem

`🧹 Lint workflows` (`.github/workflows/lint-workflows.yml`) is flagged `failing, flaky`.

The evidence is not a lint failure — the run never reaches `actionlint`. Every failure is a **zero-job startup failure**:

```
X main 🧹 Lint workflows bamr87/it-journey#691 · 33711542314
X This run likely failed because of a workflow file issue.
```

That run started `2026-09-03T03:29:28Z` and was over by `03:29:34Z` — 6 seconds, no jobs, nothing checked out.

Correlating against the run list, the trigger is unambiguous:

| time (UTC) | event |
| --- | --- |
| 03:29:10 | `🚀 Sync gh-pages from main` (schedule) starts |
| 03:29:25 | it opens PR #691 — `main` → **`gh-pages`** |
| 03:29:28 | `🧹 Lint workflows` fires on that PR |
| 03:29:32 | PR #691 is auto-merged (7s after opening) |
| 03:29:34 | the lint run dies, 0 jobs |

The 71.4% "success" rate is just the ratio of real PRs to gh-pages deploy PRs. The workflow is not flaky; it is deterministically red on one class of PR.

## Root cause

`lint-workflows.yml` filters on `paths:` but not on the PR's **base** branch:

```yaml
on:
  pull_request:
    paths:
      - '.github/workflows/**'
```

`sync-gh-pages.yml` opens its deploy PR from `main` into `gh-pages`. That PR's diff spans the whole tree, so `.github/workflows/**` always matches and the workflow is always selected. GitHub then cannot compute a merge ref for `refs/pull/N/merge` against `gh-pages`' unrelated history, so the run fails at **load time**, before any job exists — which is exactly the 0-job "workflow file issue" signature. (The PR being auto-merged ~7s later removes the ref entirely, which is why the log endpoint returns nothing to read.)

This is the same defect already diagnosed and fixed in three sibling workflows:

- `ci.yml` and `frontmatter-validation.yml` — #670, merged 2026-09-03 01:55
- `content-review.yml` — #687, merged 2026-09-03 01:53

Both of those landed *after* this workflow's failing run window, and the very next deploy PR (#691, 03:29) confirms the fix works: `Frontmatter Validation` and `📝 Content Review` did not fire at all, while `🧹 Lint workflows` — still unfiltered — went red along with `🎯 Quest Content Validation` and `🔗 Link Health Guardian`.

## Fix

Add the same base-branch filter, with the same explanatory comment used in #670:

```yaml
on:
  pull_request:
    branches: [main]
    paths:
      - '.github/workflows/**'
```

`branches:` filters on the PR's *base* ref, so the `main` → `gh-pages` deploy PR is no longer selected. Every real PR in this repo targets `main`, so gate coverage is unchanged — a PR that adds or edits a workflow file still gets `actionlint`.

No `continue-on-error`, no retry, no change to the actionlint step or its pinned digest.

## Expected impact

- Removes ~2 guaranteed-red runs/week (`sync-gh-pages` runs on `cron: '20 2,14 * * *'`, self-gated on main being ahead + green).
- **Billed minutes recovered: ~0.** These runs never reach a runner; GitHub's timing endpoint reports `billable: {}` for them. The value here is signal quality, not spend — this workflow's red runs are noise that mask real workflow-validity regressions, which is precisely what this gate exists to catch.
- Note for the dash: the `high-cost-low-value`/`slow` flags on the sibling it-journey workflows in the same queue are a hub-side measurement artifact, not real spend — filed separately at bamr87/bamr87.

## Links

- Failing run: https://github.com/bamr87/it-journey/actions/runs/33711542314
- Deploy PR that triggered it: https://github.com/bamr87/it-journey/pull/691
- Prior fixes: #670, #687
- Dash Actions analytics: https://bamr87.github.io/bamr87/actions/

---
🤖 Opened by the fleet-doctor loop (`fleet-pulse.yml`).
