### PR TITLE
fix(quests): Agentic Codex hub + Learn weight ranges (P0)

### DIFF
--- a/pages/_quests/0111/agentic-codex-01-agents-in-the-sdlc.md
+++ b/pages/_quests/0111/agentic-codex-01-agents-in-the-sdlc.md
@@ -2,7 +2,7 @@
 title: 'Initiation Rites: Agents in the SDLC'
 description: 'Embed GitHub Copilot agents into the software lifecycle with bounded roles, plan-then-act gates, and observable traces — GH-600 Domain 1 of The Agentic Codex.'
 date: '2026-06-30T00:00:00.000Z'
-lastmod: '2026-09-13T04:45:00.000Z'
+lastmod: '2026-09-13T04:55:00.000Z'
 level: '0111'
 difficulty: '🟡 Medium'
 estimated_time: 2-4 hours
@@ -318,6 +318,9 @@ Now the **degree of autonomy** is a dial you control: the JSONL trail is the evi
 ## 🧪 Hands-On Lab: Raise the Gate in Fifteen Minutes
 
 *Rites are learned by performing them, not reading them.* This lab stands up a real plan-then-act pipeline — plan job, human gate, observable trace — in a scratch repository, using nothing but the `gh` CLI. No Copilot subscription required: the "agent" is a stub you can later replace with the real coding agent.
+
+> **Workbench status (verified):** **Needs GitHub** for the full rite — `gh` auth, a **public** scratch repo, and an Environment with a required reviewer. The stub agent is local-honest (no Copilot). The Environment gate and artifact download only prove out on GitHub.
+
 
 ### Step 1 — Forge the scratch repo
 

--- a/pages/_quests/0111/agentic-codex-01-agents-in-the-sdlc.md
+++ b/pages/_quests/0111/agentic-codex-01-agents-in-the-sdlc.md
@@ -2,7 +2,7 @@
 title: 'Initiation Rites: Agents in the SDLC'
 description: 'Embed GitHub Copilot agents into the software lifecycle with bounded roles, plan-then-act gates, and observable traces — GH-600 Domain 1 of The Agentic Codex.'
 date: '2026-06-30T00:00:00.000Z'
-lastmod: '2026-07-01T00:00:00.000Z'
+lastmod: '2026-09-13T04:45:00.000Z'
 level: '0111'
 difficulty: '🟡 Medium'
 estimated_time: 2-4 hours
@@ -85,7 +85,7 @@ validation_criteria:
 
 *The realm has summoned its first familiars — tireless constructs that read your code, draft your changes, and stand ready at the gate. But a familiar without a leash is a liability. Loose one with the keys to the whole castle and no record of where it walked, and the first night it errs you will have no torch to follow its steps. The Initiation Rites teach the oldest discipline of the agentic order: give every familiar a **bound** — a door it enters, rooms it may touch, a task it knows is finished, and a trail of footprints anyone can read.*
 
