### PR TITLE
🔧 Quest fix: developer/0001

### DIFF
--- a/pages/_quests/0001/analytics-integration.md
+++ b/pages/_quests/0001/analytics-integration.md
@@ -203,7 +203,7 @@ xdg-open http://127.0.0.1:4000/
 ```
 
 **Linux-Specific Notes:**
-- `curl -s http://127.0.0.1:4000/ | grep -i analytics` confirms the snippet renders.
+- `curl -s http://127.0.0.1:4000/ | grep -iE 'googletagmanager|gtag|plausible'` confirms the snippet renders (the rendered GA4/Plausible tags never contain the literal word "analytics").
 - Use the provider's real-time view to verify events arrive.
 
 </details>
@@ -254,12 +254,12 @@ A clean GA4 install lives in one include so a single config value controls it. I
   window.dataLayer = window.dataLayer || [];
   function gtag(){ dataLayer.push(arguments); }
   gtag('js', new Date());
-  // anonymize_ip trims the visitor's IP for privacy
-  gtag('config', '{% raw %}{{ site.ga_id }}{% endraw %}', { anonymize_ip: true });
+  gtag('config', '{% raw %}{{ site.ga_id }}{% endraw %}');
 </script>
 {% raw %}{% endif %}{% endraw %}
 ```
 
+GA4 does not store visitor IP addresses by default, so it needs no `anonymize_ip` flag - that option only did something on the older Universal Analytics. If you migrated a snippet from Universal Analytics, drop `anonymize_ip` rather than carrying it forward; it is silently ignored by GA4's `gtag('config', ...)` call.
 
 The `jekyll.environment == "production"` guard is the key habit: your local clicks never pollute your real data. (This is a common, real-world mistake - sites that fire analytics in dev end up with most of their "traffic" being themselves.) A privacy-first tool is even simpler - one script tag, no cookies:
 

--- a/pages/_quests/0001/docs-in-a-row.md
+++ b/pages/_quests/0001/docs-in-a-row.md
@@ -230,7 +230,7 @@ By completing this quest, you will:
 **Checkpoint**: You now have a structured repository ready for automation!
 
 ### Step 2: Weave the Automation Spell (GitHub Workflow)
-Harness the power of GitHub Actions to automate your doc-harvesting ritual. Create `.github/workflows/aggregate-docs.yaml` with this incantation:
+Harness the power of GitHub Actions to automate your doc-harvesting ritual. Open the `.github/workflows/aggregate-docs.yml` file you created in Step 1 and add this incantation:
 
 ```yaml
 name: Aggregate Documentation
@@ -365,7 +365,8 @@ while IFS= read -r repo || [ -n "$repo" ]; do
         
         # Create target directory and copy file
         mkdir -p "$target_dir"
-        cp "$file" "$target_dir/" && ((file_count++))
+        cp "$file" "$target_dir/"
+        file_count=$((file_count + 1))
     done < <(find "$temp_dir" -type f \( -name "*.md" -o -name "README*" \) -not -path "*/.git/*" -not -path "*/node_modules/*" -not -path "*/vendor/*")
     
     log_info "Collected $file_count documentation files from $repo_name"
@@ -440,7 +441,9 @@ def generate_front_matter(content):
 # Process files
 for root, dirs, files in os.walk(RAW_DIR):
     for file in files:
-        if file.endswith('.md'):
+        # aggregate.sh collects both *.md and extension-less README* files,
+        # so process.py must handle both or it silently loses the READMEs.
+        if file.endswith('.md') or file.startswith('README'):
             src_path = Path(root) / file
             with open(src_path, 'r') as f:
                 content = f.read()
@@ -459,7 +462,10 @@ for root, dirs, files in os.walk(RAW_DIR):
 
             # Organize
             category = categorize_content(body)
-            dest_dir = Path(ORGANIZED_DIR) / category / Path(root).relative_to(RAW_DIR).parent
+            # Note: no trailing .parent here — keep the per-repo subpath so
+            # same-named files from different repos (e.g. every README.md)
+            # never collide and overwrite each other under docs/.
+            dest_dir = Path(ORGANIZED_DIR) / category / Path(root).relative_to(RAW_DIR)
             dest_dir.mkdir(parents=True, exist_ok=True)
             dest_path = dest_dir / file
 


### PR DESCRIPTION
## 🔧 Quest fix — `developer/0001`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: developer/0001

Evidence: `walk-evidence.json` — 5 quests scored, execute-mode, not truncated (no `truncated` key), 0 errored. Eligible for fixes: **2 of 5** quests (the other 3 passed and are out of scope).

