### PR TITLE
🔧 Quest fix: digital-artist/0001

### DIFF
--- a/pages/_quests/0001/github-pages-portal.md
+++ b/pages/_quests/0001/github-pages-portal.md
@@ -386,6 +386,12 @@ git push origin main
    jekyll new . --force  # Force to avoid conflicts
    ```
 
+   > ⚠️ `jekyll new --force` will NOT overwrite the `index.html` you created in
+   > Chapter 1 — it generates `index.markdown` alongside it instead. If both files
+   > remain, `jekyll build` silently keeps the OLD static `index.html` and discards
+   > your new Jekyll content (only a "Conflict: shared destination" warning, easy to
+   > miss). Delete or rename the Chapter 1 `index.html` now: `rm index.html`.
+
 3. **Configure for GitHub Pages**
    Create `Gemfile`:
    ```ruby
@@ -440,7 +446,7 @@ git push origin main
    ### Project 1: GitHub Pages Mastery
    - **Status**: ✅ Completed
    - **Technologies**: HTML, CSS, Jekyll
-   - **Live Demo**: [View Site]({% raw %}{{ site.url }}{% endraw %})
+   - **Live Demo**: [View Site](https://yourusername.github.io/)
    
    ### Project 2: Portfolio Foundation
    - **Status**: 🚧 In Progress
@@ -450,6 +456,11 @@ git push origin main
 
 6. **Build and Test Locally**
    ```bash
+   # On a stock Linux Ruby install, a plain `bundle install` can fail with
+   # Bundler::PermissionError (no write access to the system gem cache) even
+   # after installing Jekyll/Bundler with --user-install. Scope bundler to a
+   # project-local folder first to avoid it:
+   bundle config set --local path vendor/bundle
    bundle install
    bundle exec jekyll serve
    # Visit http://localhost:4000

--- a/pages/_quests/0001/it-journey-stack-analysis.md
+++ b/pages/_quests/0001/it-journey-stack-analysis.md
@@ -93,7 +93,7 @@ By the end of this quest, you will be able to:
 
 ### Key Highlights
 
-- **Primary Stack**: Jekyll 3.9.5 + Ruby 3.2.3 + Bootstrap 5.2.0
+- **Primary Stack**: Jekyll 3.10.0 + Ruby 3.2.3 + Bootstrap 5.2.0
 - **Deployment**: GitHub Pages with automated CI/CD pipelines
 - **Innovation**: AI-powered content analysis and link monitoring (Guardian 2.0)
 - **Architecture**: Container-first development with Docker
@@ -146,7 +146,7 @@ graph TB
     end
     
     subgraph "Build Layer"
-        JK[Jekyll 3.9.5]
+        JK[Jekyll 3.10.0]
         RB[Ruby 3.2.3]
         BS[Bootstrap 5.2.0]
         SASS[Sass/SCSS]
@@ -219,7 +219,7 @@ graph TB
 
 ### 1. Frontend Stack
 
-#### Core Framework: Jekyll 3.9.5
+#### Core Framework: Jekyll 3.10.0
 ```yaml
 # _config.yml - Jekyll Configuration
 markdown: kramdown
@@ -246,15 +246,15 @@ collections:
 - Liquid templating for complex logic
 - Collection-based content organization
 
-**Version Justification**: Jekyll 3.9.5 is the latest GitHub Pages-compatible version, ensuring deployment reliability.
+**Version Justification**: Jekyll 3.10.0 is the version this repo's Gemfile.lock currently resolves via the `github-pages` gem, ensuring deployment reliability.
 
 #### UI Framework: Bootstrap 5.2.0
 
 ```ruby
 # Gemfile - Frontend Dependencies
-gem 'github-pages', '~> 231'
+gem 'github-pages', '~> 232'
 gem 'jekyll-theme-zer0'
-gem 'webrick', '~> 1.8'
+gem 'webrick', '~> 1.9'
 ```
 
 **Component Library**: Bootstrap 5.2.0 via CDN
@@ -279,10 +279,10 @@ gem 'webrick', '~> 1.8'
 ```ruby
 # Gemfile
 source "https://rubygems.org"
-gem 'github-pages', '~> 231'
+gem 'github-pages', '~> 232'
 gem 'jekyll-theme-zer0'
-gem 'ffi', "~> 1.17.0"
-gem 'webrick', '~> 1.8'
+gem 'ffi', "~> 1.17.4"
+gem 'webrick', '~> 1.9'
 
 # Jekyll Plugins (included in github-pages)
 group :jekyll_plugins do
@@ -296,8 +296,8 @@ end
 
 **Version Details**:
 - **Ruby**: 3.2.3 (stable, secure, performant)
-- **Jekyll**: 3.9.5 (GitHub Pages compatible)
-- **GitHub Pages Gem**: 231 (ensures version compatibility)
+- **Jekyll**: 3.10.0 (GitHub Pages compatible)
+- **GitHub Pages Gem**: 232 (ensures version compatibility)
 
 #### Build Pipeline
 
@@ -557,8 +557,8 @@ docker compose up
 bundle install
 bundle exec jekyll serve --config "_config.yml,_config_dev.yml"
 
-# Quest Validator
-python3 test/quest-validator/quest_validator.py
+# Quest Validator — requires a quest_file or --directory, e.g. validate the whole collection:
+python3 test/quest-validator/quest_validator.py -d pages/_quests/ --summary
 ```
 
 #### Code Quality Tools
@@ -591,12 +591,12 @@ repos:
 
 ```text
 # Core Dependencies (from Gemfile.lock)
-jekyll (3.9.5)
+jekyll (3.10.0)
   - Safe HTML rendering
   - Liquid templating
   - Plugin system
   
-github-pages (231)
+github-pages (232)
   - Pins all Jekyll dependencies to GitHub Pages versions
   - Ensures deployment compatibility
   - Includes all default plugins
@@ -606,11 +606,11 @@ jekyll-theme-zer0 (custom theme)
   - Custom layouts and includes
   - Dark/light theme support
 
-ffi (1.17.0)
+ffi (1.17.4)
   - Foreign function interface
   - Required for Jekyll on M1 Macs
 
-webrick (1.8)
+webrick (1.9.2)
   - Ruby web server
   - Required for Jekyll 3.x on Ruby 3.x
 ```
@@ -897,7 +897,7 @@ This stack directly translates to professional skills:
 ### Current Maturity: ✅ **Modern (2024-2025 Standards)**
 
 The IT-Journey stack runs current versions across the board:
-- Jekyll 3.9.5 (latest GitHub Pages-compatible version)
+- Jekyll 3.10.0 (current GitHub Pages-compatible version, per this repo's Gemfile.lock)
 - Ruby 3.2.3 (current stable)
 - Bootstrap 5.2.0 (modern UI framework)
 - Docker-first development
@@ -1273,7 +1273,7 @@ The IT-Journey stack represents a mature, well-architected solution that balance
 ### Summary
 
 IT-Journey is a **modern, production-ready educational platform** built on a solid foundation of:
-- **Jekyll 3.9.5** for static site generation
+- **Jekyll 3.10.0** for static site generation
 - **Ruby 3.2.3** for build tooling
 - **Python 3.11+** for automation and AI integration
 - **Docker** for consistent development environments

--- a/pages/_quests/0001/personal-site.md
+++ b/pages/_quests/0001/personal-site.md
@@ -77,7 +77,7 @@ My personal website can be accessed through following domains. These sites are a
  3   | <https://travis-ci.org/>                             | CI/CD for {% raw %}{{ site.github_user }}{% endraw %}.github.io
  4   | https://{% raw %}{{ site.github_user }}{% endraw %}.netlify.app/                    | `Domain 2`, hosted by Netlify
  5   | <https://www.netlify.com/>                           | CI/CD for {% raw %}{{ site.github_user }}{% endraw %}.netlify.app
- 6   | https://{% raw %}{{ site.github_user }}{% endraw %}.github.io/                             | `Domain 3`, hosted by Cloudflare
+ 6   | *(update with your own Cloudflare-hosted custom domain — was a copy/paste duplicate of Domain 1)* | `Domain 3`, hosted by Cloudflare
  7   | <https://www.cloudflare.com/>                        | CDN for {% raw %}{{ site.github_user }}{% endraw %}.github.io
  8   | <https://www.godaddy.com/>                           | Domain service for {% raw %}{{ site.github_user }}{% endraw %}.github.io
  9   | <https://sharethis.com/>                             | Share buttons


### PR DESCRIPTION
## 🔧 Quest fix — `digital-artist/0001`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: digital-artist/0001

Evidence: execute-mode, non-truncated run (5/5 planned quests evaluated, no top-level `truncated` flag). Eligibility was assessed per-quest per M7.

- **pages/_quests/0001/github-pages-portal.md** (verdict: warn) — fixed failed command
  `Chapter 3 Step 6: bundle install` (verified: `commands[].status=failed`,
  `Bundler::PermissionError`) by adding `bundle config set --local path vendor/bundle`
  before `bundle install`, matching the high-priority recommendation
  (area: "Chapter 3 Step 6 (bundle install)"). tier-1 score_pct 100.0 → 100.0 (held),
  brand clean. ✅ kept.
- **pages/_quests/0001/github-pages-portal.md** — addressed high-priority recommendation
  (area: "Chapter 1 → Chapter 3 handoff (index.html vs index.markdown)") by adding an
  inline warning + `rm index.html` instruction right after `jekyll new . --force`, so the
  build no longer silently discards the learner's new Jekyll content. tier-1 score_pct
  100.0 → 100.0 (held), brand clean. ✅ kept.
- **pages/_quests/0001/github-pages-portal.md** — fixed failed command
  `Chapter 3 Step 5: index.markdown (front matter + Liquid)` (verified:
  `commands[].status=failed`, leaked `{% raw %}{{ site.url }}{% endraw %}` artifact) by
  replacing the copy-paste snippet's Liquid tag with a plain placeholder URL, consistent
  with the rest of the quest's `yourusername.github.io` placeholder style. tier-1
  score_pct 100.0 → 100.0 (held), brand clean. ✅ kept.
- **pages/_quests/0001/it-journey-stack-analysis.md** (verdict: fail) — fixed failed
  command `bash: Local Development quick start` (verified: `commands[].status=failed`,
  `quest_validator.py: error: Either quest_file or --directory must be specified`) by
  adding the required `-d pages/_quests/ --summary` args, matching the high-priority
  recommendation (area: "Local Development bash block / quest_validator.py"). Re-ran the
  corrected command locally — it now runs cleanly. tier-1 score_pct 85.1 → 85.1 (held),
  brand clean. ✅ kept.
- **pages/_quests/0001/it-journey-stack-analysis.md** — addressed high-priority
  recommendation (area: "content_accuracy — versions") by correcting the repeated
  Jekyll/github-pages/ffi/webrick version claims (3.9.5→3.10.0, 231→232, 1.17.0→1.17.4,
  1.8→1.9.2) throughout the doc (8+ occurrences) to match this repo's actual
  `Gemfile.lock`. tier-1 score_pct 85.1 → 85.1 (held), brand clean. ✅ kept.
- **pages/_quests/0001/personal-site.md** (verdict: fail) — addressed medium-priority
  recommendation (area: "Personal Site table") by fixing the row 6 copy/paste bug (the
  "Domain 3, hosted by Cloudflare" URL was byte-identical to row 2's GitHub Pages URL);
  replaced it with an explicit placeholder note rather than fabricating an unverified
  domain. tier-1 score_pct 76.8 → 76.8 (held), brand clean. ✅ kept.

_Left (per-quest eligibility / cap):_

- **pages/_quests/0001/self-operating-website-01-the-summoning.md** — `verdict: pass`;
  skipped per M7 (only `warn`/`fail` results are eligible). Its 3 recommendations
  (baseurl flag + workflow step ordering, clickable PR URLs, optional local-preview
  mention) are real but out of scope on a passing quest.
- **pages/_quests/0001/seo-optimization.md** — result carries a top-level `error`
  (`claude exited 1`, `max_turns` reached) and `verdict_obj: null`; not execution-grounded
  → "engine error — needs a re-walk." Nothing in it is verified; no edit made.
- **github-pages-portal.md** — left unfixed at the per-slice cap: high-priority
  "Custom domain objective vs content" (checklist claims custom-domain coverage the body
  never delivers) needs either real CNAME/DNS/HTTPS steps or a checklist correction —
  judged too large for a minimal edit this pass; medium "GitHub Actions / CI-CD Master
  Challenge" (no workflow YAML shown despite being a required deliverable); low "platform
  ordering" and low "multi-page navigation" recommendations.
- **it-journey-stack-analysis.md** — left unfixed at the cap: high-priority "Quest
  Objectives" (auto-seeded placeholder, no concrete objectives — same defect pattern as
  personal-site.md); medium "Docker snippets" (stale `jekyll/jekyll:latest` image +
  standalone Dockerfile that doesn't match the real repo's single `Dockerfile`); medium
  "`_config.yml` collections snippet" (lists `posts/quests/notebooks/docs` vs real
  `pages/quests/notes/about/quest-reports`); low "deployment workflow description" and low
  "Python/Ruby dependency lists" (`requirements.txt` overstatement).
- **personal-site.md** — left unfixed at the cap: high-priority "Overall quest body"
  (rewrite the reference table into an actual step-by-step tutorial) and high-priority
  "Objectives" (replace auto-seeded placeholder) — both call for substantive new
  authoring, not a smallest-faithful edit, and risk weakening/ballooning the diff beyond
  a reviewable fix PR; medium "Content accuracy" (stale Travis CI reference); low
  "Structure" (add prerequisites/numbered steps/validation).

No quest in this slice carries `source_repo`/`source_url` — none were vendored-skipped.
No edit touched frontmatter, so `_data/quests/**` regeneration was not needed.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/33770182128)._
