### PR TITLE
🔧 Quest fix: developer/0001

### DIFF
--- a/pages/_quests/0001/analytics-integration.md
+++ b/pages/_quests/0001/analytics-integration.md
@@ -273,6 +273,14 @@ The `jekyll.environment == "production"` guard is the key habit: your local clic
 - [ ] Why guard the snippet on `jekyll.environment == "production"`?
 - [ ] What does `anonymize_ip` do?
 
+<details><summary>Answer key</summary>
+
+- GA4: free, event-based, deep integration with Google Ads/Search Console. A cookieless tool (e.g. Plausible): no cookie banner needed, lighter weight, simpler privacy story.
+- The guard keeps local development clicks out of production analytics - without it, your own testing looks like "traffic."
+- `anonymize_ip` was a Universal Analytics option to trim the visitor's IP before storing it; GA4 does not store IP addresses at all, so the flag is unused there (see the note above).
+
+</details>
+
 ### ⚡ Quick Wins and Checkpoints
 - [ ] **Tool chosen**: You picked an analytics provider for your needs
 - [ ] **Snippet gated**: Analytics only fires in production, not on localhost
@@ -331,6 +339,14 @@ Collect the minimum, anonymize where you can, and make it easy to opt out. Good 
 - [ ] Why check `typeof gtag === "function"` before calling it?
 - [ ] What is the simplest way to respect consent before tracking?
 
+<details><summary>Answer key</summary>
+
+- A page view says someone loaded a page; an event says they *did* something on it - clicked, submitted, scrolled.
+- The check avoids a `ReferenceError` if the analytics script has not loaded yet (blocked, still loading, or consent not yet granted).
+- Do not load or call the analytics script at all until the visitor opts in - gate the load, not just the calls.
+
+</details>
+
 ### ⚡ Quick Wins and Checkpoints
 - [ ] **Event fired**: A custom event appears in your provider's real-time view
 - [ ] **Consent respected**: Tracking waits for opt-in where required
@@ -357,7 +373,15 @@ Events / Goals     — which actions people took
 Engagement time    — how long they actually stayed
 ```
 
-A critical, often-skipped step: **filter out pollution**. Your own visits and bot traffic can dwarf real users on a small site. In GA4, add an internal-traffic filter (by IP) or a hostname filter so only your production domain counts. The lesson from real sites is blunt: without a hostname filter, the bulk of "traffic" can be developers hitting `localhost`.
+A critical, often-skipped step: **filter out pollution**. Your own visits and bot traffic can dwarf real users on a small site. In GA4, add an internal-traffic filter (by IP, under Admin → Data Streams → Configure tag settings → Show more → Define internal traffic) or a hostname filter so only your production domain counts. The lesson from real sites is blunt: without a hostname filter, the bulk of "traffic" can be developers hitting `localhost`. A quick client-side hostname guard gives the same protection without any dashboard configuration:
+
+```javascript
+if (location.hostname !== 'example.com') {
+  // Not the production domain (localhost, a preview deploy, etc.) - skip tracking.
+} else {
+  gtag('event', 'page_view');
+}
+```
 
 Finally, define a **goal**: the one action that means a visit succeeded - a newsletter signup, a quest started, a contact form sent. Tracking a goal turns vanity metrics into a measure of whether your site does its job.
 
@@ -365,6 +389,14 @@ Finally, define a **goal**: the one action that means a visit succeeded - a news
 - [ ] What is the difference between a user and a session?
 - [ ] Why filter by hostname or internal IP?
 - [ ] What makes a good goal for a content site?
+
+<details><summary>Answer key</summary>
+
+- A user is a distinct person (by device/browser); a session is one visit - the same user can open several sessions.
+- Without it, your own dev-server visits and bot traffic can outnumber real visitors, especially on a small site.
+- One action that means the visit succeeded - a newsletter signup, a quest started, a contact form sent - not a vanity metric like raw page views.
+
+</details>
 
 ## 🎮 Mastery Challenges
 

--- a/pages/_quests/0001/docs-in-a-row.md
+++ b/pages/_quests/0001/docs-in-a-row.md
@@ -67,13 +67,12 @@ layout: quest
 
 By the end of this quest, you will be able to:
 
-- [ ] Understand the core concepts introduced in this quest
-- [ ] Complete the hands-on exercises and verify the results
-- [ ] Apply what you learned to a follow-up scenario of your own design
+- [ ] Write a GitHub Actions workflow that runs the aggregation on a schedule and on-demand via manual trigger
+- [ ] Write a Bash script that clones and collects documentation files from at least 2 repositories
+- [ ] Write a Python script that organizes collected files into a logical, non-colliding directory structure
+- [ ] Generate correct YAML front matter for every processed document
 
-> *Note: objectives auto-seeded during framework alignment — authors should refine these to reflect this quest's specific skills.*
-
-## � Quest Overview
+## 📖 Quest Overview
 
 **Level**: Journeyman (Lvl 001) | **Difficulty**: 🟡 Medium | **Time**: 2-3 hours
 
@@ -485,8 +484,6 @@ for root, dirs, files in os.walk(RAW_DIR, topdown=False):
 os.rmdir(RAW_DIR)
 ```
 
-**Script creates proper Python implementation** - Full implementation provided above replaces this placeholder.
-
 ---
 
 ### Step 5: Deploy and Test Your System
