### PR TITLE
🔧 Quest fix: digital-artist/0001

### DIFF
--- a/pages/_quests/0001/forge-your-character.md
+++ b/pages/_quests/0001/forge-your-character.md
@@ -146,33 +146,34 @@ Open the file in your editor and fill in your details:
 # ═══════════════════════════════════════════
 profile:
   display_name: "Your Display Name"
-  class: Wizard          # Choose: Wizard, Warrior, Ranger, Rogue, Healer, Bard, Paladin
   avatar: ""             # URL to avatar image (leave blank for GitHub default)
+  class: Wizard          # Choose: Wizard, Warrior, Ranger, Rogue, Healer, Bard, Paladin
+  title: "Your Title or Role"
   bio: "A brief description of your quest in IT."
   location: ""
-  joined: "2026-03-20"
+  motto: ""
   banner_color: "#6c3fc5" # Hex color for your profile banner
   links:
     github: "https://github.com/YOUR_USERNAME"
-    website: ""
     twitter: ""
-  badges_pinned: []      # Pin up to 3 badge IDs here after earning them
+    linkedin: ""
+    website: ""
+  badges_pinned: []      # Pin up to 5 achievement IDs here after earning them
 
 # ═══════════════════════════════════════════
 # 🤖 AUTO-GENERATED — Do not edit below
 # ═══════════════════════════════════════════
 stats:
-  commits: 0
-  prs_merged: 0
-  quests_authored: 0
-  posts_authored: 0
+  total_commits: 0
+  total_prs_merged: 0
+  total_quests_authored: 0
+  total_posts_authored: 0
   lines_added: 0
   lines_removed: 0
+  first_contribution_date: null
+  latest_contribution_date: null
   active_days: 0
-  current_streak: 0
-  longest_streak: 0
-  first_commit: null
-  latest_commit: null
+  streak_days: 0
   top_languages: []
   top_categories: []
   contribution_calendar: []
@@ -181,9 +182,10 @@ achievements: []
 
 level:
   xp: 0
-  current_level: 0
-  tier: Apprentice
-  next_level_xp: 100
+  current_level: "0000"
+  tier: "Apprentice"
+  xp_to_next_level: 100
+  progress_percent: 0
 ```
 
 ### 🎭 Choosing Your Class
@@ -228,9 +230,9 @@ permalink: /contributors/YOUR_USERNAME/
 lastmod: 2026-03-20T00:00:00.000Z
 ---
 
-<link rel="stylesheet" href="{% raw %}{{ '/assets/css/contributor-profile.css' | relative_url }}{% endraw %}">
+<link rel="stylesheet" href="{{ '/assets/css/contributor-profile.css' | relative_url }}">
 
-{% raw %}{% include contributor/character_sheet.html username="YOUR_USERNAME" %}{% endraw %}
+{% include contributor/character_sheet.html username="YOUR_USERNAME" %}
 
 ---
 
@@ -277,9 +279,10 @@ cat _data/contributors/YOUR_USERNAME.yml
 
 ## ✅ Step 5: Verify Your Character Sheet
 
-Build the Jekyll site locally to see your profile:
+Build the Jekyll site locally to see your profile. If this is your first time running the site, install the Ruby gems first:
 
 ```bash
+bundle install
 bundle exec jekyll serve
 ```
 

--- a/pages/_quests/0001/side-quest-avatar-forge.md
+++ b/pages/_quests/0001/side-quest-avatar-forge.md
@@ -123,9 +123,10 @@ cp <PATH_TO_YOUR_AVATAR> assets/images/contributors/YOUR_USERNAME.png
 
 ### Step 4: Verify
 
-Build the site and check your profile page:
+Build the site and check your profile page. This assumes the site repo is already cloned and bundled from the prerequisite **Forge Your Character** quest — run `bundle install` first if you haven't yet:
 
 ```bash