- **pages/_quests/0001/docs-in-a-row.md** (verdict: fail, overall 42.0) — 4 kept edits, tier-1 held **60/74 (81.1%) → 60/74 (81.1%)** across every edit, brand_lint clean throughout:
  - Fixed failed commands `scripts/aggregate.sh` and `./scripts/aggregate.sh (Test Locally)` (verified: `commands[].status=failed`, both root-caused to the same bug) and the matching high-priority recommendation (area: *Step 3 – scripts/aggregate.sh*): replaced `cp "$file" "$target_dir/" && ((file_count++))` with a two-statement copy + increment, since `((file_count++))` returns falsy on the 0→1 transition and `set -euo pipefail` was aborting the script after the very first file. ✅ kept.
  - Addressed high-priority recommendation (area: *Step 4 – scripts/process.py destination path*), grounded in the failed `scripts/process.py` command: removed the trailing `.parent` from `dest_dir = Path(ORGANIZED_DIR) / category / Path(root).relative_to(RAW_DIR)` so same-named files (e.g. every repo's `README.md`) no longer collide and silently overwrite each other. ✅ kept.
  - Addressed high-priority recommendation (area: *Step 3/4 – README file extension mismatch*), same failed `scripts/process.py` command: changed the file filter from `file.endswith('.md')` to `file.endswith('.md') or file.startswith('README')` so extension-less `README` files that `aggregate.sh`'s own `find` pattern collects are no longer silently dropped. ✅ kept.
  - Addressed medium-priority recommendation (area: *Step 1 vs Step 2 – workflow filename*): Step 2 told the learner to *create* `aggregate-docs.yaml` after Step 1 already `touch`ed `aggregate-docs.yml`, which could leave two workflow files (one empty). Reworded Step 2 to open the file already created in Step 1, and fixed the extension. ✅ kept.

- **pages/_quests/0001/analytics-integration.md** (verdict: warn, overall 72.0) — 2 kept edits, tier-1 held **74/74 (100.0%) → 74/74 (100.0%)** across every edit, brand_lint clean throughout:
  - Fixed the failed command `curl -s http://127.0.0.1:4000/ | grep -i analytics (Linux-Specific Note)` and its matching high-priority recommendation (area: *Linux-Specific Note verification command*): the literal word "analytics" never appears in the rendered GA4 or Plausible snippet, so the verification tip could never pass. Replaced with `grep -iE 'googletagmanager|gtag|plausible'`. ✅ kept.
  - Addressed medium-priority recommendation (area: *Chapter 1 anonymize_ip claim*): GA4 does not store IPs by default and silently ignores `anonymize_ip` in `gtag('config', ...)` — it's a legacy Universal Analytics option. Removed the flag from the code sample and added a short note explaining why, so the example no longer implies learners are configuring a real GA4 privacy control. ✅ kept.

_Left:_
- **javascript-fundamentals.md**, **jekyll-plugins.md**, **kaizen.md** — all `verdict: pass`; out of scope per M7 (only `warn`/`fail` quests are eligible).
- **docs-in-a-row.md** — failed command / medium recommendation on the *Challenge 1 GitHub Pages deploy step* (`github_token: ${% raw %}{{ secrets.GITHUB_TOKEN }}{% endraw %}`, flagged as a "leaked Jekyll templating artifact"): verified this is **not a defect** — it's this repo's established, correct idiom for displaying a literal `${{ secrets.NAME }}` in a Jekyll-rendered page (same pattern used in `0101/secrets-management.md`, `0101/github-actions-basics.md`, and elsewhere); Jekyll's `{% raw %}…{% endraw %}` renders the enclosed text verbatim, so the *rendered* page shows the correct `${{ secrets.GITHUB_TOKEN }}`. The walker read the raw Markdown source rather than the rendered output. No faithful edit exists here — editing it would break the established convention and regress the rendered page. Not fixed; flagged as a false positive for the walker.
- **docs-in-a-row.md** — medium recommendation (area: *Step 5 – Expected Directory Structure*, tree showing `guides/`, `architecture/`, `general/` vs. the shipped `categorize_content()` which only emits `api`/`user-guides`/`misc`) and two low-priority recommendations (unrefined Objectives boilerplate; mojibake heading + leftover authoring note) — real, evidence-grounded issues, but left unaddressed this pass to keep the per-slice edit count small and reviewable per the fix-lane cap; candidates for the next daily pass.

All 6 kept edits are body-content only (no frontmatter touched in either file), so `make quest-data` was not required.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/33973499013)._
