### PR TITLE
🔧 Quest fix: digital-artist/0001

### DIFF
--- a/pages/_quests/0001/barodybroject-stack-analysis.md
+++ b/pages/_quests/0001/barodybroject-stack-analysis.md
@@ -108,6 +108,15 @@ Work these four steps in order — each maps directly to a Quest Objective above
 
 **Quest complete when:** you can list at least one confirmed-accurate claim and one confirmed-stale claim from this document, backed by what you actually saw in the live repo — check off each objective above as you go.
 
+> **Reading map.** The four steps above are the entire hands-on walkthrough. Everything
+> from Executive Summary through Detailed Stack Analysis, Dependency Analysis, and
+> Security & Quality Assessment is reference material the steps point into. The
+> Recommendations, Educational Value, Modernization Opportunities, Comparative Analysis,
+> Strategic Recommendations, Innovation Highlights, and Stack Maturity Assessment sections
+> further below are optional deep-dive reading, generated at Analysis Date as
+> forward-looking commentary — skip straight to them only if you want more context after
+> completing the four steps.
+
 ## 📊 Executive Summary
 
 Barodybroject is a Django-based web application that leverages OpenAI's APIs to generate AI-powered parody news content. The project demonstrates modern web development practices with a focus on **container-first development**, **cloud-native deployment**, and **cost-optimized infrastructure**. Successfully deployed to Azure Container Apps in January 2025, the application showcases a production-ready Django stack with sophisticated AI integration.


### PR DESCRIPTION
## 🔧 Quest fix — `digital-artist/0001`

The `quest-fixer` agent consumed the walkthrough's **verified** evidence for
this slice and applied the smallest **content-only** edits that fix what the
walker witnessed. Each kept edit passed the deterministic keep/revert gate
(tier-1 `quest_validator.py` held-or-rose **and** `brand_lint` stayed clean —
never the model's own agentic grade).

### quest-fix: digital-artist/0001

Evidence: `mode=execute`, run non-truncated (`errored: 0`, `truncated` absent → false), 5/5 quests scored. Only one quest scored below `pass` (`warn`), so it is the only quest whose issues are eligible for repair (M7 — issues are collected only from `warn`/`fail` results); the other four quests (`advanced-markdown.md`, `css-styling-basics.md`, `bootstrap-framework.md`, `building-testing-git-init-script.md`) scored `pass` and were skipped — no edits made on `pass` quests regardless of their recommendation lists.

- **pages/_quests/0001/barodybroject-stack-analysis.md** (verdict `warn`, `executed: true`, no `error`, not `budget_exhausted` — eligible). Checked frontmatter first: no `source_repo`/`source_url`, not vendored.
  - Three of the four verified issues this evidence lists were found **already resolved** on disk by a prior fix round (commit `64a138c4`, PR #713) before I touched anything, so no re-edit was made for them:
    - high `Content accuracy — un-flagged stale claims` → the point-in-time disclaimer already explicitly names "the README's line count, the `requires-python` floor, the static-asset path, and the exact `.github/workflows/` file list" as drift-prone (lines 93-96) — satisfies the recommendation's own "either update these figures **or** explicitly extend the point-in-time warning" alternative.
    - medium `Python excerpts (L220-251, L669-677)` → both settings.py excerpts already carry a `# excerpt — assumes env, IS_PRODUCTION, BASE_DIR ... raises NameError` comment.
    - low `Frontend row (Bootstrap Configuration Location)` → the Bootstrap table row already reads "`django-bootstrap5` template tags in `base.html` (only `bootstrap-icons` is CDN-sourced)".
  - Applied the one remaining, still-unaddressed, verified issue: low-priority `Structure` recommendation ("the hands-on 4-step walkthrough only touches a small fraction of this 1,130-line document ... consider moving the large forward-looking sections into a separate reference doc"). Rather than the invasive split (out of scope for a smallest edit — would touch permalinks/links and risks losing content), added one short "Reading map" callout right after the walkthrough's completion line, explicitly scoping the four hands-on steps and marking the Recommendations/Educational Value/Modernization/Comparative Analysis/Strategic Recommendations/Innovation Highlights/Stack Maturity sections as optional reference reading.
  - tier-1 `score_pct` 71.6 → 71.6 (held, 53/74 both). `brand_lint.py`: clean, no new drift. ✅ kept. No frontmatter touched, so `_data/quests/**` regeneration is not required.

_Left:_ nothing reverted. The remaining two "reasoned"/non-executed diagram-only items and the two `failed` python-excerpt commands (`settings.py` DB-selection / CACHES excerpts) are inherent to teaching non-standalone `settings.py` snippets — already labeled as excerpts (see above); further "fixing" would mean fabricating surrounding `env`/`BASE_DIR` context that doesn't belong in a stack-analysis document, which is out of scope for this pass. No quest in this slice was skipped for being vendored or `budget_exhausted`.

_Generated by the Quest Fix lane — [run](https://github.com/bamr87/it-journey/actions/runs/34367419199)._