+bundle install
 bundle exec jekyll serve
 # Visit http://localhost:4000/contributors/YOUR_USERNAME/
 ```
@@ -133,7 +134,7 @@ bundle exec jekyll serve
 Your avatar should appear in the circular frame at the top of your character card.
 
 - [ ] Avatar displays correctly
-- [ ] Fallback still works if image fails to load
+- [ ] Fallback still works if image fails to load — test by temporarily pointing `avatar:` at a broken URL and confirming the GitHub identicon (or a default placeholder) still renders instead of a blank/broken image
 
 ## 🏆 Reward: Portrait Artist Badge 🎨
 

--- a/pages/_quests/0001/stating-the-stats.md
+++ b/pages/_quests/0001/stating-the-stats.md
@@ -500,21 +500,21 @@ permalink: /stats/
         Comprehensive analytics and insights from the IT-Journey knowledge base
       </p>
       
-      {% raw %}{% if site.data.content_statistics %}{% endraw %}
+      {% if site.data.content_statistics %}
         <p class="text-muted">
           <i class="bi bi-clock"></i> 
-          Last updated: {% raw %}{{ site.data.content_statistics.generated_at | date: "%B %d, %Y at %I:%M %p" }}{% endraw %}
+          Last updated: {{ site.data.content_statistics.generated_at | date: "%B %d, %Y at %I:%M %p" }}
         </p>
-      {% raw %}{% else %}{% endraw %}
+      {% else %}
         <div class="alert alert-warning" role="alert">
           <i class="bi bi-exclamation-triangle"></i>
           Statistics not yet generated. Run <code>ruby scripts/generation/generate_statistics.rb</code> to create statistics.
         </div>
-      {% raw %}{% endif %}{% endraw %}
+      {% endif %}
     </div>
   </div>
 
-  {% raw %}{% if site.data.content_statistics %}{% endraw %}
+  {% if site.data.content_statistics %}
   
   <!-- Overview Cards -->
   <div class="row g-4 mb-5">
@@ -524,7 +524,7 @@ permalink: /stats/
         <div class="card-body text-center">
           <i class="bi bi-file-text display-4 text-primary"></i>
           <h2 class="card-title mt-3 mb-0">
-            {% raw %}{{ site.data.content_statistics.total_posts }}{% endraw %}
+            {{ site.data.content_statistics.total_posts }}
           </h2>
           <p class="card-text text-muted">Total Posts</p>
         </div>
@@ -537,7 +537,7 @@ permalink: /stats/
         <div class="card-body text-center">
           <i class="bi bi-fonts display-4 text-success"></i>
           <h2 class="card-title mt-3 mb-0">
-            {% raw %}{{ site.data.content_statistics.total_words }}{% endraw %}
+            {{ site.data.content_statistics.total_words }}
           </h2>
           <p class="card-text text-muted">Total Words</p>
         </div>
@@ -550,7 +550,7 @@ permalink: /stats/
         <div class="card-body text-center">
           <i class="bi bi-pencil display-4 text-info"></i>
           <h2 class="card-title mt-3 mb-0">
-            {% raw %}{{ site.data.content_statistics.average_words_per_post }}{% endraw %}
+            {{ site.data.content_statistics.average_words_per_post }}
           </h2>
           <p class="card-text text-muted">Avg. Words/Post</p>
         </div>
@@ -563,7 +563,7 @@ permalink: /stats/
         <div class="card-body text-center">
           <i class="bi bi-folder display-4 text-warning"></i>
           <h2 class="card-title mt-3 mb-0">
-            {% raw %}{{ site.data.content_statistics.categories | size }}{% endraw %}
+            {{ site.data.content_statistics.categories | size }}
           </h2>
           <p class="card-text text-muted">Categories</p>
         </div>
@@ -582,12 +582,12 @@ permalink: /stats/
         </div>
         <div class="card-body">
           <ul class="list-group list-group-flush">
-            {% raw %}{% for category in site.data.content_statistics.categories limit:10 %}{% endraw %}
+            {% for category in site.data.content_statistics.categories limit:10 %}
               <li class="list-group-item d-flex justify-content-between align-items-center">
-                <span>{% raw %}{{ category[0] | capitalize }}{% endraw %}</span>
-                <span class="badge bg-primary rounded-pill">{% raw %}{{ category[1] }}{% endraw %}</span>
+                <span>{{ category[0] | capitalize }}</span>
+                <span class="badge bg-primary rounded-pill">{{ category[1] }}</span>
               </li>
-            {% raw %}{% endfor %}{% endraw %}
+            {% endfor %}
           </ul>
         </div>
       </div>
@@ -603,12 +603,12 @@ permalink: /stats/
         </div>
         <div class="card-body">
           <ul class="list-group list-group-flush">
-            {% raw %}{% for tag in site.data.content_statistics.tags limit:10 %}{% endraw %}
+            {% for tag in site.data.content_statistics.tags limit:10 %}
               <li class="list-group-item d-flex justify-content-between align-items-center">
-                <span>{% raw %}{{ tag[0] }}{% endraw %}</span>
-                <span class="badge bg-success rounded-pill">{% raw %}{{ tag[1] }}{% endraw %}</span>
+                <span>{{ tag[0] }}</span>
+                <span class="badge bg-success rounded-pill">{{ tag[1] }}</span>
               </li>
-            {% raw %}{% endfor %}{% endraw %}
+            {% endfor %}
           </ul>
         </div>
       </div>
@@ -626,23 +626,23 @@ permalink: /stats/
         </div>
         <div class="card-body">
           <div class="tag-cloud">
-            {% raw %}{% for tag in site.data.content_statistics.tags limit:30 %}{% endraw %}
-              {% raw %}{% assign tag_size = tag[1] | times: 100 | divided_by: site.data.content_statistics.total_posts %}{% endraw %}
-              {% raw %}{% if tag_size > 50 %}{% endraw %}
-                {% raw %}{% assign tag_class = "fs-1" %}{% endraw %}
-              {% raw %}{% elsif tag_size > 30 %}{% endraw %}
-                {% raw %}{% assign tag_class = "fs-2" %}{% endraw %}
-              {% raw %}{% elsif tag_size > 15 %}{% endraw %}
-                {% raw %}{% assign tag_class = "fs-3" %}{% endraw %}
-              {% raw %}{% elsif tag_size > 8 %}{% endraw %}
-                {% raw %}{% assign tag_class = "fs-4" %}{% endraw %}
-              {% raw %}{% else %}{% endraw %}
-                {% raw %}{% assign tag_class = "fs-5" %}{% endraw %}
-              {% raw %}{% endif %}{% endraw %}
-              <span class="badge bg-secondary {% raw %}{{ tag_class }}{% endraw %} m-1">
-                {% raw %}{{ tag[0] }}{% endraw %} <small>({% raw %}{{ tag[1] }}{% endraw %})</small>
+            {% for tag in site.data.content_statistics.tags limit:30 %}
+              {% assign tag_size = tag[1] | times: 100 | divided_by: site.data.content_statistics.total_posts %}
+              {% if tag_size > 50 %}
+                {% assign tag_class = "fs-1" %}
+              {% elsif tag_size > 30 %}
+                {% assign tag_class = "fs-2" %}
+              {% elsif tag_size > 15 %}
+                {% assign tag_class = "fs-3" %}
+              {% elsif tag_size > 8 %}
+                {% assign tag_class = "fs-4" %}
+              {% else %}
+                {% assign tag_class = "fs-5" %}
+              {% endif %}
+              <span class="badge bg-secondary {{ tag_class }} m-1">
+                {{ tag[0] }} <small>({{ tag[1] }})</small>
               </span>
-            {% raw %}{% endfor %}{% endraw %}
+            {% endfor %}
           </div>
         </div>
       </div>
@@ -650,7 +650,7 @@ permalink: /stats/
   </div>
 
   <!-- Monthly Activity -->
-  {% raw %}{% if site.data.content_statistics.monthly_posts %}{% endraw %}
+  {% if site.data.content_statistics.monthly_posts %}
   <div class="row mb-5">
     <div class="col-lg-12">
       <div class="card">
@@ -670,24 +670,24 @@ permalink: /stats/
                 </tr>
               </thead>
               <tbody>
-                {% raw %}{% for month in site.data.content_statistics.monthly_posts limit:12 %}{% endraw %}
+                {% for month in site.data.content_statistics.monthly_posts limit:12 %}
                   <tr>
-                    <td>{% raw %}{{ month[0] }}{% endraw %}</td>
-                    <td><strong>{% raw %}{{ month[1] }}{% endraw %}</strong></td>
+                    <td>{{ month[0] }}</td>
+                    <td><strong>{{ month[1] }}</strong></td>
                     <td>
                       <div class="progress" style="height: 20px;">
-                        {% raw %}{% assign percentage = month[1] | times: 100 | divided_by: site.data.content_statistics.total_posts %}{% endraw %}
+                        {% assign percentage = month[1] | times: 100 | divided_by: site.data.content_statistics.total_posts %}
                         <div class="progress-bar bg-warning" role="progressbar" 
-                             style="width: {% raw %}{{ percentage }}{% endraw %}%" 
-                             aria-valuenow="{% raw %}{{ percentage }}{% endraw %}" 
+                             style="width: {{ percentage }}%" 
+                             aria-valuenow="{{ percentage }}" 
                              aria-valuemin="0" 
                              aria-valuemax="100">
-                          {% raw %}{{ percentage }}{% endraw %}%
+                          {{ percentage }}%
                         </div>
                       </div>
                     </td>
                   </tr>
-                {% raw %}{% endfor %}{% endraw %}
+                {% endfor %}
               </tbody>
             </table>
           </div>
@@ -695,7 +695,7 @@ permalink: /stats/
       </div>
     </div>
   </div>
-  {% raw %}{% endif %}{% endraw %}
+  {% endif %}
 
   <!-- Additional Metrics -->
   <div class="row mb-5">
@@ -711,39 +711,39 @@ permalink: /stats/
             <div class="col-md-4 mb-3">
               <h5>Content Diversity</h5>
               <p>
-                <strong>Categories:</strong> {% raw %}{{ site.data.content_statistics.categories | size }}{% endraw %}<br>
-                <strong>Tags:</strong> {% raw %}{{ site.data.content_statistics.tags | size }}{% endraw %}<br>
-                <strong>Avg. Categories/Post:</strong> {% raw %}{{ site.data.content_statistics.average_categories_per_post }}{% endraw %}<br>
-                <strong>Avg. Tags/Post:</strong> {% raw %}{{ site.data.content_statistics.average_tags_per_post }}{% endraw %}
+                <strong>Categories:</strong> {{ site.data.content_statistics.categories | size }}<br>
+                <strong>Tags:</strong> {{ site.data.content_statistics.tags | size }}<br>
+                <strong>Avg. Categories/Post:</strong> {{ site.data.content_statistics.average_categories_per_post }}<br>
+                <strong>Avg. Tags/Post:</strong> {{ site.data.content_statistics.average_tags_per_post }}
               </p>
             </div>
             <div class="col-md-4 mb-3">
               <h5>Reading Metrics</h5>
-              {% raw %}{% assign estimated_reading_time = site.data.content_statistics.average_words_per_post | divided_by: 200 %}{% endraw %}
+              {% assign estimated_reading_time = site.data.content_statistics.average_words_per_post | divided_by: 200 %}
               <p>
-                <strong>Avg. Reading Time:</strong> ~{% raw %}{{ estimated_reading_time }}{% endraw %} min<br>
-                <strong>Total Reading Time:</strong> ~{% raw %}{{ site.data.content_statistics.total_words | divided_by: 200 }}{% endraw %} min<br>
+                <strong>Avg. Reading Time:</strong> ~{{ estimated_reading_time }} min<br>
+                <strong>Total Reading Time:</strong> ~{{ site.data.content_statistics.total_words | divided_by: 200 }} min<br>
                 <strong>Longest Category:</strong> 
-                {% raw %}{% assign top_category = site.data.content_statistics.categories | first %}{% endraw %}
-                {% raw %}{{ top_category[0] | capitalize }}{% endraw %} ({% raw %}{{ top_category[1] }}{% endraw %} posts)
+                {% assign top_category = site.data.content_statistics.categories | first %}
+                {{ top_category[0] | capitalize }} ({{ top_category[1] }} posts)
               </p>
             </div>
             <div class="col-md-4 mb-3">
               <h5>Content Health</h5>
               <p>
                 <strong>Data Freshness:</strong> 
-                {% raw %}{% assign update_date = site.data.content_statistics.generated_at | date: "%s" %}{% endraw %}
-                {% raw %}{% assign now = "now" | date: "%s" %}{% endraw %}
-                {% raw %}{% assign age_hours = now | minus: update_date | divided_by: 3600 %}{% endraw %}
-                {% raw %}{% if age_hours < 24 %}{% endraw %}
-                  <span class="badge bg-success">Fresh ({% raw %}{{ age_hours }}{% endraw %}h)</span>
-                {% raw %}{% elsif age_hours < 168 %}{% endraw %}
+                {% assign update_date = site.data.content_statistics.generated_at | date: "%s" %}
+                {% assign now = "now" | date: "%s" %}
+                {% assign age_hours = now | minus: update_date | divided_by: 3600 %}
+                {% if age_hours < 24 %}
+                  <span class="badge bg-success">Fresh ({{ age_hours }}h)</span>
+                {% elsif age_hours < 168 %}
                   <span class="badge bg-warning">Good</span>
-                {% raw %}{% else %}{% endraw %}
+                {% else %}
                   <span class="badge bg-danger">Stale</span>
-                {% raw %}{% endif %}{% endraw %}
+                {% endif %}
                 <br>
-                <strong>Keywords Tracked:</strong> {% raw %}{{ site.data.content_statistics.top_keywords | size }}{% endraw %}
+                <strong>Keywords Tracked:</strong> {{ site.data.content_statistics.top_keywords | size }}
               </p>
             </div>
           </div>
@@ -752,7 +752,7 @@ permalink: /stats/
     </div>
   </div>
 
-  {% raw %}{% endif %}{% endraw %}
+  {% endif %}
 </div>
 
 <style>


### PR DESCRIPTION
## 🔧 Quest fix — `digital-artist/0001`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: digital-artist/0001

Evidence: `walk-evidence.json` — execute mode, `total==scored==5`, `errored==0` (no top-level `truncated` flag present, consistent with a fully-scored, non-truncated run). All 5 quests in the slice verdict `warn`, `verdict_obj.executed==true`, no `error`, none `budget_exhausted` → all 5 eligible for triage. None carry `source_repo:`/`source_url:` (none vendored).

**Kept edits:**

- **pages/_quests/0001/stating-the-stats.md** — fixed failed command `markdown: pages/stats.md (Liquid/Bootstrap stats page)` (verified: `commands[].status=failed`, confirmed by rendering through the real Liquid gem) and the matching high-priority recommendation (area: "pages/stats.md code fence"). Stripped all 64 `{% raw %}`/`{% endraw %}` wrapper pairs from the `pages/stats.md` snippet so the Liquid tags it teaches (`{% if %}`, `{% for %}`, `{{ }}`) actually evaluate instead of rendering as literal text when copied verbatim. tier-1 score_pct 91.9 → 91.9 (held). brand clean. ✅ kept.

- **pages/_quests/0001/forge-your-character.md** — fixed failed command `Markdown sample: profile page front matter + raw-wrapped CSS link and include` (verified: `commands[].status=failed`) and the matching high-priority recommendation (area: "Step 3 — Create Your Profile Page code block"). Removed the erroneous `{% raw %}`/`{% endraw %}` wrapping around the CSS `relative_url` filter and the `character_sheet.html` include, matching the real upstream template (`pages/_about/contribute/contributors/_template/README.md`), which has no raw tags. tier-1 score_pct 85.1 → 85.1 (held). brand clean. ✅ kept.

- **pages/_quests/0001/forge-your-character.md** — addressed high-priority recommendation (area: "Step 2 — Contributor data file YAML sample"). Replaced the Step 2 sample YAML with the real shape of `_data/contributors/_template.yml` (`total_commits`, `total_prs_merged`, `total_quests_authored`, `total_posts_authored`, `first_contribution_date`, `latest_contribution_date`, `streak_days`, `xp_to_next_level`, `progress_percent`, plus `title`/`motto`/`linkedin` fields), fixed `current_level` to the real zero-padded string format, and corrected "Pin up to 3 badge IDs" → "up to 5" to match the template's own comment. tier-1 score_pct 85.1 → 85.1 (held). brand clean. ✅ kept.

- **pages/_quests/0001/forge-your-character.md** — addressed medium-priority recommendation (area: "Step 5 — Verify Your Character Sheet"). Added a `bundle install` line before `bundle exec jekyll serve` with a one-line first-time-setup note. tier-1 score_pct 85.1 → 85.1 (held). brand clean. ✅ kept.

- **pages/_quests/0001/side-quest-avatar-forge.md** — addressed the failed command `bundle exec jekyll serve` (verified: `commands[].status=failed`, "Could not locate Gemfile") via its medium-priority recommendation (area: "Step 4: Verify"). Added a `bundle install` line and a note that this step assumes the repo is already cloned/bundled from the prerequisite "Forge Your Character" quest. tier-1 score_pct 85.1 → 85.1 (held). brand clean. ✅ kept.

- **pages/_quests/0001/side-quest-avatar-forge.md** — addressed medium-priority recommendation (area: "Verification checklist"). Explained the previously unexplained "Fallback still works if image fails to load" checklist item with a concrete test (point `avatar:` at a broken URL, confirm the GitHub identicon/placeholder still renders). tier-1 score_pct 85.1 → 85.1 (held). brand clean. ✅ kept.

**Left (per-slice cap reached at 6 kept edits — a handful, per the fix-loop's small-PR rule):**

- **pages/_quests/0001/stating-the-stats.md** — medium/low recommendations not yet applied: the Chapter 3 Knowledge Check `sort` filter mismatch, the "Automated Collection" objective wording vs. manual script invocation, the `cd /path/to/it-journey` placeholder annotation, and the `divided_by: 200` integer-truncation note. All are verified (recommendations[] on a warn/executed quest) but left for a future pass under the per-slice cap.
- **pages/_quests/0001/terminal-mastery.md** — no failed commands in this run (all `passed`/`skipped`/`reasoned`); left its verified recommendations (high: missing process-management content; medium: `grep "^#" README.md` and `cat *.txt | grep "important"` examples that silently produce no match; medium: hardcoded `whoami`/`pwd` "bamr87" expected output; low: placeholder-path annotations; low: Homebrew curl-into-bash caution) for a future pass — the high-priority one in particular needs a real new section, not a one-line patch, and the cap was reached first.
- **pages/_quests/0001/side-quest-badge-collector.md** — no failed commands in this run (all `skipped`/`reasoned`, since the sandbox lacked the full repo); left its verified recommendations (medium: missing profile URL in Step 3; low: `guild_founder` auto-earned contradiction; low: empty-achievements guidance; low: `bundle install` prerequisite note) for a future pass.
- No quest in this slice was skipped as vendored, errored, or budget_exhausted — all 5 were eligible, but only the two quests with confirmed failed commands plus their directly-tied recommendations were fixed this round to keep the PR small and reviewable.

No frontmatter was touched by any kept edit, so `make quest-data` was not run.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/33973499013)._