-*Behind the spellcraft is the most-tested idea in GH-600 Domain 1 (18% of the exam, per the [official study guide](https://learn.microsoft.com/en-us/credentials/certifications/resources/study-guides/gh-600)): an agent is most useful and least dangerous when it has a **bounded role** in the software development lifecycle. You will design where Copilot's coding agent enters the SDLC, separate the act of **planning** from the act of **doing** with a human-approved gate, and make every agent run leave an **observable trace**. These are not three tricks — they are the contract that lets autonomy scale without becoming a runaway machine.*
+*Behind the spellcraft is a core GH-600 Domain 1 idea ([study guide](https://learn.microsoft.com/en-us/credentials/certifications/resources/study-guides/gh-600) weight **15–20%** — Learn publishes ranges, not a fixed percent): an agent is most useful and least dangerous when it has a **bounded role** in the software development lifecycle. You will design where Copilot's coding agent enters the SDLC, separate the act of **planning** from the act of **doing** with a human-approved gate, and make every agent run leave an **observable trace**. These are not three tricks — they are the contract that lets autonomy scale without becoming a runaway machine.*
 
 ## 📖 The Legend Behind This Quest
 

--- a/pages/_quests/1000/agentic-codex-02-tool-use-and-environment.md
+++ b/pages/_quests/1000/agentic-codex-02-tool-use-and-environment.md
@@ -2,7 +2,7 @@
 title: 'Forging the Arsenal: Tool Use & Environment'
 description: 'Equip GitHub Copilot agents with the right tools, wire MCP servers, scope least-privilege permissions, and bind agents to a CI environment — GH-600 Domain 2.'
 date: '2026-06-30T00:00:00.000Z'
-lastmod: '2026-07-01T00:00:00.000Z'
+lastmod: '2026-09-13T04:55:00.000Z'
 level: '1000'
 difficulty: '🔴 Hard'
 estimated_time: 2-4 hours
@@ -334,6 +334,9 @@ Three safety properties make this safe: **bounded retries** (transient blips rec
 ## 🧪 Hands-On Lab: Slay the Silent Failure on Your Own Bench
 
 *You do not need a CI runner to fight this dragon — you need a flaky tool and a script that refuses to lie about it.* This lab runs entirely on your machine with zero credentials: a stub tool fails deterministically, the safe-execution wrapper retries and escalates, and you verify every exit code yourself.
+
+> **Workbench status (verified):** **Demoed locally** — zero-cred stub tool, retry wrapper, exit-code checks. **Needs GitHub** to swap the stub for real `gh issue create` / CI and to exercise a live MCP allow-list against a repo.
+
 
 ### Step 1 — Build the flaky tool and a stubbed `gh`
 

--- a/pages/_quests/1001/agentic-codex-03-memory-state-and-execution.md
+++ b/pages/_quests/1001/agentic-codex-03-memory-state-and-execution.md
@@ -2,7 +2,7 @@
 title: 'Vaults of Recollection: Memory & State'
 description: 'Master the three tiers of agent memory, persist state across GitHub Actions runs, and detect context drift before it corrupts an agent. GH-600 Domain 3.'
 date: '2026-06-30T00:00:00.000Z'
-lastmod: '2026-09-13T04:45:00.000Z'
+lastmod: '2026-09-13T04:55:00.000Z'
 level: '1001'
 difficulty: '🔴 Hard'
 estimated_time: 2-4 hours
@@ -352,6 +352,9 @@ This single document prevents the two failure modes named in the sub-skill. It p
 ## 🧪 Hands-On Lab: Carve All Three Vaults on Your Own Machine
 
 *The vaults do not require a cloud — they require discipline you can practice at a terminal.* This lab builds every memory tier and the drift guard locally, in ten minutes, with `git`, `jq`, and `sha256sum`.
+
+> **Workbench status (verified):** **Demoed locally** — Tier 1–3 vaults, drift guard, `git`/`jq`/`sha256sum`. **Needs GitHub** for Actions artifacts and the cross-surface handoff (issue → workflow → PR) the chapter describes in production shape.
+
 
 ### Step 1 — Raise the lab realm
 

--- a/pages/_quests/1001/agentic-codex-03-memory-state-and-execution.md
+++ b/pages/_quests/1001/agentic-codex-03-memory-state-and-execution.md
@@ -2,7 +2,7 @@
 title: 'Vaults of Recollection: Memory & State'
 description: 'Master the three tiers of agent memory, persist state across GitHub Actions runs, and detect context drift before it corrupts an agent. GH-600 Domain 3.'
 date: '2026-06-30T00:00:00.000Z'
-lastmod: '2026-07-01T00:00:00.000Z'
+lastmod: '2026-09-13T04:45:00.000Z'
 level: '1001'
 difficulty: '🔴 Hard'
 estimated_time: 2-4 hours
@@ -86,13 +86,13 @@ validation_criteria:
 
 *The agent stands again at the threshold of your repository, exactly as it stood yesterday — and it remembers nothing. Not the decision you reached together at dusk, not the file it carefully rewrote, not the plan it swore to follow. Every workflow run is a fresh-summoned familiar with no past. This is not a flaw to be patched over; it is the iron law of the realm. An agent forgets by design — and so **memory is something you must build, deliberately, from stone you lay yourself.***
 
-*Beneath this castle lie the Vaults of Recollection. Some chambers hold what vanishes when a single job ends. Some hold what survives a run but no longer. And one deep vault — sealed with a committed file — holds what endures across every awakening. Learn which vault holds which truth, and you will have learned the lesson on which 19% of the GH-600 exam turns, and the skill on which most real agentic systems quietly fail. The real-world stakes are blunt: an agent that "forgets" a prior decision will happily undo a colleague's work, re-run an irreversible step, or ship a plan built on a world that no longer exists.*
+*Beneath this castle lie the Vaults of Recollection. Some chambers hold what vanishes when a single job ends. Some hold what survives a run but no longer. And one deep vault — sealed with a committed file — holds what endures across every awakening. Learn which vault holds which truth, and you will have learned a Domain 3 lesson (Learn weight **10–15%**), and the skill on which most real agentic systems quietly fail. The real-world stakes are blunt: an agent that "forgets" a prior decision will happily undo a colleague's work, re-run an irreversible step, or ship a plan built on a world that no longer exists.*
 
 ## 📖 The Legend Behind This Quest
 
 Every agentic AI design eventually collides with the same wall: agents do not automatically remember things across tasks. A GitHub Actions workflow starts in a clean, ephemeral runner every single time. A Copilot coding-agent session begins with no recollection of the conversation before it. This is **by design** — isolation is what makes runs reproducible and safe — but it means memory is your responsibility, not the model's.
 
-The Agentic Codex models this with **three tiers** of memory, each mapped to a concrete GitHub primitive: ephemeral memory inside one job, session memory across jobs in one run, and persistent memory across runs. Get the tiers wrong and you get the quiet failure mode of agentic systems — **context drift** — where what the agent *believes* about the world has silently diverged from what is *true*. This chapter (GH-600 Domain 3, 19% of the exam) teaches you to choose the right vault for each memory, to detect drift before it corrupts a run, and to hand context cleanly across the tools and surfaces a task crosses on its way from issue to merge.
+The Agentic Codex models this with **three tiers** of memory, each mapped to a concrete GitHub primitive: ephemeral memory inside one job, session memory across jobs in one run, and persistent memory across runs. Get the tiers wrong and you get the quiet failure mode of agentic systems — **context drift** — where what the agent *believes* about the world has silently diverged from what is *true*. This chapter (GH-600 Domain 3; Learn weight **10–15%**) teaches you to choose the right vault for each memory, to detect drift before it corrupts a run, and to hand context cleanly across the tools and surfaces a task crosses on its way from issue to merge.
 
 ## 🎯 Quest Objectives
 
@@ -534,7 +534,7 @@ The vaults are carved and the world can no longer drift out from under your agen
 
 ## 📚 Resource Codex
 
-- [GH-600 Study Guide — Developing in Agentic AI Systems](https://learn.microsoft.com/en-us/credentials/certifications/resources/study-guides/gh-600) — the official skills-measured list; Domain 3 is 19% of the exam
+- [GH-600 Study Guide — Developing in Agentic AI Systems](https://learn.microsoft.com/en-us/credentials/certifications/resources/study-guides/gh-600) — the official skills-measured list; Domain 3 is **10–15%** (Learn range)
 - [GitHub Copilot coding agent documentation](https://docs.github.com/en/copilot/using-github-copilot/coding-agent) — the agent whose sessions start without memory
 - [Storing workflow data as artifacts](https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts) — Tier 2 session memory
 - [Caching dependencies with `actions/cache`](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows) — non-authoritative persistent state

--- a/pages/_quests/1010/agentic-codex-04-evaluation-and-tuning.md
+++ b/pages/_quests/1010/agentic-codex-04-evaluation-and-tuning.md
@@ -2,7 +2,7 @@
 title: 'The Oracle Rubric: Evaluation & Tuning'
 description: 'Define machine-verifiable success criteria, read GitHub signals to grade agent runs, run root-cause analysis on failures, and tune behaviour by instruction.'
 date: '2026-06-30T00:00:00.000Z'
-lastmod: '2026-07-01T00:00:00.000Z'
+lastmod: '2026-09-13T04:55:00.000Z'
 level: '1010'
 difficulty: '🔴 Hard'
 estimated_time: 2-4 hours
@@ -385,6 +385,9 @@ This closes the loop the legend opened: rubric → signal → trace → tuned in
 ## 🧪 Hands-On Lab: Build the Oracle on Your Own Bench
 
 *A rubric you have never watched fail is a rubric you do not understand.* This lab builds a working completion detector locally — deterministic signals in a JSON file, a grader that reads them — then points it at a real pull request with `gh`. Ten minutes, no Copilot required.
+
+> **Workbench status (verified):** **Demoed locally** — fixture signals + grader (no Copilot). **Needs GitHub** (optional for the lesson, required for the live half) — point the same grader at a real PR via `gh` / Actions check conclusions.
+
 
 ### Step 1 — Fabricate a run's signals
 

--- a/pages/_quests/1011/agentic-codex-05-multi-agent-coordination.md
+++ b/pages/_quests/1011/agentic-codex-05-multi-agent-coordination.md
@@ -2,7 +2,7 @@
 title: 'The Council of Many: Multi-Agent Coordination'
 description: 'Orchestrate a council of agents on GitHub Actions: fan-out and chain patterns, correlation-ID tracing, failure recovery, and lifecycle. GH-600 Domain 5.'
 date: '2026-06-30T00:00:00.000Z'
-lastmod: '2026-07-01T00:00:00.000Z'
+lastmod: '2026-09-13T04:55:00.000Z'
 level: '1011'
 difficulty: '🔴 Hard'
 estimated_time: 2-4 hours
@@ -314,6 +314,9 @@ Adding an agent to an existing workflow is a new roster row plus a new job; *rep
 ## 🧪 Hands-On Lab: Convene a Council at Your Own Table
 
 *The exam's hardest Domain 5 question hands you a trace and asks which agent caused the fault. Answer it once with your own hands and you will never miss it.* This lab runs a three-agent council locally — one of them sabotaged — then stitches the unified trace and finds the culprit. Pure shell and `jq`, five minutes.
+
+> **Workbench status (verified):** **Demoed locally** — three-agent council, sabotage, unified trace with `jq`. **Needs GitHub** for Actions matrix fan-out, `continue-on-error`, and correlation IDs across real workflow jobs.
+
 
 ### Step 1 — Mint the correlation ID and the trace writer
 

--- a/pages/_quests/1100/agentic-codex-06-guardrails-and-accountability.md
+++ b/pages/_quests/1100/agentic-codex-06-guardrails-and-accountability.md
@@ -2,7 +2,7 @@
 title: 'The Warden Pact: Guardrails & Accountability'
 description: 'GH-600 Domain 6: classify agent actions by risk, set autonomy levels, enforce least-privilege guardrails, gate humans in the loop, and build an audit trail.'
 date: '2026-06-30T00:00:00.000Z'
-lastmod: '2026-07-01T00:00:00.000Z'
+lastmod: '2026-09-13T04:45:00.000Z'
 level: '1100'
 difficulty: '🔴 Hard'
 estimated_time: 2-4 hours
@@ -79,7 +79,7 @@ validation_criteria:
 ---
 *The campaign nears its end. Your familiars can plan, reason, wield tools, remember, recover, and coordinate as a council — but power without a Warden is a wildfire. This chapter raises the last gate of the Codex: **the Warden Pact**, the sworn boundary between what an agent may do alone, what it must ask permission for, and what it may never do at all. The Warden does not fear the agent. She judges the action.*
 
-*Beneath the spellcraft lies the most consequential skill in the entire certification: **responsible autonomy**. GH-600 Domain 6 (9% of the exam — the smallest domain, yet the one that decides whether your agents are trustworthy in production) asks you to classify an action by its risk, assign exactly the right autonomy level, enforce least-privilege guardrails with GitHub-native controls, and leave behind an audit trail that proves what happened. Get the gate wrong and a single autonomous mistake becomes irreversible. Get it right and your agents move fast **because** they are constrained, not in spite of it.*
+*Beneath the spellcraft lies the most consequential skill in the entire certification: **responsible autonomy**. GH-600 Domain 6 (Learn weight **10–15%** — still the domain that decides whether your agents are trustworthy in production) asks you to classify an action by its risk, assign exactly the right autonomy level, enforce least-privilege guardrails with GitHub-native controls, and leave behind an audit trail that proves what happened. Get the gate wrong and a single autonomous mistake becomes irreversible. Get it right and your agents move fast **because** they are constrained, not in spite of it.*
 
 ## 📖 The Legend Behind This Quest
 

--- a/pages/_quests/1100/agentic-codex-06-guardrails-and-accountability.md
+++ b/pages/_quests/1100/agentic-codex-06-guardrails-and-accountability.md
@@ -2,7 +2,7 @@
 title: 'The Warden Pact: Guardrails & Accountability'
 description: 'GH-600 Domain 6: classify agent actions by risk, set autonomy levels, enforce least-privilege guardrails, gate humans in the loop, and build an audit trail.'
 date: '2026-06-30T00:00:00.000Z'
-lastmod: '2026-09-13T04:45:00.000Z'
+lastmod: '2026-09-13T04:55:00.000Z'
 level: '1100'
 difficulty: '🔴 Hard'
 estimated_time: 2-4 hours
@@ -333,6 +333,9 @@ A final accountability note that the exam loves: the human gate must never be a 
 ## 🧪 Hands-On Lab: Build a Warden That Says No
 
 *A guardrail you have never watched refuse an action is a decoration.* This lab builds a working policy gate on your own machine: an autonomy map, a forbidden-paths list, and a warden script that allows, gates, or refuses each proposed action. Then you attack it and watch it hold. Pure shell, five minutes.
+
+> **Workbench status (verified):** **Demoed locally** — autonomy map, forbidden paths, warden allow/gate/refuse. **Needs GitHub** for production Environment required reviewers, CODEOWNERS, and repo-level audit trails.
+
 
 ### Step 1 — Write the Pact as data
 

--- a/pages/_quests/1100/agentic-codex-capstone-exam-trial.md
+++ b/pages/_quests/1100/agentic-codex-capstone-exam-trial.md
@@ -40,7 +40,7 @@ keywords:
   - GitHub Copilot certification
   - agentic codex master
   - all domains review
-lastmod: '2026-07-01T00:00:00.000Z'
+lastmod: '2026-09-13T04:45:00.000Z'
 permalink: /quests/1100/agentic-codex-capstone-exam-trial/
 quest_dependencies:
   required_quests:
@@ -121,12 +121,12 @@ graph TD
 
 *Six seals, six domains — break them all to claim the trial:*
 
-- [ ] **Seal 1 (Domain 1 — 18%)**: Implement agent-in-SDLC and define boundaries
-- [ ] **Seal 2 (Domain 2 — 18%)**: Configure tools, permissions, MCP, environment integration
-- [ ] **Seal 3 (Domain 3 — 19%)**: Implement memory strategy and context continuity
-- [ ] **Seal 4 (Domain 4 — 19%)**: Evaluate agent performance and iterate on instructions
-- [ ] **Seal 5 (Domain 5 — 17%)**: Build and manage a multi-agent system
-- [ ] **Seal 6 (Domain 6 — 9%)**: Implement responsible autonomy, guardrails, and HITL
+- [ ] **Seal 1 (Domain 1 — Learn 15–20%)**: Implement agent-in-SDLC and define boundaries
+- [ ] **Seal 2 (Domain 2 — Learn 20–25%)**: Configure tools, permissions, MCP, environment integration
+- [ ] **Seal 3 (Domain 3 — Learn 10–15%)**: Implement memory strategy and context continuity
+- [ ] **Seal 4 (Domain 4 — Learn 15–20%)**: Evaluate agent performance and iterate on instructions
+- [ ] **Seal 5 (Domain 5 — Learn 15–20%)**: Build and manage a multi-agent system
+- [ ] **Seal 6 (Domain 6 — Learn 10–15%)**: Implement responsible autonomy, guardrails, and HITL
 
 ---
 
@@ -142,7 +142,7 @@ The following 6 chapters map directly to the GH-600 exam domains.
 
 ---
 
-## ⚔️ Seal 1: The Agentic SDLC (Domain 1 — 18%)
+## ⚔️ Seal 1: The Agentic SDLC (Domain 1 — Learn 15–20%)
 
 *Related quests: Q1 (SDLC Integration), Q2 (Plan vs Action), Q3 (Observability)*
 
@@ -224,7 +224,7 @@ jobs:
 
 ---
 
-## ⚔️ Seal 2: Tools, Permissions, and Environment (Domain 2 — 18%)
+## ⚔️ Seal 2: Tools, Permissions, and Environment (Domain 2 — Learn 20–25%)
 
 *Related quests: Q4 (Tool Selection), Q5 (MCP), Q6 (Dev Env), Q7 (Safe Execution)*
 
@@ -270,7 +270,7 @@ permissions:
 
 ---
 
-## ⚔️ Seal 3: Memory and Context (Domain 3 — 19%)
+## ⚔️ Seal 3: Memory and Context (Domain 3 — Learn 10–15%)
 
 *Related quests: Q8 (Memory Strategies), Q9 (State Persistence), Q10 (Cross-tool Continuity)*
 
@@ -300,7 +300,7 @@ permissions:
 
 ---
 
-## ⚔️ Seal 4: Evaluation and Performance (Domain 4 — 19%)
+## ⚔️ Seal 4: Evaluation and Performance (Domain 4 — Learn 15–20%)
 
 *Related quests: Q11 (Success Criteria), Q12 (Root Cause Analysis), Q13 (Behavior Tuning)*
 
@@ -349,7 +349,7 @@ permissions:
 
 ---
 
-## ⚔️ Seal 5: Multi-Agent Systems (Domain 5 — 17%)
+## ⚔️ Seal 5: Multi-Agent Systems (Domain 5 — Learn 15–20%)
 
 *Related quests: Q14 (Orchestration), Q15 (Observability), Q16 (Recovery), Q17 (Lifecycle)*
 
@@ -379,7 +379,7 @@ permissions:
 
 ---
 
-## ⚔️ Seal 6: Responsible Agentic AI (Domain 6 — 9%)
+## ⚔️ Seal 6: Responsible Agentic AI (Domain 6 — Learn 10–15%)
 
 *Related quests: Q18 (Autonomy Levels), Q19 (Guardrails & HITL)*
 
@@ -397,17 +397,19 @@ permissions:
 
 ---
 
-## 📋 Domain Coverage Rubric (GH-600 Exam Alignment)
+## 📋 Domain Coverage Rubric
 
-| Domain | Weight | Your Score | Pass Threshold |
+Official exam weights are **ranges** from Microsoft Learn ([GH-600 study guide](https://learn.microsoft.com/en-us/credentials/certifications/resources/study-guides/gh-600) — Skills at a glance). The campaign score columns are **IT-Journey pedagogy only** — not Microsoft point values. Official pass rule: a score of **700 or greater**.
+
+| Domain | Learn weight (official) | Campaign seal (IT-Journey) | Notes |
 |---|---|---|---|
-| D1: Agentic SDLC | 18% | /18 | ≥ 14 |
-| D2: Tools & Environment | 18% | /18 | ≥ 14 |
-| D3: Memory & Context | 19% | /19 | ≥ 15 |
-| D4: Evaluation | 19% | /19 | ≥ 15 |
-| D5: Multi-Agent | 17% | /17 | ≥ 13 |
-| D6: Governance | 9% | /9 | ≥ 7 |
-| **Total** | **100%** | **/100** | **≥ 70** |
+| D1: Agentic SDLC | 15–20% | Pass / Fail | Integrate agents; plan vs execute; observability |
+| D2: Tools & Environment | 20–25% | Pass / Fail | Tools, permissions, MCP, safe execution |
+| D3: Memory & Context | 10–15% | Pass / Fail | Memory strategy, persistence, drift |
+| D4: Evaluation | 15–20% | Pass / Fail | Signals, RCA, tune from evidence |
+| D5: Multi-Agent | 15–20% | Pass / Fail | Orchestration, observability, recovery |
+| D6: Governance | 10–15% | Pass / Fail | Autonomy levels, guardrails, HITL |
+| **Exam pass (official)** | — | — | **≥ 700** on the GH-600 (not a 70/100 campaign total) |
 
 ---
 

--- a/pages/_quests/1100/agentic-codex-capstone-exam-trial.md
+++ b/pages/_quests/1100/agentic-codex-capstone-exam-trial.md
@@ -40,7 +40,7 @@ keywords:
   - GitHub Copilot certification
   - agentic codex master
   - all domains review
-lastmod: '2026-09-13T04:45:00.000Z'
+lastmod: '2026-09-13T04:55:00.000Z'
 permalink: /quests/1100/agentic-codex-capstone-exam-trial/
 quest_dependencies:
   required_quests:
@@ -118,6 +118,9 @@ graph TD
 ```
 
 ## 🎯 Quest Objectives
+
+> **Workbench status (verified):** **Needs GitHub + Copilot** for the full trial — especially the MCP seal and hosted agent runs. There is no honest local-only claim for the Grand Capstone; use the chapter mini-labs to rehearse patterns, then assemble in a real repository.
+
 
 *Six seals, six domains — break them all to claim the trial:*
 

--- a/pages/_quests/codex/agentic-codex.md
+++ b/pages/_quests/codex/agentic-codex.md
@@ -3,7 +3,7 @@ title: 'Epic Quest: The Agentic Codex'
 description: 'Earn the GitHub GH-600 — six chapters that build, evaluate, and govern autonomous AI agents on GitHub-native rails, from the SDLC to the Warden Pact.'
 excerpt: A six-chapter GH-600 campaign — build, tool, remember, evaluate, coordinate, and govern AI agents with Copilot, MCP, Actions, and the Models API.
 date: '2026-06-30T00:00:00.000Z'
-lastmod: '2026-07-01T00:00:00.000Z'
+lastmod: '2026-09-13T04:45:00.000Z'
 level: '1100'
 difficulty: '⚔️ Epic'
 estimated_time: 40-60 hours
@@ -91,297 +91,58 @@ validation_criteria:
   - Understands the three memory tiers and when each applies
   - Can classify an agent action by risk and choose the right human-in-the-loop gate
 ---
-*Deep within the GitHub Citadel, an ancient order guards the **Agentic Codex** — a tome describing how autonomous agents are summoned, armed, remembered, judged, marshaled, and bound within the Software Development Life Cycle. Most who open it see only spells. You will see the discipline underneath: an agent is not a wish granted, it is a system designed — with inputs, outputs, tools, memory, evaluation, and a human who holds the final seal.*
+Six chapters. Six GH-600 domains. Build, tool, remember, evaluate, coordinate, and govern agents on GitHub-native rails — then prove it in the Grand Capstone.
 
-*This campaign is the GitHub-native road to the **[GH-600 certification](https://learn.microsoft.com/en-us/credentials/certifications/resources/study-guides/gh-600)** — *Developing in Agentic AI Systems*. Six chapters map one-to-one to the six exam domains. Every concept is forged with tools you can actually run: the **Copilot coding agent**, **MCP servers**, **GitHub Actions**, **GitHub Environments**, and the **GitHub Models API**. You do not memorize the Codex. You build it, page by page, and the title of **Agentic Architect** is earned in the forge — not given.*
+This campaign is exam prep for **[GH-600: Developing in Agentic AI Systems](https://learn.microsoft.com/en-us/credentials/certifications/resources/study-guides/gh-600)**. Domain weights below are **ranges from Microsoft Learn** ("Skills at a glance") — Learn does not publish fixed percents. Passing score: **700 or greater**. Certification renews annually via a free Learn assessment.
 
-## 📖 The Legend Behind This Quest
+## Quest objectives
 
-*An autonomous agent is a familiar you send into the world to act on your behalf. Summon one carelessly and it wanders — calling the same tool forever, forgetting yesterday's decision, deleting what it should have spared. Summon one with discipline and it plans before it acts, reaches only for the tools you sanctioned, remembers exactly what it must, proves its own work, coordinates with its kin, and brings every irreversible choice back to you for the final seal.*
+- [ ] **D1 — Agents in the SDLC** — integrate agents in the lifecycle; separate plan vs execute; observability and control
+- [ ] **D2 — Tool Use & Environment** — select tools and permissions; configure MCP; safe execution and retries
+- [ ] **D3 — Memory, State & Execution** — memory strategies; persist state and detect drift; continuity across tools
+- [ ] **D4 — Evaluation & Tuning** — success criteria and signals; failure root-cause analysis; tune from evidence
+- [ ] **D5 — Multi-Agent Coordination** — orchestration; multi-agent observability; failure recovery; agent lifecycle
+- [ ] **D6 — Guardrails & Accountability** — autonomy levels; guardrails and human-in-the-loop
 
-The GH-600 exam tests precisely that discipline across six domains. The Agentic Codex is the order's curriculum: not a survey of buzzwords, but a build-it path where each chapter leaves you with a working artifact and a verifiable skill. The deepest lesson of the whole campaign is the one the **Warden Pact** (Chapter VI) makes explicit — **autonomy that proposes, a human that disposes**. Master that and you have mastered the Codex.
+You will know you are ready when you can map a task to the six domains, write a least-privilege `permissions:` block and an MCP allow-list, diagnose a failing agent from logs, and keep irreversible actions behind an explicit human gate (the Warden Pact).
 
-## 🎯 Quest Objectives
+## Campaign — six chapters
 
-By the end of this campaign you will have built, evaluated, and governed real agents covering all six GH-600 domains:
+Play in order. Weights cite Learn ranges only.
 
-### Primary Objectives (Required for Campaign Completion)
-- [ ] **D1 — Agents in the SDLC** — embed an agent in the lifecycle with defined inputs, outputs, and success criteria, and separate planning from execution
-- [ ] **D2 — Tool Use & Environment** — select and scope tools, configure an MCP server, and operate the agent with safe execution and error handling
-- [ ] **D3 — Memory, State & Execution** — choose between short-term, long-term, and external memory, persist state as durable artifacts, and detect context drift
-- [ ] **D4 — Evaluation & Tuning** — define machine-verifiable success signals, run root-cause analysis on failures, and tune behavior from the evidence
-- [ ] **D5 — Multi-Agent Coordination** — apply an orchestration pattern, make multi-agent runs observable, and recover from partial or stalled failures
-- [ ] **D6 — Guardrails & Accountability** — classify actions by risk, assign autonomy levels, and enforce least-privilege human-in-the-loop gates
-
-### Mastery Indicators
-You will know you have mastered the Codex when you can:
-- [ ] Map any agentic task to the six domains and name the GH-600 sub-skill it exercises
-- [ ] Write a least-privilege `permissions:` block and an MCP allow-list from memory
-- [ ] Diagnose a failing agent from logs/traces and classify the root cause (reasoning vs tool vs environment)
-- [ ] Defend the Warden Pact: an irreversible or compliance-sensitive action never ships without explicit authorization
-
-## 🗺️ Quest Metadata
-
-| Field | Value |
-|---|---|
-| **Type** | `epic_quest` — a multi-session GH-600 campaign |
-| **Tier** | ⚡ Master `1100` capstone — chapters span ⚔️ Adventurer → ⚡ Master |
-| **Total XP** | +200 for the hub, ~600 XP across the six chapters and the Grand Capstone |
-| **Primary classes** | 🤖 AI Engineer · 💻 Software Developer · 🛡️ Security Specialist |
-| **Exam** | [GH-600: Developing in Agentic AI Systems](https://learn.microsoft.com/en-us/credentials/certifications/resources/study-guides/gh-600) — **6 domains**, **70% passing** (700/1000), annual free renewal |
-| **Stack** | GitHub Copilot coding agent · MCP · GitHub Actions · GitHub Environments · GitHub Models API |
-| **Capstone** | [Trial of the Agentic Codex: The Grand Capstone](/quests/1100/agentic-codex-capstone-exam-trial/) — all six domains in one system |
-
-## 📜 The Campaign — Six Chapters
-
-The six chapters map one-to-one to the six GH-600 exam domains, with the same weights the exam uses. Play them in order; each unlocks the next, and the Grand Capstone gates behind all six.
-
-| # | Chapter | Level | Domain (weight) | Difficulty |
+| # | Chapter | Level | Domain (Learn weight) | Difficulty |
 |---|---|---|---|---|
-| I | [Initiation Rites: Agents in the SDLC](/quests/0111/agentic-codex-01-agents-in-the-sdlc/) | `0111` | D1 · Agentic AI in the SDLC (18%) | 🟡 Medium |
-| II | [Forging the Arsenal: Tool Use & Environment](/quests/1000/agentic-codex-02-tool-use-and-environment/) | `1000` | D2 · Tools & Environment (18%) | 🔴 Hard |
-| III | [Vaults of Recollection: Memory & State](/quests/1001/agentic-codex-03-memory-state-and-execution/) | `1001` | D3 · Memory, State & Execution (19%) | 🔴 Hard |
-| IV | [The Oracle Rubric: Evaluation & Tuning](/quests/1010/agentic-codex-04-evaluation-and-tuning/) | `1010` | D4 · Evaluation & Tuning (19%) | 🔴 Hard |
-| V | [The Council of Many: Multi-Agent Systems](/quests/1011/agentic-codex-05-multi-agent-coordination/) | `1011` | D5 · Multi-Agent Coordination (17%) | 🔴 Hard |
-| VI | [The Warden Pact: Guardrails & Accountability](/quests/1100/agentic-codex-06-guardrails-and-accountability/) | `1100` | D6 · Guardrails & Accountability (9%) | 🔴 Hard |
+| I | [Initiation Rites: Agents in the SDLC](/quests/0111/agentic-codex-01-agents-in-the-sdlc/) | `0111` | D1 · Agentic AI in the SDLC (**15–20%**) | 🟡 Medium |
+| II | [Forging the Arsenal: Tool Use & Environment](/quests/1000/agentic-codex-02-tool-use-and-environment/) | `1000` | D2 · Tools & Environment (**20–25%**) | 🔴 Hard |
+| III | [Vaults of Recollection: Memory & State](/quests/1001/agentic-codex-03-memory-state-and-execution/) | `1001` | D3 · Memory, State & Execution (**10–15%**) | 🔴 Hard |
+| IV | [The Oracle Rubric: Evaluation & Tuning](/quests/1010/agentic-codex-04-evaluation-and-tuning/) | `1010` | D4 · Evaluation & Tuning (**15–20%**) | 🔴 Hard |
+| V | [The Council of Many: Multi-Agent Systems](/quests/1011/agentic-codex-05-multi-agent-coordination/) | `1011` | D5 · Multi-Agent Coordination (**15–20%**) | 🔴 Hard |
+| VI | [The Warden Pact: Guardrails & Accountability](/quests/1100/agentic-codex-06-guardrails-and-accountability/) | `1100` | D6 · Guardrails & Accountability (**10–15%**) | 🔴 Hard |
 
-> 🧪 **Every chapter ends at a workbench.** Each chapter closes with a hands-on lab you can run in minutes — most entirely on your own machine with `bash`, `jq`, and the `gh` CLI, no Copilot subscription required — so every domain's key pattern (the approval gate, the retry harness, the drift guard, the rubric grader, the council trace, the warden policy) is something you have actually watched work *and* watched fail.
+Source: [GH-600 study guide — Skills at a glance](https://learn.microsoft.com/en-us/credentials/certifications/resources/study-guides/gh-600).
 
-> 🏰 **The Codex is load-bearing here.** This very repository practices what the campaign preaches: an AI fleet drafts content, walks quests as a learner, repairs what it witnessed breaking, and audits itself — behind kill switches, deterministic gates, an autonomy matrix, and a human merge button. Every domain is mapped to its live artifact, file by file, in **[GH-600 in the Wild: Implemented in IT-Journey](/notes/gh-600/implemented-in-it-journey/)** — read the chapter, then read the running source.
+> Every chapter ends in a hands-on lab (mostly `bash` / `jq` / `gh`). The [Grand Capstone](/quests/1100/agentic-codex-capstone-exam-trial/) gates behind all six chapters.
 
-> 🏆 **Capstone gate.** The [Grand Capstone](/quests/1100/agentic-codex-capstone-exam-trial/) stands beyond Chapter VI. You cannot face the Trial of the Agentic Codex until all six domain seals are broken — it integrates every domain into a single working multi-agent system with observability, evaluation, and governance in place.
+**Campaign XP (front matter):** hub `progression_points: 200`; chapters and capstone sum to roughly +600 across the series. The level-banner `6000–7000` range comes from the binary level hub (`1100` in `_data/quests/levels.yml`), not this campaign’s score — treat front-matter `progression_points` as the source of truth for Agentic Codex XP.
 
-## 🌍 Choose Your Adventure Platform
+## Start here
 
-*This campaign builds GitHub-hosted agents, so your battleground is a GitHub repository plus an editor running Copilot. The agents stay gated behind the same least-privilege discipline the exam tests: scoped tokens, allow-lists, and `*_ENABLED` switches that you opt into deliberately.*
+→ **[Chapter I — Initiation Rites: Agents in the SDLC](/quests/0111/agentic-codex-01-agents-in-the-sdlc/)**
 
-### 🛠️ Arm the forge (any OS)
+Optional map: [GH-600 Study Hub](/notes/gh-600/) · [Skills checklist](/notes/gh-600/skills-checklist/) · [Implemented in IT-Journey](/notes/gh-600/implemented-in-it-journey/) · [Grand Capstone](/quests/1100/agentic-codex-capstone-exam-trial/)
 
-```bash
-# 1. Authenticate the GitHub CLI and confirm Copilot is available to you
-gh auth login
-gh copilot --version   # Copilot CLI; the coding agent runs in Actions and the web UI
+## Study apparatus
 
-# 2. Create the working repo for the campaign and scope a least-privilege token
-gh repo create agentic-codex --private --clone
-gh secret set MODELS_TOKEN --repo <you>/agentic-codex   # for the GitHub Models API
+- [GH-600 Study Guide (Microsoft Learn)](https://learn.microsoft.com/en-us/credentials/certifications/resources/study-guides/gh-600) — official skills-measured source of truth
+- [GitHub Copilot coding agent docs](https://docs.github.com/en/copilot/using-github-copilot/using-copilot-coding-agent-to-work-on-tasks)
+- [Model Context Protocol specification](https://modelcontextprotocol.io/)
+- [Extending Copilot with MCP](https://docs.github.com/en/copilot/customizing-copilot/extending-copilot-chat-with-mcp)
+- [GitHub Actions documentation](https://docs.github.com/en/actions)
+- [GitHub Models](https://docs.github.com/en/github-models)
 
-# 3. Flip a kill switch only when you want an autonomous workflow to run
-gh variable set AGENT_ENABLED --body true --repo <you>/agentic-codex
-```
+## Campaign completion checklist
 
-Each chapter adds its own apparatus — an MCP server config, a `permissions:` block, an Environment with a required reviewer. The rule never changes: **an agent reaches only for tools you sanctioned, and the most dangerous actions wait for a human.**
-
-## 🧙‍♂️ Domain Primer: The Six Disciplines of the Codex
-
-### ⚔️ Skills You'll Forge
-
-- Naming what each GH-600 domain actually tests, and the GitHub-native tool that proves it
-- Recognizing the three exam question archetypes so the content maps to how you'll be tested
-- Reading the domain weights so you spend study time where the points are
-
-The GH-600 is not a trivia exam — it tests whether you can *design* an agentic system end to end. Six domains carve that ability into testable pieces. Here is the whole Codex in one breath, with the tool you'll wield in each chapter:
-
-| Domain | What it tests | Forged with |
-|---|---|---|
-| **D1 · SDLC** | Where agents fit the lifecycle; plan-vs-act boundaries; observability | Copilot coding agent, structured plan artifacts |
-| **D2 · Tools & Env** | Tool selection and scoping; MCP servers; safe execution and retries | MCP, scoped `permissions:`, GitHub Actions |
-| **D3 · Memory & State** | Short/long/external memory; durable state; drift detection | Repo artifacts, issue/PR state, external stores |
-| **D4 · Evaluation** | Machine-verifiable success signals; root-cause analysis; tuning | GitHub Models API, CI checks, logs and traces |
-| **D5 · Multi-Agent** | Orchestration patterns; observability; failure recovery | Actions matrix/fan-out, correlation IDs |
-| **D6 · Guardrails** | Autonomy levels; least-privilege; human-in-the-loop | Environments, required reviewers, audit trails |
-
-Three question archetypes recur across all six domains — keep them in view as you study each chapter:
-
-- **Scenario → Diagnosis** — a misbehaving agent is described; you identify the root cause ("an agent repeatedly requests the same endpoint — why?").
-- **Config Selection** — choose the YAML/config that satisfies a stated constraint ("which `permissions:` block grants least privilege to open a PR?").
-- **Best Practice** — pick the most appropriate design decision from four plausible options ("which guardrail preserves velocity while preventing irreversible deletes?").
-
-The very first thing every chapter does is give the agent a contract — inputs, outputs, and success criteria — before it is allowed to act. Here is that contract as the kind of structured plan artifact Domain 1 expects an agent to emit *before* execution:
-
-```json
-{
-  "task": "Add a failing-test reproduction for issue #42",
-  "inputs": ["issue #42 body", "repository at HEAD"],
-  "tools_allowed": ["read_files", "run_tests", "open_pull_request"],
-  "success_criteria": [
-    "A new test reproduces the bug and fails on main",
-    "No existing test is modified",
-    "A PR is opened, not merged"
-  ],
-  "stop_conditions": ["plan rejected by reviewer", "more than 3 tool errors"]
-}
-```
-
-That JSON is the seed of the whole Codex: a plan the agent (and a human) can inspect *before* anything irreversible happens. Domain by domain, the campaign teaches you to arm, remember, judge, coordinate, and govern around exactly this contract.
-
-### 🔍 Knowledge Check
-
-- [ ] Which two domains carry the most weight, and what does each one test?
-- [ ] What distinguishes a "structured plan artifact" from the agent's execution?
-- [ ] Match each question archetype to the kind of answer it expects (a diagnosis, a config, or a design choice).
-
-## 🧙‍♂️ The GitHub-Native Toolchain You'll Master
-
-### ⚔️ Skills You'll Forge
-
-- Invoking the **Copilot coding agent** to act autonomously on an issue and open a PR
-- Wiring an **MCP server** so the agent gains a scoped, declared tool surface
-- Running an agent step inside **GitHub Actions** behind a least-privilege token and an **Environment** gate
-- Calling the **GitHub Models API** to generate the evaluation signals Domain 4 needs
-
-Every chapter draws from the same GitHub-native toolchain. The **Copilot coding agent** is the familiar itself: assign it an issue and it plans, edits in a branch, and opens a pull request you review — it never merges its own work. The **Model Context Protocol (MCP)** is how you *arm* that familiar: an MCP server declares a typed set of tools (read a file, query an API, search a registry), and an allow-list controls exactly which the agent may call. **GitHub Actions** is the arena where agents run on a schedule or trigger, and **Environments** add the human seal — a required reviewer who must approve before a deploy-class action proceeds.
-
-Here is the shape of an Actions workflow that runs an agent step under least privilege and pauses for a human at an Environment gate. (Wrap any Actions YAML containing {% raw %}`${{ }}`{% endraw %} in this site's `raw` escapes — omit them when you copy into your own `.github/workflows/`.)
-
-{% raw %}
-```yaml
-# .github/workflows/agent.yml — a gated, least-privilege agent run
-name: Codex Agent
-on:
-  workflow_dispatch:
-permissions:
-  contents: write        # branch + commit
-  pull-requests: write   # open a PR — but never merge
-  # no admin, no deployments, no secrets scope: least privilege by omission
-jobs:
-  run-agent:
-    if: ${{ vars.AGENT_ENABLED == 'true' }}   # the kill switch
-    runs-on: ubuntu-latest
-    environment: agent-review                  # required reviewer gates this job
-    steps:
-      - uses: actions/checkout@v4
-      - name: Generate an evaluation signal via the Models API
-        env:
-          GITHUB_TOKEN: ${{ secrets.MODELS_TOKEN }}
-        run: |
-          curl -sS https://models.github.ai/inference/chat/completions \
-            -H "Authorization: Bearer $GITHUB_TOKEN" \
-            -H "Content-Type: application/json" \
-            -d '{"model":"openai/gpt-4o-mini","messages":[
-                 {"role":"user","content":"Rate this diff 1-5 for clarity."}]}'
-```
-{% endraw %}
-
-Two disciplines in that file are tested on the exam directly: the `permissions:` block grants only `contents` and `pull-requests` write — least privilege by *omission* — and the `environment:` key forces a required reviewer to approve before the job runs. The `if: vars.AGENT_ENABLED` line is the kill switch: until you flip the variable, the agent idles. This is the Warden Pact in miniature, and you will deepen it in Chapter VI.
-
-The MCP side of the toolchain looks like this — a declared server plus an allow-list so the agent's reach is auditable, not implicit:
-
-```json
-{
-  "mcpServers": {
-    "github": {
-      "type": "http",
-      "url": "https://api.githubcopilot.com/mcp/",
-      "tools": ["get_issue", "list_pull_requests", "create_pull_request"]
-    }
-  }
-}
-```
-
-The `tools` array *is* the allow-list: the agent can call `get_issue` and open a PR, but nothing else on that server. Scope it tighter than you think you need — Chapter II turns this into a habit.
-
-### 🔍 Knowledge Check
-
-- [ ] Why does the Copilot coding agent open a PR instead of committing to `main`?
-- [ ] In the workflow above, which two lines enforce the human-in-the-loop gate and the kill switch?
-- [ ] What is the purpose of the `tools` array in an MCP server config?
-
-## ⚔️ The Quests of This Domain
-
-The campaign is six chapters, each a playable quest that breaks one domain seal. Play them in order — every chapter unlocks the next, and the Capstone gates behind all six.
-
-- **[Chapter I — Initiation Rites: Agents in the SDLC](/quests/0111/agentic-codex-01-agents-in-the-sdlc/)** — embed an agent in the lifecycle with defined inputs, outputs, and success criteria, and split planning from action (D1, 18%).
-- **[Chapter II — Forging the Arsenal: Tool Use & Environment](/quests/1000/agentic-codex-02-tool-use-and-environment/)** — select and scope tools, stand up an MCP server, and operate the agent with safe execution and error handling (D2, 18%).
-- **[Chapter III — Vaults of Recollection: Memory & State](/quests/1001/agentic-codex-03-memory-state-and-execution/)** — choose between the three memory tiers, persist state as durable artifacts, and detect context drift (D3, 19%).
-- **[Chapter IV — The Oracle Rubric: Evaluation & Tuning](/quests/1010/agentic-codex-04-evaluation-and-tuning/)** — define machine-verifiable success signals, run root-cause analysis, and tune behavior from the evidence (D4, 19%).
-- **[Chapter V — The Council of Many: Multi-Agent Systems](/quests/1011/agentic-codex-05-multi-agent-coordination/)** — apply an orchestration pattern, make multi-agent runs observable, and recover from partial failures (D5, 17%).
-- **[Chapter VI — The Warden Pact: Guardrails & Accountability](/quests/1100/agentic-codex-06-guardrails-and-accountability/)** — classify actions by risk, assign autonomy levels, and enforce least-privilege human-in-the-loop gates (D6, 9%).
-- **[🏆 The Grand Capstone — Trial of the Agentic Codex](/quests/1100/agentic-codex-capstone-exam-trial/)** — integrate all six domains into one working multi-agent system with observability, evaluation, and governance.
-
-## 🎮 Mastery Challenge
-
-**Objective:** Prove the Codex is yours — not as memorized lore, but as a working, governed system.
-
-- [ ] You completed all six chapters in order and broke each domain seal
-- [ ] You can produce, from a blank file, an MCP server config with a tools allow-list and a least-privilege `permissions:` block
-- [ ] You passed the [Grand Capstone](/quests/1100/agentic-codex-capstone-exam-trial/) by deploying a multi-agent system with observability, evaluation, and a human-in-the-loop gate
-- [ ] You can take the GH-600 [Skills Checklist](/notes/gh-600/skills-checklist/) and rate every one of the 19 sub-skills at confidence 4 or higher
-
-## 🎁 Rewards & Progression
-
-**🎖️ Capstone Badges**
-- 👑 **GH-600 Agentic Architect** — you built and governed agents across all six domains
-- 🏛️ **Codex Master** — you survived the Grand Capstone trial
-- 🛡️ **Warden of Autonomy** — you enforced least-privilege human-in-the-loop on the most dangerous actions
-
-**🛠️ Skills Unlocked**
-- Designing bounded, observable agents in the SDLC · Tooling agents with MCP and scoped permissions · Orchestrating and governing multi-agent systems on GitHub
-
-**📊 Progression Points**: +200 XP for the hub, ~600 XP across the six chapters and the Capstone
-
-## 🗺️ Quest Network
-
-```mermaid
-graph TD
-    Hub[👑 The Agentic Codex] --> I[I · Agents in the SDLC]
-    I --> II[II · Tool Use & Environment]
-    II --> III[III · Memory & State]
-    III --> IV[IV · Evaluation & Tuning]
-    IV --> V[V · Multi-Agent Systems]
-    V --> VI[VI · Guardrails & Accountability]
-    VI --> CAP{🏆 Grand Capstone}
-    click I "/quests/0111/agentic-codex-01-agents-in-the-sdlc/"
-    click II "/quests/1000/agentic-codex-02-tool-use-and-environment/"
-    click III "/quests/1001/agentic-codex-03-memory-state-and-execution/"
-    click IV "/quests/1010/agentic-codex-04-evaluation-and-tuning/"
-    click V "/quests/1011/agentic-codex-05-multi-agent-coordination/"
-    click VI "/quests/1100/agentic-codex-06-guardrails-and-accountability/"
-    click CAP "/quests/1100/agentic-codex-capstone-exam-trial/"
-```
-
-## 📚 Study Apparatus
-
-The conceptual companion to the chapters lives in the **GH-600 reference notes**. Read the note to understand *why*, then play the chapter to practice *how*.
-
-**Core reference (in notes):**
-- [GH-600 Study Hub](/notes/gh-600/) — the map: domains, weights, and the full quest line
-- [Skills Checklist (printable)](/notes/gh-600/skills-checklist/) — all 19 sub-skills as checkboxes
-- [Exam Overview & Logistics](/notes/gh-600/exam-overview/) — scoring, scheduling, renewal
-- [Glossary](/notes/gh-600/glossary/) — agent, MCP, HITL, drift, autonomy, and more
-- [MCP Quick Reference](/notes/gh-600/mcp-quickref/) — server config, registries, allow-list syntax
-- [GH-600 in the Wild](/notes/gh-600/implemented-in-it-journey/) — every domain mapped to the live artifact implementing it in this repository
-
-**Deeper study (in notes):**
-- [Skills Measured — Full Breakdown](/notes/gh-600/skills-measured/) — every sub-skill, domain by domain
-- [Week-by-Week Learning Path](/notes/gh-600/learning-path/) — a structured study schedule
-- [Recommended Resources](/notes/gh-600/recommended-resources/) — Microsoft Learn paths and GitHub docs
-
-## 🔮 Next Adventures
-
-- 🎯 Begin the campaign: [Chapter I — Initiation Rites: Agents in the SDLC](/quests/0111/agentic-codex-01-agents-in-the-sdlc/)
-- 🏆 Face the trial: [Trial of the Agentic Codex: The Grand Capstone](/quests/1100/agentic-codex-capstone-exam-trial/)
-- 📜 Study the map: [GH-600 Study Hub](/notes/gh-600/)
-- 🏰 Sibling campaign: [Epic Quest: The Self-Operating Website](/quests/codex/self-operating-website/) — apply the same governance discipline to a site that runs itself
-
-## 📚 Resource Codex
-
-- [GH-600 Study Guide (Microsoft Learn)](https://learn.microsoft.com/en-us/credentials/certifications/resources/study-guides/gh-600) — the official skills-measured source of truth
-- [GitHub Copilot coding agent docs](https://docs.github.com/en/copilot/using-github-copilot/coding-agent) — invoking the agent, scopes, and the autonomous-PR pattern
-- [Model Context Protocol specification](https://modelcontextprotocol.io/) — the MCP standard the exam tests
-- [Extending Copilot with MCP (GitHub docs)](https://docs.github.com/en/copilot/customizing-copilot/extending-copilot-chat-with-mcp) — adding and allow-listing MCP servers
-- [GitHub Actions documentation](https://docs.github.com/en/actions) — the engine every agent runs on
-- [GitHub Models API](https://docs.github.com/en/github-models) — generating evaluation signals for Domain 4
-
-## 🤝 Campaign Completion Checklist
-
-- [ ] ✅ Completed all six chapters in order
-- [ ] ✅ Broke every domain seal (D1 through D6)
-- [ ] ✅ Earned the Warden of Autonomy and Codex Master badges
-- [ ] ✅ Passed the Grand Capstone with a governed multi-agent system
-
-## 🕸️ Knowledge Graph
-
-*Structured wiki-links connect this quest to the IT-Journey knowledge graph. Open the [Obsidian Graph View](/notes/obsidian/graph/) to explore connections.*
-
-**Overworld:** [[🏰 Overworld - Master Quest Map]] **Study hub:** [[The Agentic Codex: GH-600 Study Hub]] **Chapters:** [[Initiation Rites: Agents in the SDLC]] · [[Forging the Arsenal: Tool Use & Environment]] · [[Vaults of Recollection: Memory & State]] · [[The Oracle Rubric: Evaluation & Tuning]] · [[The Council of Many: Multi-Agent Systems]] · [[The Warden Pact: Guardrails & Accountability]] **Capstone:** [[Trial of the Agentic Codex: The Grand Capstone]] **Obsidian docs:** [[Obsidian Knowledge Graph and Wiki Links]]
+- [ ] Completed all six chapters in order
+- [ ] Broke every domain seal (D1 through D6)
+- [ ] Earned the Warden of Autonomy and Codex Master badges
+- [ ] Passed the Grand Capstone with a governed multi-agent system


### PR DESCRIPTION
## Summary
P0 content accuracy for **The Agentic Codex** (GH-600 campaign), per room review with @Researcher / @Reviewer.

### Hub (`pages/_quests/codex/agentic-codex.md`)
- Thinned to: promise → objectives → chapter table → Start Chapter I → study links → empty checklist
- Removed: Legend, Arm the forge, duplicated domain lists, invented **question archetypes**, Obsidian `[[wiki-links]]` leak, pre-checked ✅ checklist items
- Domain weights: **Learn ranges only** (D1 15–20 · D2 20–25 · D3 10–15 · D4 15–20 · D5 15–20 · D6 10–15)
- Exam line: **700 or greater** + annual free Learn renewal (not “70% (700/1000)”)
- Noted XP: `progression_points` is campaign truth; level-banner `6000–7000` is binary `1100` hub metadata

### Citation fixes (labs untouched)
- Ch I: drop “18% … per the official study guide”
- Ch III: drop fixed 19%
- Ch VI: drop fixed 9%
- Capstone: seal labels + rubric use Learn ranges; campaign Pass/Fail columns labeled **IT-Journey pedagogy**, not Microsoft points

### Source
https://learn.microsoft.com/en-us/credentials/certifications/resources/study-guides/gh-600 — Skills at a glance

## Out of scope (follow-ups)
- Ch II / IV / V weight passes
- Series-specific nav (vs binary level dumps)
- Labs rewrite
- `levels.yml` XP banner decoupling

## Test plan
- [ ] Grep PR diff for fixed `18%`/`19%`/`17%`/`9%` claimed as official — should be gone in touched files
- [ ] Hub renders: empty checkboxes, no `[[wiki]]` raw text, Start Chapter I above the fold
- [ ] @Researcher sanity-check against Learn Skills at a glance
- [ ] @Reviewer tear into structure / XP note