@@ -546,16 +543,16 @@ head -n 20 docs/api/README.md
 ```text
 docs/
 ├── api/
-│   ├── README.md
-│   └── endpoints.md
-├── guides/
-│   ├── getting-started.md
-│   └── tutorial.md
-├── architecture/
-│   └── design-decisions.md
-└── general/
-    └── misc-docs.md
+│   ├── my-repo/README.md
+│   └── my-repo/endpoints.md
+├── user-guides/
+│   ├── other-repo/getting-started.md
+│   └── other-repo/tutorial.md
+└── misc/
+    └── my-repo/notes.md
 ```
+
+`categorize_content()` only sorts into three buckets — `api` (content mentioning "api"), `user-guides` (content mentioning "guide" or "tutorial"), and `misc` (everything else) — and `process.py` keeps each file's per-repo subpath under its category, so expand the function first if you want the `guides`/`architecture`/`general` split shown in earlier drafts of this quest.
 
 **Checkpoint**: Your documentation hub is live and automatically updating!
 
@@ -595,7 +592,7 @@ Deploy your documentation hub as a searchable website:
 - name: Deploy to GitHub Pages
   uses: peaceiris/actions-gh-pages@v3
   with:
-    github_token: ${% raw %}{{ secrets.GITHUB_TOKEN }}{% endraw %}
+    github_token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
     publish_dir: ./docs
 ```
 


### PR DESCRIPTION
## 🔧 Quest fix — `developer/0001`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: developer/0001

Evidence: `walk-evidence.json` (5 quests, execute-mode, `errored: 0`, no top-level `truncated` flag; every result carries `mode: execute`, `executed: true`, no `error`, not `budget_exhausted`) — an honest, non-truncated run. Two quests were eligible for repair (`verdict` `fail`/`warn`); the other three (`javascript-fundamentals.md` 94% pass, `jekyll-plugins.md` 88% pass, `kaizen.md` 81% pass) were skipped per the verdict-pass rule even though `jekyll-plugins.md` had 2 failed commands (Bundler downloader flakiness the walker itself called "an environment quirk rather than a quest defect", not a quest defect to fix).

Note: this evidence's **high-priority** verified issues (docs-in-a-row's `((file_count++))`/`set -e` bug, its `process.py` README-extension/`dest_dir` collision bugs, and analytics-integration's broken `grep` verification command + stale `anonymize_ip` claim) were **already fixed and merged** in a prior fix pass (commit `160aad6b`, PR #706) against this same evidence — confirmed by reading the current file content and `git log`. Nothing further was owed there; this pass worked the remaining **medium/low** verified recommendations still present in the files.

- **pages/_quests/0001/docs-in-a-row.md** — fixed leaked Jekyll templating artifact in the Challenge 1 GitHub Actions YAML (verified: medium recommendation, "leaked Jekyll artifact `${% raw %}...`"): `github_token: ${% raw %}{{ secrets.GITHUB_TOKEN }}{% endraw %}` → `{% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}` so the copy-pasted YAML renders a valid `${{ secrets.GITHUB_TOKEN }}` expression. tier-1 score_pct 81.1 → 81.1 (held). ✅ kept.
- **pages/_quests/0001/docs-in-a-row.md** — fixed the "Expected Directory Structure" example (verified: medium recommendation, mismatched vs. actual `categorize_content()` output) to show the real `api/`, `user-guides/`, `misc/` buckets with per-repo subpaths preserved, plus a one-line note pointing out the function needs expanding for the `guides`/`architecture`/`general` split shown in older drafts. tier-1 score_pct 81.1 → 81.1 (held). ✅ kept.
- **pages/_quests/0001/docs-in-a-row.md** — fixed formatting (verified: low recommendation, "mojibake character... and leftover authoring note"): replaced the broken `�` glyph in `## � Quest Overview` with `📖`, and removed the leftover authoring note ("Script creates proper Python implementation..."). tier-1 score_pct 81.1 → 81.1 (held). ✅ kept.
- **pages/_quests/0001/docs-in-a-row.md** — replaced the generic auto-seeded Quest Objectives checklist with objectives tied to this quest's own 5 stated `validation_criteria` (verified: low recommendation, "replace the auto-seeded generic checklist with objectives specific to this quest"). tier-1 score_pct 81.1 → 81.1 (held). ✅ kept.
- **pages/_quests/0001/analytics-integration.md** — added a concrete client-side hostname-guard code example (mirroring the worked production-gate example) for the Advanced Mastery Challenge's internal-traffic/hostname filter requirement (verified: medium recommendation, "Add a concrete code/config example for the internal-traffic or hostname filter"). tier-1 score_pct 100.0 → 100.0 (held, already at max). ✅ kept.
- **pages/_quests/0001/analytics-integration.md** — added a brief collapsible answer key under each of the three Knowledge Check sections (verified: low recommendation, "Provide brief answers or a link to an answer key for the knowledge-check questions"). tier-1 score_pct 100.0 → 100.0 (held, already at max). ✅ kept.

All 6 edits verified with `brand_lint.py` staying clean (no spelling/voice drift) and no sandbox command regressing. No frontmatter was touched, so `make quest-data` was not needed.

_Left:_ nothing reverted this pass — every queued edit held or was already at ceiling. `pages/_quests/0001/javascript-fundamentals.md`, `pages/_quests/0001/jekyll-plugins.md`, and `pages/_quests/0001/kaizen.md` were left untouched — all three are `verdict: pass`, out of scope per the verified-issues-only rule regardless of any individual failed/skipped commands they carried. No vendored quests were encountered in this slice (none of the 5 carry `source_repo`/`source_url`). Stopped at 6 kept edits (a handful) across the slice's two non-pass quests, per the per-slice cap.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/34367419199)._
