### PR TITLE
🔧 Quest fix: digital-artist/0001

### DIFF
--- a/pages/_quests/0001/barodybroject-stack-analysis.md
+++ b/pages/_quests/0001/barodybroject-stack-analysis.md
@@ -90,8 +90,12 @@ By the end of this quest, you will be able to:
 > & Quality Assessment's "Known Vulnerabilities" claims** — they reflect a scan
 > taken on the Analysis Date, not a live guarantee; run `pip-audit` yourself
 > (see Quick Setup) against the current `main` before trusting them, since new
-> CVEs are disclosed continuously. Always re-verify against the current
-> repository before relying on any specific figure here.
+> CVEs are disclosed continuously. The same drift also applies to figures not
+> called out individually below, such as the README's line count, the
+> `requires-python` floor, the static-asset path, and the exact
+> `.github/workflows/` file list — treat every specific number or path in this
+> document as a claim to re-verify, not a live guarantee. Always re-verify
+> against the current repository before relying on any specific figure here.
 
 ## ✅ Do This (Hands-On Walkthrough)
 
@@ -197,7 +201,7 @@ graph TB
 
 | Technology | Version | Purpose | Configuration Location |
 |------------|---------|---------|------------------------|
-| Bootstrap | 5.3.3 | Responsive UI framework | CDN, templates |
+| Bootstrap | 5.3.3 | Responsive UI framework | `django-bootstrap5` template tags in `base.html` (only `bootstrap-icons` is CDN-sourced) |
 | Django Templates | 4.2.20 | Server-side rendering | src/parodynews/templates/ |
 | jQuery | Optional | DOM manipulation | Optional inclusion |
 | Static Assets | N/A | CSS, JS, images | src/static/ |
@@ -285,6 +289,9 @@ def generate_parody_content(prompt: str, model: str = "gpt-4") -> str:
 
 **Database Configuration Strategy**:
 ```python
+# excerpt — assumes env, IS_PRODUCTION, BASE_DIR already exist earlier in
+# settings.py; not a standalone snippet, so running it verbatim raises
+# NameError: name 'env' is not defined.
 # settings.py - Intelligent database selection
 DB_CHOICE = env.str("DB_CHOICE", default="postgres")
 
@@ -734,6 +741,9 @@ python manage.py createsuperuser
 **Performance Optimization**:
 1. ⚠️ **Enable Caching**: Configure Redis for production caching
    ```python
+   # excerpt — assumes env, IS_PRODUCTION, BASE_DIR from settings.py; not a
+   # standalone snippet, so running it verbatim raises
+   # NameError: name 'env' is not defined.
    # Add to settings.py
    CACHES = {
        'default': {


### PR DESCRIPTION
## 🔧 Quest fix — `digital-artist/0001`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: digital-artist/0001

Slice run was `mode=execute`, non-truncated (`walk-plan.json` `stats.truncated=false`). Of the 5 quests walked, only **1** returned a non-`pass` (execution-grounded) verdict; the other 4 (`advanced-markdown.md`, `css-styling-basics.md`, `bootstrap-framework.md`, `building-testing-git-init-script.md`) scored `pass` and are out of scope per M7 (issues are only eligible on `warn`/`fail` results).

- **pages/_quests/0001/barodybroject-stack-analysis.md** — fixed both failed sandbox
  commands (`verdict_obj.commands[].status=failed`: the settings.py DB-selection
  excerpt L220-251 and the CACHES/Redis excerpt L669-677, both raising `NameError:
  name 'env' is not defined` when run standalone) by labeling each `python` block as
  a non-standalone excerpt that assumes `env`/`IS_PRODUCTION`/`BASE_DIR` already
  exist — this is the same fix the medium-priority recommendation ("Python excerpts
  (L220-251, L669-677)") named. tier-1 score_pct 71.6 → 71.6 (held), brand_lint clean.
  ✅ kept.
- **pages/_quests/0001/barodybroject-stack-analysis.md** — addressed the high-priority
  recommendation (area: "Content accuracy — un-flagged stale claims") by extending the
  existing point-in-time disclaimer to explicitly name the drifted figures the
  evidence called out (README line count, `requires-python` floor, static-asset path,
  `.github/workflows/` file list) as claims to re-verify, rather than silently leaving
  them uncovered by the disclaimer's examples. tier-1 score_pct 71.6 → 71.6 (held),
  brand_lint clean. ✅ kept.
- **pages/_quests/0001/barodybroject-stack-analysis.md** — addressed the low-priority
  recommendation (area: "Frontend row (Bootstrap Configuration Location)") by
  correcting the Bootstrap "Configuration Location" cell from "CDN, templates" to
  note it's loaded via `django-bootstrap5` template tags in `base.html` (only
  `bootstrap-icons` is CDN-sourced). tier-1 score_pct 71.6 → 71.6 (held), brand_lint
  clean. ✅ kept.

No frontmatter was touched by any kept edit, so `make quest-data` was not required.

_Left:_ the low-priority "Structure" recommendation (move the large forward-looking
sections — Strategic Recommendations, Innovation Highlights, Comparative Analysis,
Modernization roadmap — into a separate reference doc) was left out of scope: it asks
for a document split, which is not a "smallest faithful edit" and risks weakening or
relocating real content rather than repairing a defect. A human should own that
restructuring call. No quest in this slice was vendored, errored, or
`budget_exhausted`.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/34136036494)._
